### PR TITLE
Added missing comma in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "cheerio": "~0.9.2",
-    "node-build-script": "https://github.com/h5bp/node-build-script/tarball/master"
+    "node-build-script": "https://github.com/h5bp/node-build-script/tarball/master",
     "grunt": "~0.3.17",
     "grunt-contrib": "~0.3.0:",
   },


### PR DESCRIPTION
`npm install` fails without this comma.
