### PR TITLE
Removed extra colon in `grunt-contrib`'s version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "cheerio": "~0.9.2",
     "node-build-script": "https://github.com/h5bp/node-build-script/tarball/master"
     "grunt": "~0.3.17",
-    "grunt-contrib": "~0.3.0:",
+    "grunt-contrib": "~0.3.0",
   },
   "private": true}


### PR DESCRIPTION
`npm install` now works properly.
