### PR TITLE
Full-width timetable

### DIFF
--- a/app/styles/_timetable.scss
+++ b/app/styles/_timetable.scss
@@ -7,8 +7,8 @@
   line-height: 13px;
 }
 #timetable {
-  width: 1159px;
-  max-width: none;
+  width: 100%;
+  min-width: 1159px;
   margin: 0 0 15px -20px;
   table-layout: fixed;
 }


### PR DESCRIPTION
The current timetable shows some whitespace to the right on screens more than ~1200px in width.
