### PR TITLE
Removes qtip before view changes

### DIFF
--- a/app/scripts/timetable/views/LessonView.js
+++ b/app/scripts/timetable/views/LessonView.js
@@ -192,6 +192,10 @@ var LessonView = Marionette.ItemView.extend({
       tr.remove();
     }
     return this;
+  },
+
+  onBeforeDestroy: function() {
+    this.$el.qtip('hide');
   }
 });
 


### PR DESCRIPTION
Added in ```onBeforeDestroy``` in ```LessonView``` that hides qtip before view changes.

For issue [#129].

[#129]: https://github.com/nusmodifications/nusmods/issues/129