### PR TITLE
CSS fix for affix sidebar positioning

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -715,6 +715,9 @@ colgroup.hover {
     &.affix {
       top: 85px;
     }
+    &.affix-bottom {
+      position: relative;
+    }
   }
   .module-main-content:before {
     content: ' ';


### PR DESCRIPTION
For issue [#159]

The problem was caused by jQuery's ```.offset()``` function. More information can be found [here].

```.affix-bottom``` has to be added to ensure that jQuery doesn't set ```position: relative;``` inline every time we navigate to a new module.

[#159]: https://github.com/nusmodifications/nusmods/issues/159
[here]: https://github.com/twbs/bootstrap/issues/9342