### PR TITLE
Renamed size options for image export

### DIFF
--- a/app/scripts/timetable/templates/export.hbs
+++ b/app/scripts/timetable/templates/export.hbs
@@ -6,35 +6,35 @@
   </button>
   <ul class="dropdown-menu">
     <li>
-      <a download="My NUSMods.com Timetable.xls" href="#" id="xls-file">
+      <a download="My NUSMods.com Timetable.xls" href="#" data-export-type="xls-file">
         <i class="fa fa-file-excel-o fa-fw"></i>&nbsp;Excel File
       </a>
     </li>
     <li>
-      <a download="My NUSMods.com Timetable.html" href="#" id="html-file">
+      <a download="My NUSMods.com Timetable.html" href="#" data-export-type="html-file">
         <i class="fa fa-file-code-o fa-fw"></i>&nbsp;HTML File
       </a>
     </li>
     <li{{#if isSpecialTerm}} class="disabled"{{/if}}>
-      <a download="My NUSMods.com Timetable.ics" href="#" id="ical-file">
+      <a download="My NUSMods.com Timetable.ics" href="#" data-export-type="ical-file">
         <i class="fa fa-calendar fa-fw"></i>&nbsp;iCalendar File (.ics)<br>
         (For Google Calendar / iCal / Outlook)
       </a>
     </li>
     <li class="horiz-menu">
-      <a href="#" class="col-xs-8" id="jpg-file" data-imagesize="1" title="Normal">
+      <a href="#" class="col-xs-8" data-export-type="jpg-file" data-image-size="1" title="Normal">
         <i class="fa fa-file-image-o fa-fw"></i>&nbsp;Image File (.jpg)
         <i class="fa fa-picture-o image-normal"></i>
       </a>
-      <a href="#" class="col-xs-2" id="jpg-file" data-imagesize="2" title="Big">
+      <a href="#" class="col-xs-2" data-export-type="jpg-file" data-image-size="2" title="Big">
         <i class="fa fa-picture-o image-big"></i>
       </a>
-      <a href="#" class="col-xs-2" id="jpg-file" data-imagesize="3" title="Large">
+      <a href="#" class="col-xs-2" data-export-type="jpg-file" data-image-size="3" title="Large">
         <i class="fa fa-picture-o image-large"></i>
       </a>
     </li>
     <li>
-      <a href="#" id="pdf-file">
+      <a href="#" data-export-type="pdf-file">
         <i class="fa fa-file-pdf-o fa-fw"></i>&nbsp;PDF File
       </a>
     </li>

--- a/app/scripts/timetable/templates/export.hbs
+++ b/app/scripts/timetable/templates/export.hbs
@@ -24,13 +24,13 @@
     <li class="horiz-menu">
       <a href="#" class="col-xs-8" data-export-type="jpg-file" data-image-size="1" title="Normal">
         <i class="fa fa-file-image-o fa-fw"></i>&nbsp;Image File (.jpg)
-        <i class="fa fa-picture-o image-normal"></i>
+        <i class="fa fa-picture-o icon-image-normal"></i>
       </a>
       <a href="#" class="col-xs-2" data-export-type="jpg-file" data-image-size="2" title="Big">
-        <i class="fa fa-picture-o image-big"></i>
+        <i class="fa fa-picture-o icon-image-big"></i>
       </a>
       <a href="#" class="col-xs-2" data-export-type="jpg-file" data-image-size="3" title="Large">
-        <i class="fa fa-picture-o image-large"></i>
+        <i class="fa fa-picture-o icon-image-large"></i>
       </a>
     </li>
     <li>

--- a/app/scripts/timetable/templates/export.hbs
+++ b/app/scripts/timetable/templates/export.hbs
@@ -23,7 +23,7 @@
     </li>
     <li class="horiz-menu">
       <a href="#" class="col-xs-8" id="jpg-file" data-imagesize="1" title="Normal">
-        <i class="fa fa-file-image-o fa-fw"></i>&nbsp;Image File (.jpg) &nbsp; 
+        <i class="fa fa-file-image-o fa-fw"></i>&nbsp;Image File (.jpg)
         <i class="fa fa-picture-o image-normal"></i>
       </a>
       <a href="#" class="col-xs-2" id="jpg-file" data-imagesize="2" title="Big">

--- a/app/scripts/timetable/templates/export.hbs
+++ b/app/scripts/timetable/templates/export.hbs
@@ -22,11 +22,16 @@
       </a>
     </li>
     <li class="horiz-menu">
-      <a href="#" class="col-xs-6" id="jpg-file" data-imagesize="1">
-        <i class="fa fa-file-image-o fa-fw"></i>&nbsp;Image (.jpg)
+      <a href="#" class="col-xs-8" id="jpg-file" data-imagesize="1" title="Normal">
+        <i class="fa fa-file-image-o fa-fw"></i>&nbsp;Image File (.jpg) &nbsp; 
+        <i class="fa fa-picture-o image-normal"></i>
       </a>
-      <a href="#" class="col-xs-3" id="jpg-file" data-imagesize="2">Good</a>
-      <a href="#" class="col-xs-3" id="jpg-file" data-imagesize="3">Best</a>
+      <a href="#" class="col-xs-2" id="jpg-file" data-imagesize="2" title="Big">
+        <i class="fa fa-picture-o image-big"></i>
+      </a>
+      <a href="#" class="col-xs-2" id="jpg-file" data-imagesize="3" title="Large">
+        <i class="fa fa-picture-o image-large"></i>
+      </a>
     </li>
     <li>
       <a href="#" id="pdf-file">

--- a/app/scripts/timetable/views/ExportView.js
+++ b/app/scripts/timetable/views/ExportView.js
@@ -31,13 +31,13 @@ module.exports = Marionette.ItemView.extend({
       window.alert('No modules to export!');
       return false;
     }
-    switch (event.currentTarget.id) {
+    switch (event.currentTarget.dataset.exportType) {
       case 'jpg-file':
         analytics.track('Timetable', 'Export', 'JPEG', +this.dlAttrSupported);
         $.fileDownload('/jpg.php', {
           httpMethod: 'POST',
           data: {
-            size: event.currentTarget.dataset.imagesize,
+            size: event.currentTarget.dataset.imageSize,
             html: encodeURIComponent(this.htmlTimetable())
           }
         });

--- a/app/styles/_timetable.scss
+++ b/app/styles/_timetable.scss
@@ -52,6 +52,17 @@
     padding-right: 0;
     text-align: center;
   }
+  .image-normal {
+    position: relative;
+    font-size: 0.8em;
+    right: -5px;
+  }
+  .image-big {
+    font-size: 1em;
+  }
+  .image-large {
+    font-size: 1.2em;
+  }
 }
 
 .hide-code .code,

--- a/app/styles/_timetable.scss
+++ b/app/styles/_timetable.scss
@@ -53,9 +53,9 @@
     text-align: center;
   }
   .image-normal {
-    position: relative;
     font-size: 0.8em;
     left: 12px;
+    position: relative;
   }
   .image-big {
     font-size: 1em;

--- a/app/styles/_timetable.scss
+++ b/app/styles/_timetable.scss
@@ -52,15 +52,15 @@
     padding-right: 0;
     text-align: center;
   }
-  .image-normal {
+  .icon-image-normal {
     font-size: 0.8em;
     left: 12px;
     position: relative;
   }
-  .image-big {
+  .icon-image-big {
     font-size: 1em;
   }
-  .image-large {
+  .icon-image-large {
     font-size: 1.2em;
   }
 }

--- a/app/styles/_timetable.scss
+++ b/app/styles/_timetable.scss
@@ -55,7 +55,7 @@
   .image-normal {
     position: relative;
     font-size: 0.8em;
-    right: -5px;
+    left: 12px;
   }
   .image-big {
     font-size: 1em;


### PR DESCRIPTION
* Changed the size options to fa icons. 
* Added link titles.
* The normal-size icon is a bit special because it is alongside the description. So I used a bit of magic number (left: 12px;) to adjust the distance between it and the next icon. Tell me if there is any better ways. 