### PR TITLE
Show contributor's commits instead of GitHub profile.

### DIFF
--- a/app/scripts/contribute/templates/developers_item.hbs
+++ b/app/scripts/contribute/templates/developers_item.hbs
@@ -1,13 +1,16 @@
-<a href="{{html_url}}" target="_blank">
-  <div class="nm-ct-dev-head">
-    <img class="img-rounded img-responsive" src="{{avatar_url}}" alt="{{login}}">
-    <div class="nm-ct-dev-stat img-rounded">
-      <p>
+<div class="nm-ct-dev-head">
+  <img class="img-rounded img-responsive" src="{{avatar_url}}" alt="{{login}}">
+  <div class="nm-ct-dev-stat img-rounded">
+    <p>
+      <a href="{{html_url}}" target="_blank" class="nm-ct-dev-profile">
+        <i class="fa fa-github fa-lg"></i>
+      </a>
+      <a href="https://github.com/nusmodifications/nusmods/commits?author={{login}}" target="_blank">
         <span class="nm-text-xlarge">{{contributions}}</span>
         <span class="nm-text-medium hidden-xs hidden-sm"><br></span>
         commit{{#notequals contributions 1}}s{{/notequals}}
-      </p>
-    </div>
+      </a>
+    </p>
   </div>
-  <h4 class="nm-ct-dev-id"><i class="fa fa-github"></i> {{login}}</h4>
-</a>
+</div>
+<h4 class="nm-ct-dev-id">{{login}}</h4>

--- a/app/styles/_contribute.scss
+++ b/app/styles/_contribute.scss
@@ -1,3 +1,11 @@
+@mixin dev-github-profile($font-size) {
+  .nm-ct-dev-profile {
+    .fa-github {
+      font-size: $font-size;
+    }
+  }
+}
+
 .nm-ct {
   .nm-ct-devs-container {
     margin-top: 30px;
@@ -18,7 +26,7 @@
         .nm-ct-dev-id {
           filter: grayscale(0);
           text-decoration: none;
-        }  
+        }
       }
     }
     .nm-ct-dev-head {
@@ -28,7 +36,6 @@
       width: 100%;
       .nm-ct-dev-stat {
         background: rgba(255, 100, 0, 0.5);
-        color: white;
         display: block;
         height: 100%;
         left: 0;
@@ -42,8 +49,21 @@
           top: 50%;
           transform: translateY(-50%);
         }
+        a {
+          color: white;
+        }
+        a:hover{
+          color: black;
+        }
+      }
+      @include dev-github-profile(5em);
+      @media (max-width: 1250px) {
+        @include dev-github-profile(3em);
       }
       @media (max-width: 1024px) {
+        .nm-ct-dev-profile {
+          display: none;
+        }
         .nm-ct-dev-stat {
           bottom: 0;
           opacity: 1;


### PR DESCRIPTION
@yangshun Not sure if you'll prefer this but I think it makes more sense to showcase all the contributions made to NUSMods instead of just the contributor's GitHub profile.