### PR TITLE
Removes qtips on module page before view changes.

### DIFF
--- a/app/scripts/modules/views/ModuleItemView.js
+++ b/app/scripts/modules/views/ModuleItemView.js
@@ -66,5 +66,9 @@ module.exports = Marionette.ItemView.extend({
 
   onShow: function() {
     this.$('.js-nm-mi-filter').qtip();
+  },
+
+  onBeforeDestroy: function() {
+    $("a[href^='/modules/']").qtip('destroy', true);
   }
 });

--- a/app/scripts/modules/views/ModuleItemView.js
+++ b/app/scripts/modules/views/ModuleItemView.js
@@ -69,6 +69,6 @@ module.exports = Marionette.ItemView.extend({
   },
 
   onBeforeDestroy: function() {
-    $("a[href^='/modules/']").qtip('destroy', true);
+    $('a[href^="/modules/"]').qtip('destroy', true);
   }
 });

--- a/app/scripts/modules/views/ModulesView.js
+++ b/app/scripts/modules/views/ModulesView.js
@@ -6,7 +6,6 @@ var ArrayFacetModel = require('../models/ArrayFacetModel');
 var FacetCollection = require('../collections/FacetCollection');
 var FacetsView = require('./FacetsView');
 var GoToTopBehavior = require('../../common/behaviors/GoToTopBehavior');
-var ModuleHoverBehavior = require('../../common/behaviors/ModuleHoverBehavior');
 var Marionette = require('backbone.marionette');
 var ModuleCollection = require('../../common/collections/ModuleCollection');
 var ModulesListingView = require('./ModulesListingView');


### PR DESCRIPTION
Similar bug to issue [#129]. 

To reproduce the bug:
1. Head to modules page
2. Hover over one of the module pre-requisites
3. Hit '?' to access the help page
4. qtip does not disappear

Did not take this into consideration when implementing the qtips on the module page, apologies! 

Is there a better way to implement this though, instead of including it into ```onBeforeDestroy``` for every ```View``` that we have?