### PR TITLE
Change to FB Page Plugin #188

### DIFF
--- a/app/scripts/timetable/templates/timetable.hbs
+++ b/app/scripts/timetable/templates/timetable.hbs
@@ -22,7 +22,7 @@
           <div class="url-sharing-region"></div>
         </div>
         <div class="hidden-xs">
-          <iframe src="//www.facebook.com/plugins/likebox.php?href=https%3A%2F%2Fwww.facebook.com%2FNUSMods&amp;width&amp;height=558&amp;colorscheme=light&amp;show_faces=true&amp;header=false&amp;stream=true&amp;show_border=false&amp;appId=491857110934417" scrolling="no" frameborder="0" style="border:none; overflow:hidden; height:448px; width: 100%" allowTransparency="true"></iframe>
+          <div class="fb-page" data-href="https://www.facebook.com/nusmods" data-width="500" data-height="448" data-hide-cover="false" data-show-facepile="true" data-show-posts="true"><div class="fb-xfbml-parse-ignore"><blockquote cite="https://www.facebook.com/nusmods"><a href="https://www.facebook.com/nusmods">NUSMods</a></blockquote></div></div>
         </div>
       </form>
     </div>

--- a/app/scripts/timetable/views/TimetableView.js
+++ b/app/scripts/timetable/views/TimetableView.js
@@ -71,6 +71,15 @@ module.exports = Marionette.LayoutView.extend({
       collection: this.selectedModules
     }));
     this.modulesChanged(null, null, {replace: true});
+
+    // TODO: Discuss a better place to place JS SDK required for page plugin
+    (function(d, s, id) {
+      var js, fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) return;
+      js = d.createElement(s); js.id = id;
+      js.src = "//connect.facebook.net/en_GB/sdk.js#xfbml=1&version=v2.3&appId=491857110934417";
+      fjs.parentNode.insertBefore(js, fjs);
+    }(document, 'script', 'facebook-jssdk'));
   },
 
   modulesChanged: function (model, collection, options) {


### PR DESCRIPTION
Change to FB Page Plugin for #188 

Demo:

![screen shot 2015-05-10 at 9 28 57 pm](https://cloud.githubusercontent.com/assets/6291947/7554487/6a0ece32-f75d-11e4-91a2-f022970d45b7.png)
![screen shot 2015-05-10 at 9 28 52 pm](https://cloud.githubusercontent.com/assets/6291947/7554488/6a0ecf4a-f75d-11e4-9993-db6535b72407.png)


Discussion:

1. Page plugin requires JS-SDK as per FB Page Plugin documentation
2. Because of 1, we need to insert it somewhere where it'll be loaded upon refresh, appending it under fb-root in index.html causes the FB Page Plugin to disappear upon refresh ->

![screen shot 2015-05-10 at 9 41 53 pm](https://cloud.githubusercontent.com/assets/6291947/7554489/71de44c6-f75d-11e4-8893-1f1d12f22b2b.png)
![screen shot 2015-05-10 at 9 41 48 pm](https://cloud.githubusercontent.com/assets/6291947/7554490/720752a8-f75d-11e4-99ab-91351e43b82a.png)

3. Currently, I'm not very sure where to place such a JS and have put it within one of the view's JS (added a TODO to move it somewhere else) so what would be a good place to put this SDK? (Tried to put it beside Google Analytics but that doesn't work either, causes it to disappear upon refresh as in 2)

Let me know if anything is gravely wrong, still figuring out how nusmods work and how the app is structured :)