### PR TITLE
Fixes #212

### DIFF
--- a/app/scripts/common/views/AppView.js
+++ b/app/scripts/common/views/AppView.js
@@ -20,7 +20,8 @@ module.exports = Backbone.View.extend({
   el: 'body',
 
   events: {
-    'click a[href]:not([data-bypass])': 'hijackLinks'
+    'click a[href]:not([data-bypass])': 'hijackLinks',
+	'mouseup a[href]:not([data-bypass])' : 'removeFocus',
   },
 
   hijackLinks: function (event) {
@@ -49,6 +50,10 @@ module.exports = Backbone.View.extend({
       // calls this anyways.  The fragment is sliced from the root.
       this.navigateWithScrollTop(href.attr, true);
     }
+  },
+
+  removeFocus: function(event) {
+    $(event.currentTarget).blur();
   },
 
   initialize: function () {

--- a/app/scripts/common/views/AppView.js
+++ b/app/scripts/common/views/AppView.js
@@ -21,7 +21,7 @@ module.exports = Backbone.View.extend({
 
   events: {
     'click a[href]:not([data-bypass])': 'hijackLinks',
-	'mouseup a[href]:not([data-bypass])' : 'removeFocus',
+    'mouseup a[href]:not([data-bypass])' : 'removeFocus',
   },
 
   hijackLinks: function (event) {


### PR DESCRIPTION
There is discrepancy between the handling of link navigation between
Chrome and the other browsers such as Safari in that focus on the anchor
is not removed.

This forces the anchor to lose focus after clicking.