### PR TITLE
Revise meta-description content for more effective SEO marketing

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,7 +11,7 @@
   <meta name="og:image" content="icon.png">
   <meta name="og:url" content="http://nusmods.com">
   <meta name="og:title" content="NUSMods - NUS Timetable Builder">
-  <meta name="og:description" content="NUSMods provides students with a better way to plan their school timetables with a user-friendly timetable builder and also serves to be a complete knowledge bank of NUS modules by providing useful module-related information such as archived NUS CORS bidding statistics and community-driven module reviews and discussions.">
+  <meta name="og:description" content="Plan your timetables with the complete, community-driven module knowledge bank. Do more, get involved, and engage with others. Enhance your student experience with NUSMods.">
   <meta name="og:site_name" content="NUSMods">
   <meta name="og:type" content="website">
 


### PR DESCRIPTION
Discovered the long meta description when pasting shortlinks into the Telegram messenger.