### PR TITLE
Display modules without exams before those with exams

### DIFF
--- a/app/scripts/timetable/collections/ExamCollection.js
+++ b/app/scripts/timetable/collections/ExamCollection.js
@@ -57,9 +57,8 @@ module.exports = Backbone.Collection.extend({
   },
 
   // Sort by custom key: if have exam, month then date then clustered hour,
-  // if not, sort alphabetically by code. As the numerical keys come before
-  // the alphabetical ones, modules with no exam will appear at the bottom,
-  // as intended.
+  // if not, sort alphabetically by code. Modules without exams will be 
+  // displayed before those with exams.
   comparator: function(exam) {
     return exam.get('key');
   }

--- a/app/scripts/timetable/models/ExamModel.js
+++ b/app/scripts/timetable/models/ExamModel.js
@@ -23,7 +23,8 @@ module.exports = Backbone.Model.extend({
     } else {
       // For modules without exam, sort alphabetically by id (code).
       this.set('examStr', this.defaults.time);
-      this.set('key', this.id);
+      // Add '00' before the module code to force the 'time' to be smaller than others
+      this.set('key', '00' + this.id);
     }
 
     var moduleCredit = this.get('moduleCredit');


### PR DESCRIPTION
Modules without exams usually end during week 13 or reading week, which is before the starting of final exams of other modules. Therefore it is more intuitive to have modules without exams displayed before those with exams.