### PR TITLE
JPEG image generation truncates filename

### DIFF
--- a/app/jpg.php
+++ b/app/jpg.php
@@ -10,5 +10,5 @@ $snappy->setOption('zoom', $size);
 $description = $size == 1 ? 'Normal' : ($size == 2 ? 'Big' : 'Large');
 $filename = 'My NUSMods.com Timetable (' . $description . ').jpg';
 header('Content-Type: image/jpeg');
-header('Content-Disposition: attachment; filename=' . $filename);
+header('Content-Disposition: attachment; filename="' . $filename . '"');
 echo $snappy->getOutputFromHtml(urldecode($_POST['html']));


### PR DESCRIPTION
I often use the JPEG version and find it downloading on Firefox as just "My" instead of the full file name. Turns out that the double quotes were missing from the header in just the JPEG creation file.

See also: http://kb.mozillazine.org/Filenames_with_spaces_are_truncated_upon_download