### PR TITLE
Fix ansible provision on windows

### DIFF
--- a/provisioning/JJG-Ansible-Windows/windows.sh
+++ b/provisioning/JJG-Ansible-Windows/windows.sh
@@ -56,4 +56,4 @@ grep -q -F "alias npm='npm --no-bin-links'" /home/vagrant/.bashrc || echo "alias
 
 # Run the playbook.
 echo "Running Ansible provisioner defined in Vagrantfile."
-sudo -H -u vagrant bash -c "ansible-playbook -i 'localhost,' \"/home/vagrant/NUSMods/${ANSIBLE_PLAYBOOK}\" --extra-vars \"is_windows=true\" --connection=local"
+sudo -H -u vagrant bash -c "ansible-playbook -v -i 'localhost,' \"/home/vagrant/NUSMods/${ANSIBLE_PLAYBOOK}\" --extra-vars \"is_windows=true ansible_ssh_user=vagrant\" --connection=local"

--- a/provisioning/roles/app_server/tasks/install_dependencies.yml
+++ b/provisioning/roles/app_server/tasks/install_dependencies.yml
@@ -1,5 +1,5 @@
 ---
-- command: bower install chdir={{ project_dir }}
+- command: bower install chdir={{ project_dir }} --allow-root
 - composer: working_dir={{ project_dir }}
 - npm: path={{ project_dir }}
 - npm: path={{ project_dir }}/api


### PR DESCRIPTION
1. in install_dependencies.yml, we use the command module and to
   run bower, in that case we need to sepcify --allow-root, otherwise
   bower will crap out saying that we cannot run with root
2. in windows.sh (the shim to do ansible provisioning for us when
   the host machine is a Windows), the variable `ansible_ssh_user` is
   missing, so the other config files that rely on that variable, and
   also on `user` variable gets a blank string, which is not good.
   To fix, we pass in the `ansible_ssh_user` via the --extra-vars
   command line param, set to the value of `vagrant`, which is what
   it is if we use vagrant to provision the box.