### PR TITLE
Update npm to 3.6.0 before running npm install

### DIFF
--- a/provisioning/roles/app_server/tasks/install_dependencies.yml
+++ b/provisioning/roles/app_server/tasks/install_dependencies.yml
@@ -1,6 +1,7 @@
 ---
 - command: bower install chdir={{ project_dir }} --allow-root
 - composer: working_dir={{ project_dir }}
+- npm: name=npm version=3.6.0 global=yes
 - npm: path={{ project_dir }}
 - npm: path={{ project_dir }}/api
 - git:


### PR DESCRIPTION
On windows, the symlinks that npm uses for binaries crap doesn't work:
https://github.com/npm/npm/issues/2380
https://github.com/npm/npm/issues/6309

One way to solve it is to use --no-bin-links
https://github.com/npm/npm/pull/3090
This would require us to update ansible's [npm module](https://github.com/ansible/ansible-modules-extras/blob/devel/packaging/language/npm.py) to include `--no-bin-links` as an option.
However, some digging later, it looks like newer versions of npm solves this problem:
https://github.com/npm/npm/issues/6309#issuecomment-57040586

This commit will cause provisioning to run an npm update on itself first.