### PR TITLE
Add babel

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -121,16 +121,16 @@ function bundle() {
 
 gulp.task('bundle', bundle);
 
-gulp.task('browserify', function() {
+gulp.task('browserify', ['copyscripts'], function() {
   bundler = browserify({
-    entries: ['app/scripts/main.js'],
+    entries: ['.tmp/modules/main.js'],
   });
   return bundle();
 });
 
-gulp.task('browserify:watch', function() {
+gulp.task('browserify:watch', ['copyscripts'], function() {
   bundler = browserify({
-    entries: ['app/scripts/main.js'],
+    entries: ['.tmp/modules/main.js'],
     debug: true,
     cache: {},
     packageCache: {},
@@ -237,7 +237,26 @@ gulp.task('eslint', function() {
   .pipe(plugins.eslint.format());
 });
 
-gulp.task('serve', ['sass', 'copy:styles', 'browserify:watch'], function() {
+gulp.task('copyscripts', function() {
+  const config = gulp.src('app/config/*.json')
+    .pipe(gulp.dest('.tmp/config'))
+
+  const hbs = gulp.src('app/scripts/**/*.hbs')
+    .pipe(gulp.dest('.tmp/modules'))
+
+  const json = gulp.src('app/scripts/**/*.json')
+    .pipe(gulp.dest('.tmp/modules'))
+
+  const scripts = gulp.src('app/scripts/**/*.js')
+    .pipe(plugins.babel({
+      presets: ['es2015']
+    }))
+    .pipe(gulp.dest('.tmp/modules'));
+
+  return merge(hbs, json, config, scripts);
+})
+
+gulp.task('serve', ['sass', 'copy:styles', 'copyscripts', 'browserify:watch'], function() {
   browserSync.init({
     port: 9000,
     server: {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -273,6 +273,7 @@ gulp.task('serve', ['sass', 'copy:styles', 'copyscripts', 'browserify:watch'], f
   ], reload);
   gulp.watch('test/spec/{,*/}*.js', ['test:watch']);
   gulp.watch('package.json', ['browserify']);
+  gulp.watch('app/scripts/**/*.js', ['copyscripts'])
 });
 
 gulp.task('serve:dist', ['build'], function() {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^6.3.1",
+    "babel-preset-es2015": "^6.9.0",
     "browser-sync": "^2.11.1",
     "browserify": "^10.2.6",
     "browserify-shim": "~3.8.9",
@@ -60,6 +61,7 @@
     "eslint-plugin-react": "^5.2.2",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.1.0",
+    "gulp-babel": "^6.1.2",
     "gulp-batch": "^1.0.5",
     "gulp-cssmin": "^0.1.7",
     "gulp-cssnano": "^2.1.0",


### PR DESCRIPTION
Fixes #281 .

So seems like it isn't that hard, the thing I had to do was to use `gulp-babel` to copy the files into `.tmp/modules`, and then change the `browserify` tasks to bundle starting from `.tmp/modules/main.js` instead of the original `app/scripts/main.js`.
Also had to copy some extra `.json` and `.hbs` files into `.tmp` so that browserify can find them.

I also looked at the generated `main.js` file (was worried that it would cause sizes of file to increase), seems like it doesn't, for now!

```
old: 2273158
new: 2272611
```