### PR TITLE
[FIX] Module not found, redirect back to timetable

### DIFF
--- a/app/scripts/modules/controllers/ModulesController.js
+++ b/app/scripts/modules/controllers/ModulesController.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var App = require('../../app');
+var Backbone = require('backbone');
 var Marionette = require('backbone.marionette');
 var _Promise = require('bluebird');
 var config = require('../../common/config');
@@ -42,6 +43,8 @@ module.exports = Marionette.Controller.extend({
           module: moduleModel.attributes
         });
         App.mainRegion.show(new ModuleView({model: modulePageModel}));
+      }).catch(function(){
+        Backbone.history.navigate('/timetable', {trigger: true, navigate: true})
       });
     }
   }

--- a/app/scripts/modules/controllers/ModulesController.js
+++ b/app/scripts/modules/controllers/ModulesController.js
@@ -44,7 +44,7 @@ module.exports = Marionette.Controller.extend({
         });
         App.mainRegion.show(new ModuleView({model: modulePageModel}));
       }).catch(function(){
-        Backbone.history.navigate('/timetable', {trigger: true, navigate: true})
+        Backbone.history.navigate('/timetable', {trigger: true, navigate: true});
       });
     }
   }

--- a/app/scripts/modules/views/ModulesView.js
+++ b/app/scripts/modules/views/ModulesView.js
@@ -40,7 +40,7 @@ module.exports = Marionette.LayoutView.extend({
 
   initialize: function (options) {
     this.mods = options.mods;
-    var departmentToFaculty = {}
+    var departmentToFaculty = {};
     Object.keys(options.facultyDepartments).map(function(fac) {
       options.facultyDepartments[fac].map(function(dept) {
         departmentToFaculty[dept] = fac;
@@ -177,7 +177,7 @@ module.exports = Marionette.LayoutView.extend({
       key: 'faculty',
       label: 'Faculty',
       slug: 'faculty'
-    })
+    });
     facets.add(_.map({
       Department: 'Department',
       level: 'Level'

--- a/app/scripts/nusmods.js
+++ b/app/scripts/nusmods.js
@@ -67,7 +67,7 @@ module.exports = {
   getFacultyDepartments: function(semester, callback) {
     facultyDepartmentsPromise = facultyDepartmentsPromise || Promise.resolve(
       $.getJSON([ayBaseUrl, semester, 'facultyDepartments.json'].join('/')));
-    return facultyDepartmentsPromise.then(callback)
+    return facultyDepartmentsPromise.then(callback);
   },
   setConfig: function (config) {
     ayBaseUrl = config.baseUrl + config.academicYear.replace('/', '-') + '/';


### PR DESCRIPTION
Currently if a module code is not found, the spinner will spin until the laptop battery goes flat. So I added a catch to the `getMod()` so that it will redirect the user to their timetable if the module is not found.

I cross-matched the code against other code for the practices used by other developers.

Preferably, if possible, after redirect we should tell user that the module is not found. 