### PR TITLE
Upgrade localforage to 1.4.2 to fix indexdb version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "jquery-file-download": "~1.4.3",
     "jquery.ui": "~1.11.4",
     "jqueryui-touch-punch": "#4bc009145202d9c7483ba85f3a236a8f3470354d",
-    "localforage": "ahbeng/localForage#2da72b902fb55866f6a4c0415970931d94d98592",
+    "localforage": "1.4.2",
     "nusmoderator": "~1.1.1",
     "qtip2": "~2.2.1",
     "select2": "~3.5.2",


### PR DESCRIPTION
So apparently, indexdb in latest chrome is version 2, but our existing version of localforage tries to request in a version 1 format. Upgrade our version to fix this.

ref: http://stackoverflow.com/questions/33660849/domerror-localforage-indexeddb-cases