### PR TITLE
Fix #301: Add support for lessons ending at 2359 or 0000

### DIFF
--- a/app/scripts/timetable/views/LessonView.js
+++ b/app/scripts/timetable/views/LessonView.js
@@ -98,13 +98,18 @@ var LessonView = Marionette.ItemView.extend({
         '.m' + startTime.slice(2) + ':empty');
       if (tdStart.length) {
         var endTime = this.model.get('EndTime');
+        endTime = endTime === '2359' ? '0000' : endTime;
         var tdAfterEnd = tdStart.nextAll('.h' + endTime.slice(0, 2) +
           '.m' + endTime.slice(2));
-        // 0000 EndTime has never been seen but just in case.
         if (tdAfterEnd.length || endTime === '0000') {
           this.detached = tdStart.nextUntil(tdAfterEnd, 'td:empty');
           if (this.detached.length === this.model.get('duration') - 1) {
             tdStart.attr('colspan', this.model.get('duration')).html(this.$el);
+            this.detached.detach();
+            break;
+          // no cell beyond 0000, so lessons ending at this timing must extend themselves
+          } else if (endTime === '0000') {
+            tdStart.attr('colspan', this.model.get('duration') + 1).html(this.$el);
             this.detached.detach();
             break;
           }


### PR DESCRIPTION
So the reason for the bug was 2 fold.

1. EndTime wasn't a whole number, so there was no corresponding table cell to slot into.
2. Lessons ended at the last possible cell, for which there was none (no 0000 to 0030 cell).

So I changed '2359' to '0000' and extended the colspan of such modules to fill up the gap.