### PR TITLE
Prototype hiding lessons in timetable

### DIFF
--- a/v3/src/js/actions/settings.js
+++ b/v3/src/js/actions/settings.js
@@ -17,3 +17,19 @@ export function selectFaculty(faculty: Faculty): FSA {
     payload: faculty,
   };
 }
+
+export const HIDE_LESSON_IN_TIMETABLE: string = 'HIDE_LESSON_IN_TIMETABLE';
+export function hideLessonInTimetable(moduleCode: ModuleCode): FSA {
+  return {
+    type: HIDE_LESSON_IN_TIMETABLE,
+    payload: moduleCode,
+  };
+}
+
+export const SHOW_LESSON_IN_TIMETABLE: string = 'SHOW_LESSON_IN_TIMETABLE';
+export function showLessonInTimetable(moduleCode: ModuleCode): FSA {
+  return {
+    type: SHOW_LESSON_IN_TIMETABLE,
+    payload: moduleCode,
+  };
+}

--- a/v3/src/js/reducers/settings.js
+++ b/v3/src/js/reducers/settings.js
@@ -4,12 +4,30 @@ import type {
   SettingsState,
 } from 'types/reducers';
 
-import { SELECT_NEW_STUDENT, SELECT_FACULTY } from 'actions/settings';
+import {
+  SELECT_NEW_STUDENT,
+  SELECT_FACULTY,
+
+  HIDE_LESSON_IN_TIMETABLE,
+  SHOW_LESSON_IN_TIMETABLE,
+} from 'actions/settings';
 
 const defaultSettingsState: SettingsState = {
   newStudent: false,
   faculty: '',
+  hiddenInTimetable: [],
 };
+
+function hidden(state = [], action: FSA) {
+  switch (action.type) {
+    case HIDE_LESSON_IN_TIMETABLE:
+      return [action.payload, ...state];
+    case SHOW_LESSON_IN_TIMETABLE:
+      return state.filter(c => c !== action.payload);
+    default:
+      return state;
+  }
+}
 
 function settings(state: SettingsState = defaultSettingsState, action: FSA): SettingsState {
   switch (action.type) {
@@ -22,6 +40,12 @@ function settings(state: SettingsState = defaultSettingsState, action: FSA): Set
       return {
         ...state,
         faculty: action.payload,
+      };
+    case HIDE_LESSON_IN_TIMETABLE:
+    case SHOW_LESSON_IN_TIMETABLE:
+      return {
+        ...state,
+        hiddenInTimetable: hidden(state.hiddenInTimetable, action),
       };
     default:
       return state;

--- a/v3/src/js/types/reducers.js
+++ b/v3/src/js/types/reducers.js
@@ -38,6 +38,7 @@ export type ThemeState = {
 export type SettingsState = {
   newStudent: boolean,
   faculty: ?Faculty,
+  hiddenInTimetable: Array<ModuleCode>,
 };
 
 /* entities/moduleBank.js */

--- a/v3/src/js/views/timetable/TimetableContainer.jsx
+++ b/v3/src/js/views/timetable/TimetableContainer.jsx
@@ -126,9 +126,7 @@ export class TimetableContainer extends Component {
     });
 
     // inject hidden into lessons.
-    timetableLessons = timetableLessons.filter((lesson) => {
-      return !this.isHiddenInTimetable(lesson.ModuleCode);
-    });
+    timetableLessons = timetableLessons.filter(lesson => !this.isHiddenInTimetable(lesson.ModuleCode));
 
     const arrangedLessons: TimetableArrangement = arrangeLessonsForWeek(timetableLessons);
     const arrangedLessonsWithModifiableFlag: TimetableArrangement = _.mapValues(arrangedLessons, (dayRows) => {

--- a/v3/src/js/views/timetable/TimetableContainer.jsx
+++ b/v3/src/js/views/timetable/TimetableContainer.jsx
@@ -11,6 +11,7 @@ import type {
   ModifiableLesson,
   Lesson,
   Module,
+  ModuleCode,
   ModuleCondensed,
   RawLesson,
 } from 'types/modules';
@@ -54,6 +55,7 @@ type Props = {
   colors: ThemeState,
   activeLesson: ModifiableLesson,
   timetableOrientation: TimetableOrientation,
+  hiddenInTimetable: Array<ModuleCode>,
 
   addModule: Function,
   removeModule: Function,
@@ -71,6 +73,10 @@ export class TimetableContainer extends Component {
 
   componentWillUnmount() {
     this.props.cancelModifyLesson();
+  }
+
+  isHiddenInTimetable(moduleCode: ModuleCode) {
+    return this.props.hiddenInTimetable.includes(moduleCode);
   }
 
   modifyCell(lesson: ModifiableLesson) {
@@ -117,6 +123,11 @@ export class TimetableContainer extends Component {
     // Inject color index into lessons.
     timetableLessons = timetableLessons.map((lesson) => {
       return { ...lesson, colorIndex: this.props.colors[lesson.ModuleCode] };
+    });
+
+    // inject hidden into lessons.
+    timetableLessons = timetableLessons.filter((lesson) => {
+      return !this.isHiddenInTimetable(lesson.ModuleCode);
     });
 
     const arrangedLessons: TimetableArrangement = arrangeLessonsForWeek(timetableLessons);
@@ -181,6 +192,7 @@ export class TimetableContainer extends Component {
                       const module = this.props.modules[moduleCode] || {};
                       // Inject color index.
                       module.colorIndex = this.props.colors[moduleCode];
+                      module.hiddenInTimetable = this.isHiddenInTimetable(moduleCode);
                       return module;
                     })}
                     horizontalOrientation={isHorizontalOrientation}
@@ -209,6 +221,7 @@ function mapStateToProps(state) {
   const semTimetable = state.timetables[semester] || {};
   const semModuleList = getSemModuleSelectList(state.entities.moduleBank, semester, semTimetable);
   const semTimetableWithLessons = hydrateSemTimetableWithLessons(semTimetable, modules, semester);
+  const hiddenInTimetable = state.settings.hiddenInTimetable || [];
 
   return {
     semester,
@@ -219,6 +232,7 @@ function mapStateToProps(state) {
     theme: state.theme.id,
     colors: state.theme.colors,
     timetableOrientation: state.theme.timetableOrientation,
+    hiddenInTimetable,
   };
 }
 

--- a/v3/src/js/views/timetable/TimetableModulesTable.jsx
+++ b/v3/src/js/views/timetable/TimetableModulesTable.jsx
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import ColorPicker from 'views/components/color-picker/ColorPicker';
 
 import { selectModuleColor, modifyModuleColor, cancelModifyModuleColor } from 'actions/theme';
+import { hideLessonInTimetable, showLessonInTimetable } from 'actions/settings';
 import { getModuleSemExamDate, modulePagePath } from 'utils/modules';
 
 type Props = {
@@ -16,6 +17,8 @@ type Props = {
   selectModuleColor: Function,
   modifyModuleColor: Function,
   cancelModifyModuleColor: Function,
+  hideLessonInTimetable: Function,
+  showLessonInTimetable: Function,
   semester: number,
   modules: Array<ModuleWithColor>,
   onRemoveModule: Function,
@@ -25,6 +28,26 @@ type Props = {
 class TimetableModulesTable extends Component {
   componentWillUnmount() {
     this.props.cancelModifyModuleColor();
+  }
+
+  showButton(module) {
+    return (
+      <button className="btn-link" onClick={() => {
+        this.props.showLessonInTimetable(module.ModuleCode);
+      }}>
+        Show
+      </button>
+    );
+  }
+
+  hideButton(module) {
+    return (
+      <button className="btn-link" onClick={() => {
+        this.props.hideLessonInTimetable(module.ModuleCode);
+      }}>
+        Hide
+      </button>
+    );
   }
 
   props: Props;
@@ -43,7 +66,10 @@ class TimetableModulesTable extends Component {
               >
                 <div className="modules-table-row-inner">
                   <div className="color-column">
-                    <div className={`modules-table-color color-${module.colorIndex}`}
+                    <div className={classnames('modules-table-color', {
+                      [`color-${module.colorIndex}`]: !module.hiddenInTimetable,
+                      'color-muted': module.hiddenInTimetable,
+                    })}
                       onClick={() => {
                         if (this.props.activeModule === module.ModuleCode) {
                           this.props.cancelModifyModuleColor();
@@ -61,6 +87,7 @@ class TimetableModulesTable extends Component {
                     <Link to={modulePagePath(module.ModuleCode)}>
                       {module.ModuleCode} {module.ModuleTitle}
                     </Link>
+                    {module.hiddenInTimetable ? this.showButton(module) : this.hideButton(module)}
                     <div>
                       <small>
                         Exam: {getModuleSemExamDate(module, this.props.semester)}
@@ -98,5 +125,7 @@ export default connect(
     selectModuleColor,
     modifyModuleColor,
     cancelModifyModuleColor,
+    hideLessonInTimetable,
+    showLessonInTimetable,
   }
 )(TimetableModulesTable);

--- a/v3/src/js/views/timetable/TimetableModulesTable.jsx
+++ b/v3/src/js/views/timetable/TimetableModulesTable.jsx
@@ -30,22 +30,18 @@ class TimetableModulesTable extends Component {
     this.props.cancelModifyModuleColor();
   }
 
-  showButton(module) {
+  showButton(moduleCode) {
     return (
-      <button className="btn-link" onClick={() => {
-        this.props.showLessonInTimetable(module.ModuleCode);
-      }}>
-        Show
+      <button className="btn-link btn-remove" onClick={() => this.props.showLessonInTimetable(moduleCode)}>
+        <i className="fa fa-eye-slash" />
       </button>
     );
   }
 
-  hideButton(module) {
+  hideButton(moduleCode) {
     return (
-      <button className="btn-link" onClick={() => {
-        this.props.hideLessonInTimetable(module.ModuleCode);
-      }}>
-        Hide
+      <button className="btn-link btn-remove" onClick={() => this.props.hideLessonInTimetable(moduleCode)}>
+        <i className="fa fa-eye" />
       </button>
     );
   }
@@ -87,7 +83,6 @@ class TimetableModulesTable extends Component {
                     <Link to={modulePagePath(module.ModuleCode)}>
                       {module.ModuleCode} {module.ModuleTitle}
                     </Link>
-                    {module.hiddenInTimetable ? this.showButton(module) : this.hideButton(module)}
                     <div>
                       <small>
                         Exam: {getModuleSemExamDate(module, this.props.semester)}
@@ -99,6 +94,8 @@ class TimetableModulesTable extends Component {
                         }}>
                           Remove
                         </button>
+                        {module.hiddenInTimetable ?
+                          this.showButton(module.ModuleCode) : this.hideButton(module.ModuleCode)}
                       </small>
                     </div>
                   </div>

--- a/v3/src/styles/themes.scss
+++ b/v3/src/styles/themes.scss
@@ -1,5 +1,7 @@
 /* stylelint-disable */
-.color-muted { @include color(#eeeeee); }
+.color-muted {
+  border: 1px solid #ccc;
+}
 .theme-ashes {
   .color-0 { @include color(#c7ae95); }
   .color-1 { @include color(#c7c795); }

--- a/v3/src/styles/themes.scss
+++ b/v3/src/styles/themes.scss
@@ -1,4 +1,5 @@
 /* stylelint-disable */
+.color-muted { @include color(#eeeeee); }
 .theme-ashes {
   .color-0 { @include color(#c7ae95); }
   .color-1 { @include color(#c7c795); }

--- a/v3/test/actions/settings.js
+++ b/v3/test/actions/settings.js
@@ -1,6 +1,6 @@
 // @flow
 import type { FSA } from 'types/redux';
-import type { Faculty } from 'types/modules';
+import type { Faculty, ModuleCode } from 'types/modules';
 
 import test from 'ava';
 import * as actions from 'actions/settings';
@@ -22,5 +22,25 @@ test('should dispatch a select of a faculty value', (t) => {
     payload: faculty,
   };
   const resultOfAction: FSA = actions.selectFaculty(faculty);
+  t.deepEqual(resultOfAction, expectedResult);
+});
+
+test('should dispatch a module code for hiding', (t) => {
+  const moduleCode: ModuleCode = 'CS1010';
+  const expectedResult: FSA = {
+    type: actions.HIDE_LESSON_IN_TIMETABLE,
+    payload: moduleCode,
+  };
+  const resultOfAction: FSA = actions.hideLessonInTimetable(moduleCode);
+  t.deepEqual(resultOfAction, expectedResult);
+});
+
+test('should dispatch a module code for showing', (t) => {
+  const moduleCode: ModuleCode = 'CS1020';
+  const expectedResult: FSA = {
+    type: actions.SHOW_LESSON_IN_TIMETABLE,
+    payload: moduleCode,
+  };
+  const resultOfAction: FSA = actions.showLessonInTimetable(moduleCode);
   t.deepEqual(resultOfAction, expectedResult);
 });


### PR DESCRIPTION
Prototype to fix #248

** Updated screenshot on 10/12 5pm **

Visible lessons have `fa-eye`, and hidden lessons have `fa-eye-slash`. Clicking will hide and show lessons (respectively).

For this prototype I chose to store this inside `state.settings.hiddenInTimetable`, which is a list of module codes that the user has chosen to not show.

I also added a new class to the theme `'color-muted`, which outlines the color picker gray with no fill.

Not sure if this should be scoped under a semester too. Wdyt?

**new screenshot**
<img width="1421" alt="screen shot 2016-12-10 at 5 21 12 pm" src="https://cloud.githubusercontent.com/assets/1749303/21072425/26de55c4-befd-11e6-95da-0941f69c3596.png">

*old screenshot*
<img width="1438" alt="screen shot 2016-12-10 at 12 01 56 am" src="https://cloud.githubusercontent.com/assets/1749303/21055299/e689c1f2-be6b-11e6-95f3-0876157204b6.png">
