### PR TITLE
Add static pages for About and FAQ, fix #311

### DIFF
--- a/v3/src/js/routes.jsx
+++ b/v3/src/js/routes.jsx
@@ -6,6 +6,8 @@ import { Provider } from 'react-redux';
 import AppContainer from 'views/AppContainer';
 import NotFoundPage from 'views/NotFoundPage';
 
+import AboutContainer from 'views/static/AboutContainer';
+import FaqContainer from 'views/static/FaqContainer';
 import TimetableContainer from 'views/timetable/TimetableContainer';
 import ModulesContainer from 'views/browse/ModulesContainer';
 import ModuleFinderContainer from 'views/browse/ModuleFinderContainer';
@@ -19,6 +21,8 @@ export default function ({ store, history }) {
       <Router history={history}>
         <Route path="/" component={AppContainer}>
           <IndexRedirect to="/timetable"/>
+          <Route path="/about" component={AboutContainer}/>
+          <Route path="/faq" component={FaqContainer}/>
           <Route path="/timetable" component={TimetableContainer}/>
           <Route path="/modules" component={ModulesContainer}>
             <IndexRoute component={ModuleFinderContainer}/>

--- a/v3/src/js/views/layout/Footer.jsx
+++ b/v3/src/js/views/layout/Footer.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import { Link } from 'react-router';
 
 function Footer() {
   return (
@@ -11,8 +12,8 @@ function Footer() {
           <li><a href="https://twitter.com/nusmods">Twitter</a></li>
           <li><a href="http://blog.nusmods.com/">Blog</a></li>
           <li><a href="https://github.com/nusmodifications/nusmods-api">API</a></li>
-          <li><a href="/about">About</a></li>
-          <li><a href="/faq">FAQ</a></li>
+          <li><Link to="/about">About</Link></li>
+          <li><Link to="/faq">FAQ</Link></li>
         </ul>
         {/* TODO: Change team to link to internal page. */}
         {/* TODO: Change contributors link to internal page */}

--- a/v3/src/js/views/static/AboutContainer.jsx
+++ b/v3/src/js/views/static/AboutContainer.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import DocumentTitle from 'react-document-title';
+
+export default function AboutContainer() {
+  return (
+    <DocumentTitle title="About NUSMods">
+      <div className="row">
+        <div className="col-md-8 offset-md-1">
+          <h3>A brief history</h3>
+
+          <p>
+            NUS Modifications (NUSMods) was founded in 2012 by
+            <a href="http://benghee.eu/"> Beng </a>
+            to provide a better way for students to plan their school timetables.
+            Over time, more features have been added to improve the lives of NUS students.
+            Besides timetable planning, NUSMods also serves to be a complete knowledge bank of NUS modules
+            by providing useful module-related information such as archived CORS bidding statistics
+            and community-driven module reviews and discussions.
+          </p>
+
+          <h3>Goals</h3>
+
+          <p>
+            In the long term, NUSMods strives to enhance the quality of students&apos;
+            lives in school by serving as a one-stop platform that provides useful
+            utility tools and an avenue for students to share their knowledge and experiences.
+          </p>
+
+          <p>
+            As an app built by students for students,
+            NUSMods hopes to encourage fellow students to experiment and create original,
+            community-engaging work that also improves the lives of NUS students.
+            Examples of such initiatives are
+            <a href="http://cloudsync.ivle.nus.edu.sg/"> IVLE Cloud Sync </a>
+            and
+            <a href="http://www.corspedia.com/"> Corspedia </a>
+            (which has been integrated into NUSMods as of July 2014).
+          </p>
+
+          <h3>Connect with Us!</h3>
+
+          <p>
+            We would love to hear your feedback and suggestions on how to make NUSMods even better.
+            Please let us know them by leaving a comment on our
+            <a href="https://www.facebook.com/NUSMods"> Facebook page</a>.
+          </p>
+
+          <p>- NUSMods Team</p>
+        </div>
+      </div>
+    </DocumentTitle>
+  );
+}

--- a/v3/src/js/views/static/FaqContainer.jsx
+++ b/v3/src/js/views/static/FaqContainer.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import DocumentTitle from 'react-document-title';
+
+export default function FaqContainer() {
+  return (
+    <DocumentTitle title="FAQ">
+      <div className="row">
+        <div className="col-md-8 offset-md-1">
+          <h2>Contact Us</h2>
+          <hr />
+          <p><em>Hi there! Before contacting us, please read the following FAQ (Frequently Asked Questions) first.
+            In most cases, you <strong>DO NOT</strong> need to contact NUSMods.</em></p>
+
+          <h4>NUSMods is cool, where do you guys come from?</h4>
+          <p>
+            NUSMods is a student-run initiative and does not have any affiliations with
+            National University of Singapore.
+            NUSMods was born out of the frustration of a lack of usable NUS timetable planners
+            (the official one makes anyone who uses it want to pull their hair out).
+            It seems like NUS does not have any intentions to improve it anytime soon anyways.
+            Since most of us come from School of Computing, we decided to put our technical skills to good use to
+            create something that will make your lives as students easier and better.
+          </p>
+
+          <p>NUSMods does not get to make decisions regarding your curriculum, module availablity and module timetable.
+            If you have questions regarding your curriculum, CORS bidding, IVLE or anything unrelated to NUSMods,
+            maybe it would be better to contact your faculty and department or just
+            <a href="https://www.google.com/"> Google </a> it.</p>
+
+          <h4>There is a mistake. On my faculty website, SC3205 is shown to have two lecture slots but on NUSMods
+          there is only one lecture slot.</h4>
+          <p>Yes, there is a mistake, but in most cases, it is a mistake with <em>your faculty</em>.
+          Many faculties (FASS in particular) like to maintain their own module timetable schedule
+          on their own faculty website,
+          without updating the official school sources such as CORS and IVLE.
+          NUSMods obtains timetable data automatically from CORS and IVLE,
+          and the only way for the updated data to be reflected on NUSMods is to have CORS and IVLE updated.</p>
+
+          <p>Check
+            <a href="https://myaces.nus.edu.sg/cors/jsp/report/ModuleInfoListing.jsp"> CORS </a>
+            for the official timetable data (and see if that module even exists in CORS).
+            Only if it differs from NUSMods, then report it to NUSMods, else,
+            kindly inform your faculty to update the official sources and NUSMods will reflect the updates respectively.
+            If CORS is updated while NUSMods is not,
+            give it a day or two for NUSMods to update it via our automatic scripts.
+            If NUSMods is still not updated after two days, then there might be a problem.
+            Please contact us and we will look into it.
+          </p>
+
+          <h4>
+            On my faculty website, the exam date for PS3242 is different from the one shown on NUSMods.
+            It should be 28th Nov 2016 1pm and not 24th Nov.
+          </h4>
+          <p>Refer to the answer for the previous question.</p>
+
+          <h4>
+            I can add IS1112 into my list of modules but why are there no lectures or tutorial slots after adding them?
+          </h4>
+          <p>Refer to the answer for the previous question.</p>
+
+          <h4>SE5221 cannot be found on your website, can you update your system?</h4>
+          <p>Refer to the answer for the previous question.</p>
+
+          <h4>
+            SC3202 is indicated as only available in Sem 1 in NUSMods but
+            the FASS module list shows it as available in Sem 2 too?
+          </h4>
+          <p>Refer to the answer for the previous question.</p>
+
+          <h4>Why is ... ?</h4>
+          <p>
+            Before we hear the rest of your question, refer to the answer for the previous question.
+          </p>
+
+          <hr />
+
+          <p>
+            Congratulations for making it to the end!
+            If you are still bent on contacting us,
+            you may reach us via email at
+            nusmods&#123;at&#125;googlegroups[dot]com.
+            Please allow up to 90 working days for a reply.
+          </p>
+        </div>
+      </div>
+    </DocumentTitle>
+  );
+}


### PR DESCRIPTION
Contact page:
<img width="1673" alt="screen shot 2016-12-10 at 5 58 28 pm" src="https://cloud.githubusercontent.com/assets/1749303/21072573/5b99573c-bf02-11e6-8693-2f93427286b5.png">

About page:
<img width="1676" alt="screen shot 2016-12-10 at 5 58 37 pm" src="https://cloud.githubusercontent.com/assets/1749303/21072575/5e905378-bf02-11e6-9a24-3cb056b85dd3.png">
