### PR TITLE
Export as jpeg

### DIFF
--- a/v3/package.json
+++ b/v3/package.json
@@ -74,6 +74,7 @@
     "bootstrap": "^4.0.0-alpha.4",
     "classnames": "^2.2.5",
     "d3": "^4.4.0",
+    "dom-to-image": "^2.5.2",
     "js-search": "^1.3.2",
     "lodash": "^4.15.0",
     "nusmoderator": "^2.0.0",

--- a/v3/src/js/actions/export.js
+++ b/v3/src/js/actions/export.js
@@ -1,0 +1,29 @@
+// @flow
+import domtoimage from 'dom-to-image';
+
+export const DOWNLOAD_AS_JPEG = 'DOWNLOAD_AS_JPEG';
+export function downloadAsJpeg(domElement) {
+  return (dispatch: Function) => {
+    dispatch({
+      type: `${DOWNLOAD_AS_JPEG}_PENDING`,
+    });
+
+    const style = { margin: '0', marginLeft: '-0.25em' };
+    return domtoimage.toJpeg(domElement, { bgcolor: '#fff', style })
+      .then((dataUrl) => {
+        const link = document.createElement('a');
+        link.download = 'timetable.jpeg';
+        link.href = dataUrl;
+        link.click();
+        dispatch({
+          type: `${DOWNLOAD_AS_JPEG}_SUCCESS`,
+        });
+      })
+      .catch((err) => {
+        console.error(err);
+        dispatch({
+          type: `${DOWNLOAD_AS_JPEG}_FAILURE`,
+        });
+      });
+  };
+}

--- a/v3/src/js/views/timetable/Timetable.jsx
+++ b/v3/src/js/views/timetable/Timetable.jsx
@@ -67,7 +67,9 @@ class Timetable extends Component {
           .timetable-cell { ${orientationStyleProp}: ${value}%; }
           .timetable-content-inner-container { min-width: ${minWidth}px; }
         `}</style>
-        <div className="timetable-inner-container">
+        <div className="timetable-inner-container"
+          ref={r => (this.timetableDom = r)}
+        >
           <TimetableTimings startingIndex={startingIndex}
             endingIndex={endingIndex}
           />

--- a/v3/src/js/views/timetable/TimetableContainer.jsx
+++ b/v3/src/js/views/timetable/TimetableContainer.jsx
@@ -25,6 +25,7 @@ import _ from 'lodash';
 import config from 'config';
 import classnames from 'classnames';
 import { getSemModuleSelectList } from 'reducers/entities/moduleBank';
+import { downloadAsJpeg } from 'actions/export';
 import {
   addModule,
   cancelModifyLesson,
@@ -63,6 +64,7 @@ type Props = {
   changeLesson: Function,
   cancelModifyLesson: Function,
   toggleTimetableOrientation: Function,
+  downloadAsJpeg: Function,
 };
 
 export class TimetableContainer extends Component {
@@ -174,6 +176,12 @@ export class TimetableContainer extends Component {
                 >
                   <i className="fa fa-exchange"/>
                 </button>
+                <button type="button"
+                  className="btn btn-outline-primary"
+                  onClick={() => this.props.downloadAsJpeg(this.timetableDom)}
+                >
+                  <i className="fa fa-image"/>
+                </button>
               </div>
               <div className="row">
                 <div className="col-md-12">
@@ -244,5 +252,6 @@ export default connect(
     changeLesson,
     cancelModifyLesson,
     toggleTimetableOrientation,
+    downloadAsJpeg,
   }
 )(TimetableContainer);

--- a/v3/src/js/views/timetable/TimetableContainer.jsx
+++ b/v3/src/js/views/timetable/TimetableContainer.jsx
@@ -159,6 +159,7 @@ export class TimetableContainer extends Component {
               <Timetable lessons={arrangedLessonsWithModifiableFlag}
                 horizontalOrientation={isHorizontalOrientation}
                 onModifyCell={this.modifyCell}
+                ref={r => (this.timetableDom = r && r.timetableDom)}
               />
               <br/>
             </div>

--- a/v3/yarn.lock
+++ b/v3/yarn.lock
@@ -2479,6 +2479,10 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+dom-to-image@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/dom-to-image/-/dom-to-image-2.5.2.tgz#6476b9f43c27c00b76ce4f164d20e5eeab032497"
+
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"


### PR DESCRIPTION
Copied shamelessly from modify.sg, export timetable as jpeg using dom-to-image. Currently lives in a button next to the orientation rotation button.

<img width="528" alt="screen shot 2016-12-11 at 7 42 58 pm" src="https://cloud.githubusercontent.com/assets/1749303/21079862/1fdf1af0-bfda-11e6-80b7-9663c0da05b0.png">

results:
![timetable 1](https://cloud.githubusercontent.com/assets/1749303/21080189/27e21cde-bfe4-11e6-82a5-7005d96f2f71.jpeg)

for reference, the timetable-export branch:
![nusmods 1](https://cloud.githubusercontent.com/assets/1749303/21080190/2f8c5a08-bfe4-11e6-9707-454483d9f671.jpeg)
