### PR TITLE
Enable escape button shortcut to close colorpicker

### DIFF
--- a/v3/src/js/views/components/color-picker/ColorPicker.jsx
+++ b/v3/src/js/views/components/color-picker/ColorPicker.jsx
@@ -10,18 +10,24 @@ import './color-picker.scss';
 
 type Props = {
   onChooseColor: Function,
-  handleEscKeyDown: Function,
+  onDismiss: Function,
 };
 
 class ColorPicker extends Component {
   props: Props;
 
   componentWillMount() {
-    window.addEventListener('keydown', this.props.handleEscKeyDown);
+    window.addEventListener('keydown', this.handleKeyDown);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('keydown', this.props.handleEscKeyDown);
+    window.removeEventListener('keydown', this.handleKeyDown);
+  }
+
+  handleKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      this.props.onDismiss();
+    }
   }
 
   render() {

--- a/v3/src/js/views/components/color-picker/ColorPicker.jsx
+++ b/v3/src/js/views/components/color-picker/ColorPicker.jsx
@@ -8,6 +8,8 @@ import { NUM_DIFFERENT_COLORS } from 'reducers/theme';
 
 import './color-picker.scss';
 
+const ESCAPE_KEYCODE = 27;
+
 type Props = {
   onChooseColor: Function,
   onDismiss: Function,
@@ -25,7 +27,7 @@ class ColorPicker extends Component {
   }
 
   handleKeyDown = (event) => {
-    if (event.key === 'Escape') {
+    if (event.key === 'Escape' || event.keyCode === ESCAPE_KEYCODE) {
       this.props.onDismiss();
     }
   }

--- a/v3/src/js/views/components/color-picker/ColorPicker.jsx
+++ b/v3/src/js/views/components/color-picker/ColorPicker.jsx
@@ -1,6 +1,6 @@
 // @flow
 /* eslint-disable react/prefer-stateless-function */
-import React from 'react';
+import React, { Component } from 'react';
 import type { ColorIndex } from 'types/reducers';
 
 import _ from 'lodash';
@@ -10,24 +10,37 @@ import './color-picker.scss';
 
 type Props = {
   onChooseColor: Function,
+  handleEscKeyDown: Function,
 };
 
-function ColorPicker(props: Props) {
-  return (
-    <div className="color-picker-container">
-      <div className="color-picker">
-        {_.range(NUM_DIFFERENT_COLORS).map((index: ColorIndex) => {
-          return (
-            <span className={`color-option color-${index}`}
-              key={index}
-              onClick={() => {
-                props.onChooseColor(index);
-              }} />
-          );
-        })}
+class ColorPicker extends Component {
+  props: Props;
+
+  componentWillMount() {
+    window.addEventListener('keydown', this.props.handleEscKeyDown);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('keydown', this.props.handleEscKeyDown);
+  }
+
+  render() {
+    return (
+      <div className="color-picker-container">
+        <div className="color-picker">
+          {_.range(NUM_DIFFERENT_COLORS).map((index: ColorIndex) => {
+            return (
+              <span className={`color-option color-${index}`}
+                key={index}
+                onClick={() => {
+                  this.props.onChooseColor(index);
+                }} />
+            );
+          })}
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 }
 
 export default ColorPicker;

--- a/v3/src/js/views/timetable/TimetableModulesTable.jsx
+++ b/v3/src/js/views/timetable/TimetableModulesTable.jsx
@@ -83,7 +83,7 @@ class TimetableModulesTable extends Component {
                       <ColorPicker onChooseColor={(colorIndex: ColorIndex) => {
                         this.props.selectModuleColor(module.ModuleCode, colorIndex);
                       }}
-                        onDismiss={this.props.cancelModifyModuleColor} />
+                        onDismiss={this.cancelModifyModuleColor} />
                     }
                   </div>
                   <div className="module-details-column">

--- a/v3/src/js/views/timetable/TimetableModulesTable.jsx
+++ b/v3/src/js/views/timetable/TimetableModulesTable.jsx
@@ -28,23 +28,12 @@ type Props = {
 class TimetableModulesTable extends Component {
   props: Props;
 
-  constructor() {
-    super();
-    this.handleEscKeyDown = this.handleEscKeyDown.bind(this);
-  }
-
   componentWillUnmount() {
     this.cancelModifyModuleColor();
   }
 
   cancelModifyModuleColor = () => {
     if (this.props.activeModule) {
-      this.props.cancelModifyModuleColor();
-    }
-  }
-
-  handleEscKeyDown(e) {
-    if (e.key === 'Escape') {
       this.props.cancelModifyModuleColor();
     }
   }
@@ -94,7 +83,7 @@ class TimetableModulesTable extends Component {
                       <ColorPicker onChooseColor={(colorIndex: ColorIndex) => {
                         this.props.selectModuleColor(module.ModuleCode, colorIndex);
                       }}
-                        handleEscKeyDown={this.handleEscKeyDown} />
+                        onDismiss={this.props.cancelModifyModuleColor} />
                     }
                   </div>
                   <div className="module-details-column">

--- a/v3/src/js/views/timetable/TimetableModulesTable.jsx
+++ b/v3/src/js/views/timetable/TimetableModulesTable.jsx
@@ -28,12 +28,23 @@ type Props = {
 class TimetableModulesTable extends Component {
   props: Props;
 
+  constructor() {
+    super();
+    this.handleEscKeyDown = this.handleEscKeyDown.bind(this);
+  }
+
   componentWillUnmount() {
     this.cancelModifyModuleColor();
   }
 
   cancelModifyModuleColor = () => {
     if (this.props.activeModule) {
+      this.props.cancelModifyModuleColor();
+    }
+  }
+
+  handleEscKeyDown(e) {
+    if (e.key === 'Escape') {
       this.props.cancelModifyModuleColor();
     }
   }
@@ -82,7 +93,8 @@ class TimetableModulesTable extends Component {
                     {this.props.activeModule === module.ModuleCode &&
                       <ColorPicker onChooseColor={(colorIndex: ColorIndex) => {
                         this.props.selectModuleColor(module.ModuleCode, colorIndex);
-                      }} />
+                      }}
+                        handleEscKeyDown={this.handleEscKeyDown} />
                     }
                   </div>
                   <div className="module-details-column">


### PR DESCRIPTION
Attempts to fix #350 
I had to add an event listener to window, because I can't add a 'onKeyDown' handler to components that can't be focused (div and span in colorpicker).