### PR TITLE
Add aria-label to buttons with Font Awesome icons for accessibility

### DIFF
--- a/v3/src/js/views/static/DevelopersContainer.jsx
+++ b/v3/src/js/views/static/DevelopersContainer.jsx
@@ -56,7 +56,8 @@ class DevelopersContainer extends Component {
             <div className="row">
               {this.state.isLoading &&
                 <div className="col-12 text-center">
-                  <i className="fa fa-circle-o-notch fa-spin" style={{ fontSize: '4rem' }} />
+                  <i className="fa fa-circle-o-notch fa-spin" style={{ fontSize: '4rem' }} aria-hidden="true" />
+                  <span className="sr-only">Loading</span>
                 </div>
               }
               {this.state.isError &&

--- a/v3/src/js/views/static/TeamContainer.jsx
+++ b/v3/src/js/views/static/TeamContainer.jsx
@@ -34,22 +34,30 @@ export default function TeamContainer() {
                   <div className="row">
                     {teamMember.facebook &&
                       <div className="col-sm-1 col-xs-3">
-                        <a href={teamMember.facebook}><i className="fa fa-facebook-square fa-lg" /></a>
+                        <a href={teamMember.facebook} title="Facebook profile" aria-label="Facebook profile">
+                          <i className="fa fa-facebook-square fa-lg" aria-hidden="true" />
+                        </a>
                       </div>
                     }
                     {teamMember.twitter &&
                       <div className="col-sm-1 col-xs-3">
-                        <a href={teamMember.twitter}><i className="fa fa-twitter fa-lg" /></a>
+                        <a href={teamMember.twitter} title="Twitter feed" aria-label="Twitter feed">
+                          <i className="fa fa-twitter fa-lg" aria-hidden="true" />
+                        </a>
                       </div>
                     }
                     {teamMember.linkedin &&
                       <div className="col-sm-1 col-xs-3">
-                        <a href={teamMember.linkedin}><i className="fa fa-linkedin fa-lg" /></a>
+                        <a href={teamMember.linkedin} title="LinkedIn profile" aria-label="LinkedIn profile">
+                          <i className="fa fa-linkedin fa-lg" aria-hidden="true" />
+                        </a>
                       </div>
                     }
                     {teamMember.github &&
                       <div className="col-sm-1 col-xs-3">
-                        <a href={teamMember.github}><i className="fa fa-github-square fa-lg" /></a>
+                        <a href={teamMember.github} title="GitHub profile" aria-label="GitHub profile" >
+                          <i className="fa fa-github-square fa-lg" aria-hidden="true" />
+                        </a>
                       </div>
                     }
                   </div>

--- a/v3/src/js/views/timetable/TimetableContainer.jsx
+++ b/v3/src/js/views/timetable/TimetableContainer.jsx
@@ -179,27 +179,35 @@ class TimetableContainer extends Component {
                 <button
                   type="button"
                   className="btn btn-outline-primary"
+                  title={isHorizontalOrientation ? 'Vertical Mode' : 'Horizontal mode'}
+                  aria-label={isHorizontalOrientation ? 'Vertical Mode' : 'Horizontal mode'}
                   onClick={this.props.toggleTimetableOrientation}
                 >
-                  <i className={classnames('fa', 'fa-exchange', {
-                    'fa-rotate-90': isHorizontalOrientation,
-                  })}
+                  <i
+                    className={classnames('fa', 'fa-exchange', {
+                      'fa-rotate-90': isHorizontalOrientation,
+                    })}
+                    aria-hidden="true"
                   />
                 </button>
                 <button
                   type="button"
+                  title="Download as Image"
+                  aria-label="Download as Image"
                   className="btn btn-outline-primary"
                   onClick={() => this.props.downloadAsJpeg(this.timetableDom)}
                 >
-                  <i className="fa fa-image" />
+                  <i className="fa fa-image" aria-hidden="true" />
                 </button>
                 <button
                   type="button"
+                  title="Download as iCal"
+                  aria-label="Download as iCal"
                   className="btn btn-outline-primary"
                   onClick={() => this.props.downloadAsIcal(
                     this.props.semester, this.props.semTimetableWithLessons, this.props.modules)}
                 >
-                  <i className="fa fa-calendar" />
+                  <i className="fa fa-calendar" aria-hidden="true" />
                 </button>
               </div>
               <div className="row">

--- a/v3/src/js/views/timetable/TimetableModulesTable.jsx
+++ b/v3/src/js/views/timetable/TimetableModulesTable.jsx
@@ -36,20 +36,30 @@ class TimetableModulesTable extends Component {
     if (this.props.activeModule) {
       this.props.cancelModifyModuleColor();
     }
-  }
+  };
 
   showButton(moduleCode) {
     return (
-      <button className="btn-link btn-remove" onClick={() => this.props.showLessonInTimetable(moduleCode)}>
-        <i className="fa fa-eye-slash" />
+      <button
+        className="btn-link btn-remove"
+        title="Hide"
+        aria-label="Hide"
+        onClick={() => this.props.showLessonInTimetable(moduleCode)}
+      >
+        <i className="fa fa-eye-slash" aria-hidden="true" />
       </button>
     );
   }
 
   hideButton(moduleCode) {
     return (
-      <button className="btn-link btn-remove" onClick={() => this.props.hideLessonInTimetable(moduleCode)}>
-        <i className="fa fa-eye" />
+      <button
+        className="btn-link btn-remove"
+        title="Show"
+        aria-label="Show"
+        onClick={() => this.props.hideLessonInTimetable(moduleCode)}
+      >
+        <i className="fa fa-eye" aria-hidden="true" />
       </button>
     );
   }


### PR DESCRIPTION
## Context 

Font Awesome is used on the page to display icons in some buttons. However some of these icons are included without any text label, which means screen readers will not be able to discern what the icons mean 

## Approach 

In line with Font Awesome best practices, if the icons are semantic (ie. they have meaning), and if there are no text labels, we add ARIA text labels using `aria-label` attributes. We also apply `title` attributes to create tooltips. 

## Reference 

http://fontawesome.io/accessibility/ 