### PR TITLE
Fix "No modules added" text positioning

### DIFF
--- a/v3/src/js/views/timetable/TimetableModulesTable.jsx
+++ b/v3/src/js/views/timetable/TimetableModulesTable.jsx
@@ -118,7 +118,9 @@ class TimetableModulesTable extends Component {
               </div>
             );
           })
-          : <p className="text-sm-center">No modules added.</p>
+          : <div className="col-sm-12">
+            <p className="text-sm-center">No modules added.</p>
+          </div>
         }
       </div>
     );


### PR DESCRIPTION
## Context 

There's a small layout bug when there are no modules selected 

![screenshot from 2017-08-08 16-53-47](https://user-images.githubusercontent.com/445650/29064000-2a160384-7c5a-11e7-9aa7-7dba3cb85fc0.png)

## Approach 

The bug is caused by a missing `col-sm-*` wrapper element - it is present on the other branch of the ternary statement - so we simply add it back in. 