### PR TITLE
Reduce some stylistic issues to warn outside production

### DIFF
--- a/v3/.eslintrc.js
+++ b/v3/.eslintrc.js
@@ -1,3 +1,6 @@
+const warnInDevelopment = process.env.NODE_ENV === 'production' ?
+  'error' : 'warn';
+
 module.exports = {
   parser: 'babel-eslint',
   root: true,
@@ -40,20 +43,33 @@ module.exports = {
     // Body style is more troublesome than it's worth
     'arrow-body-style': 'off',
     // Consistent arrow parens.
-    'arrow-parens': ['error', 'as-needed', { requireForBlockBody: true }],
+    'arrow-parens': [warnInDevelopment, 'as-needed', { requireForBlockBody: true }],
+
+    // Minor style issues should not stop development
+    'semi': [warnInDevelopment, 'always'],
+    'no-trailing-spaces': warnInDevelopment,
+    'no-unused-vars': warnInDevelopment,
+    'comma-dangle': warnInDevelopment,
+    'comma-spacing': [warnInDevelopment, { before: false, after: true }],
+
+    // Allow debugger and console statement in development
+    'no-debugger': warnInDevelopment,
+    'no-console': warnInDevelopment,
+
     // After adding flowtypes the lines are getting longer.
-    'max-len': ['error', 120],
-    'import/extensions': ['error', 'always',
+    'max-len': [warnInDevelopment, 120],
+    'import/extensions': [warnInDevelopment, 'always',
       {
         js: 'never',
-        jsx: 'never'
+        jsx: 'never',
       }
     ],
+
     'react/no-array-index-key': 'off',
     // SEE: https://github.com/yannickcr/eslint-plugin-react/issues
     'react/no-unused-prop-types': 'off',
     // Enables typing to be placed above lifecycle
-    "react/sort-comp": ['error', {
+    'react/sort-comp': ['error', {
       order: [
         'type-annotations',
         'static-methods',

--- a/v3/package.json
+++ b/v3/package.json
@@ -9,11 +9,11 @@
     "flow": "flow check",
     "lint": "npm run lint:src && npm run flow && npm run lint:test && npm run lint:scripts",
     "lint:src": "eslint 'src/js/**/!(*.test).{js,jsx}' --cache",
-    "lint:test": "cross-env NODE_ENV=test eslint __tests__ 'src/js/**/*.test.{js,jsx}' --cache",
+    "lint:test": "cross-env BABEL_ENV=test eslint __tests__ 'src/js/**/*.test.{js,jsx}' --cache",
     "lint:scripts": "eslint webpack scripts --cache",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
-    "ci": "npm run lint && npm run test && npm run build"
+    "ci": "cross-env NODE_ENV=production npm run lint && npm run test && npm run build"
   },
   "author": "NUSModifications",
   "license": "MIT",

--- a/v3/webpack/webpack.config.common.js
+++ b/v3/webpack/webpack.config.common.js
@@ -6,7 +6,8 @@ const parts = require('./webpack.parts');
 
 const commonConfig = merge([
   {
-    // This tells Webpack where to look for modules.
+    // This tells Webpack where to look for modules. Remember to update the
+    // corresponding entry in .flowconfig if you're updating these
     resolve: {
       // Specify a few root paths when importing our own modules,
       // so that we can use absolute paths in our imports.
@@ -17,9 +18,14 @@ const commonConfig = merge([
         parts.PATHS.app,
         parts.PATHS.styles,
         parts.PATHS.node,
-        // Only include path for access to __mocks__
-        ...(process.env.NODE_ENV === 'test' || process.env.BABEL_ENV === 'test' ? [parts.PATHS.root] : []),
       ],
+      // Maps specific modules, similar to modules above, except in this case
+      // we map the folders directly - for instance we only want __mocks__ and not
+      // any of the other folders under root to be imported from root, so we use
+      // this instead of modules
+      alias: {
+        __mocks__: parts.PATHS.fixtures,
+      },
       // Importing modules from these files will not require the extension.
       extensions: ['.js', '.jsx', '.json'],
     },

--- a/v3/webpack/webpack.config.common.js
+++ b/v3/webpack/webpack.config.common.js
@@ -18,7 +18,7 @@ const commonConfig = merge([
         parts.PATHS.styles,
         parts.PATHS.node,
         // Only include path for access to __mocks__
-        ...(process.env.NODE_ENV === 'test' ? [parts.PATHS.root] : []),
+        ...(process.env.NODE_ENV === 'test' || process.env.BABEL_ENV === 'test' ? [parts.PATHS.root] : []),
       ],
       // Importing modules from these files will not require the extension.
       extensions: ['.js', '.jsx', '.json'],

--- a/v3/webpack/webpack.parts.js
+++ b/v3/webpack/webpack.parts.js
@@ -19,6 +19,7 @@ const PATHS = {
   styles: path.join(ROOT, SRC, 'styles'),
   images: path.join(ROOT, SRC, 'img'),
   build: path.join(ROOT, 'dist'),
+  fixtures: path.join(ROOT, '__mocks__'),
 };
 
 // These dependencies will be extracted out into `vendor.js` in production build.


### PR DESCRIPTION
By using `process.env.NODE_ENV`, we can drop some common style issues down to **warning** during development. This reduces development friction, since Webpack waits on ESLint **errors** to be resolved before compiling, and most style issues should not force the developer to stop and fix them before proceeding. 

Since CI runs in production, anything that slips through will be caught by Travis anyway, so this is safe. 