### PR TITLE
Upgrade to Bootstrap 4 beta

### DIFF
--- a/v3/package.json
+++ b/v3/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "axios": "^0.16.2",
     "babel-polyfill": "^6.23.0",
-    "bootstrap": "4.0.0-alpha.6",
+    "bootstrap": "4.0.0-beta",
     "classnames": "^2.2.5",
     "d3": "^4.10.0",
     "dom-to-image": "^2.5.2",

--- a/v3/src/js/views/AppShell.jsx
+++ b/v3/src/js/views/AppShell.jsx
@@ -71,7 +71,7 @@ export class AppShell extends Component {
       <div className="app-container">
         <nav className="nm-navbar fixed-top">
           <NavLink className="nm-navbar-brand" to="/" title="Home" />
-          <form className="nm-navbar-form hidden-xs-down">
+          <form className="nm-navbar-form">
             <ModulesSelect
               moduleList={this.props.moduleSelectList}
               onChange={(moduleCode) => {
@@ -80,7 +80,7 @@ export class AppShell extends Component {
               placeholder="Search modules"
             />
           </form>
-          <span className="nm-navbar-text hidden-xs-down"><small>{weekText}</small></span>
+          <span className="nm-navbar-text"><small>{weekText}</small></span>
         </nav>
         <div className="container-fluid">
           <div className="row">

--- a/v3/src/js/views/components/NewStudentSelect.jsx
+++ b/v3/src/js/views/components/NewStudentSelect.jsx
@@ -19,7 +19,7 @@ export default function NewStudentSelect(props: Props) {
         type="button"
         className={classnames('btn', {
           'btn-primary': newStudent,
-          'btn-secondary': !newStudent,
+          'btn-outline-primary': !newStudent,
         })}
         onClick={() => onSelectNewStudent(true)}
       >Yes
@@ -28,7 +28,7 @@ export default function NewStudentSelect(props: Props) {
         type="button"
         className={classnames('btn', {
           'btn-primary': !newStudent,
-          'btn-secondary': newStudent,
+          'btn-outline-primary': newStudent,
         })}
         onClick={() => onSelectNewStudent(false)}
       >No

--- a/v3/src/js/views/settings/SettingsContainer.jsx
+++ b/v3/src/js/views/settings/SettingsContainer.jsx
@@ -29,7 +29,7 @@ function SettingsContainer(props: Props) {
     <DocumentTitle title={`Settings - ${config.brandName}`}>
       <div className="settings-page-container page-container">
         <div className="row">
-          <div className="col-md-8 offset-md-1">
+          <div className="col-lg-8 offset-lg-1">
             <h1 className="page-title">Settings</h1>
             <h4>New Student</h4>
             <div className="row">

--- a/v3/src/styles/bootstrap/bootstrap.scss
+++ b/v3/src/styles/bootstrap/bootstrap.scss
@@ -4,15 +4,12 @@
 @import "variable-overrides";
 
 // Core variables and mixins
-// @import "~bootstrap/scss/custom";
+@import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
 @import "~bootstrap/scss/mixins";
 
-// Reset and dependencies
-@import "~bootstrap/scss/normalize";
+// Core styles
 // @import "~bootstrap/scss/print";
-
-// Core CSS
 @import "~bootstrap/scss/reboot";
 @import "~bootstrap/scss/type";
 @import "~bootstrap/scss/images";
@@ -23,7 +20,7 @@
 @import "~bootstrap/scss/buttons";
 
 // Components
-// @import "~bootstrap/scss/animation";
+// @import "~bootstrap/scss/transitions";
 // @import "~bootstrap/scss/dropdown";
 @import "~bootstrap/scss/button-group";
 // @import "~bootstrap/scss/input-group";
@@ -33,16 +30,15 @@
 // @import "~bootstrap/scss/card";
 // @import "~bootstrap/scss/breadcrumb";
 // @import "~bootstrap/scss/pagination";
-// @import "~bootstrap/scss/tags";
+// @import "~bootstrap/scss/badge";
 // @import "~bootstrap/scss/jumbotron";
 // @import "~bootstrap/scss/alert";
 // @import "~bootstrap/scss/progress";
 // @import "~bootstrap/scss/media";
 // @import "~bootstrap/scss/list-group";
-// @import "~bootstrap/scss/responsive-embed";
 // @import "~bootstrap/scss/close";
 
-// Components w/ JavaScript
+// Components with JavaScript
 // @import "~bootstrap/scss/modal";
 // @import "~bootstrap/scss/tooltip";
 // @import "~bootstrap/scss/popover";
@@ -50,4 +46,3 @@
 
 // Utility classes
 @import "~bootstrap/scss/utilities";
-

--- a/v3/src/styles/bootstrap/variable-overrides.scss
+++ b/v3/src/styles/bootstrap/variable-overrides.scss
@@ -9,11 +9,13 @@ $gray-lightest:             #f5f7fa;
 
 $theme-colors: (
   primary:                  #ff5138,
-  secondary:                $gray-lightest,
+  secondary:                $gray,
   success:                  #97cd76,
   info:                     #42afe3,
   warning:                  #fce473,
   danger:                   #ed6c63,
+  light:                    $gray-lightest,
+  dark:                     $gray-dark,
 );
 
 // Options

--- a/v3/src/styles/bootstrap/variable-overrides.scss
+++ b/v3/src/styles/bootstrap/variable-overrides.scss
@@ -7,34 +7,34 @@ $gray-light:                #aeb1b5;
 $gray-lighter:              #d3d6db;
 $gray-lightest:             #f5f7fa;
 
-$brand-primary:             #ff5138;
-$brand-success:             #97cd76;
-$brand-info:                #42afe3;
-$brand-warning:             #fce473;
-$brand-danger:              #ed6c63;
+$theme-colors: (
+  primary:                  #ff5138,
+  secondary:                $gray-lightest,
+  success:                  #97cd76,
+  info:                     #42afe3,
+  warning:                  #fce473,
+  danger:                   #ed6c63,
+);
 
 // Options
 
 // Body
-// $body-bg: $gray-lightest;
 $body-color: $gray;
-
-// Grid Columns
-$grid-gutter-width: 20px;
 
 // Typography
 $font-size-xlg:   2rem !default;
+$font-size-xs:    0.75rem !default;
 $font-size-xxs:   0.65rem !default;
 
 // Form states and alerts
-$state-success-text:             #fff;
-$state-success-bg:               $brand-success;
+$state-success-text:        #fff;
+$state-success-bg:          theme-color('success');
 
-$state-info-text:                #fff;
-$state-info-bg:                  $brand-info;
+$state-info-text:           #fff;
+$state-info-bg:             theme-color('info');
 
-$state-warning-text:             #fff;
-$state-warning-bg:               $brand-warning;
+$state-warning-text:        #fff;
+$state-warning-bg:          theme-color('warning');
 
-$state-danger-text:              #fff;
-$state-danger-bg:                $brand-danger;
+$state-danger-text:         #fff;
+$state-danger-bg:           theme-color('danger');

--- a/v3/src/styles/layout/nav.scss
+++ b/v3/src/styles/layout/nav.scss
@@ -55,7 +55,7 @@
     padding: 0.7rem;
 
     &.active {
-      color: $brand-primary;
+      color: theme-color('primary');
     }
   }
 

--- a/v3/src/styles/layout/nav.scss
+++ b/v3/src/styles/layout/nav.scss
@@ -42,6 +42,13 @@
     flex: 1 1 auto;
     text-align: right;
   }
+
+  @include media-breakpoint-down('xs') {
+    .nm-navbar-text,
+    .nm-navbar-form {
+      display: none;
+    }
+  }
 }
 
 .nm-nav-tabs {

--- a/v3/src/styles/layout/nav.scss
+++ b/v3/src/styles/layout/nav.scss
@@ -63,7 +63,7 @@
     list-style: none;
   }
 
-  @media (max-width: map-get($grid-breakpoints, 'md')) {
+  @include media-breakpoint-down(sm) {
     background-color: #fff;
     box-shadow: 0 0 15px -3px rgba(0, 0, 0, 0.4);
     flex-direction: row;

--- a/v3/src/styles/layout/site.scss
+++ b/v3/src/styles/layout/site.scss
@@ -2,14 +2,14 @@
 body {
   padding-top: 4rem;
 
-  @media (max-width: map-get($grid-breakpoints, 'md')) {
+  @include media-breakpoint-down(sm) {
     font-size: $font-size-sm;
     padding-top: $navbar-height * 2;
   }
 }
 
 .main-content {
-  @media (max-width: map-get($grid-breakpoints, 'md')) {
+  @include media-breakpoint-down(sm) {
     padding-top: 1rem;
   }
 }
@@ -21,4 +21,17 @@ body {
 .page-title {
   font-size: $font-size-xlg;
   margin: 2rem 0 4rem;
+}
+
+// Recreate Bootstrap v3 offsets
+@include media-breakpoint-up('md') {
+  .offset-md-1 {
+    margin-left: percentage(1 / $grid-columns);
+  }
+}
+
+@include media-breakpoint-up('sm') {
+  .offset-sm-1 {
+    margin-left: percentage(1 / $grid-columns);
+  }
 }

--- a/v3/src/styles/pages/modules.scss
+++ b/v3/src/styles/pages/modules.scss
@@ -67,7 +67,7 @@
   }
 
   .mod-rect {
-    fill: $brand-primary;
+    fill: theme-color('primary');
     transition: opacity 0.25s ease, fill 0.25s ease;
   }
 

--- a/v3/src/styles/pages/settings.scss
+++ b/v3/src/styles/pages/settings.scss
@@ -10,7 +10,7 @@
     margin-bottom: $theme-option-gap;
     width: 25%;
 
-    @media (max-width: map-get($grid-breakpoints, 'md')) {
+    @include media-breakpoint-down('sm') {
       width: 50%;
     }
   }

--- a/v3/yarn.lock
+++ b/v3/yarn.lock
@@ -1069,12 +1069,9 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap@4.0.0-alpha.6:
-  version "4.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-alpha.6.tgz#4f54dd33ac0deac3b28407bc2df7ec608869c9c8"
-  dependencies:
-    jquery ">=1.9.1"
-    tether "^1.4.0"
+bootstrap@4.0.0-beta:
+  version "4.0.0-beta"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0-beta.tgz#dc5928175d2e71310bc668cf9e05a907211b72a6"
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.7"
@@ -4138,10 +4135,6 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery@>=1.9.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
-
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
@@ -6899,10 +6892,6 @@ test-exclude@^4.1.0:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
-
-tether@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.0.tgz#0f9fa171f75bf58485d8149e94799d7ae74d1c1a"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Bootstrap 4 beta was just released, so of course we need to upgrade to the new hotness! Seriously though, given the scope of the changes and the fact that they've switched bootstrap.com over to v4-beta documentations, I *think* the code will be more stable now, so it's as good a time as any to upgrade. 

The major breaking changes that affects NUSMods v3 I've noticed are -  

- Theme colors are defined as a map and accessed through the `theme()` function now instead of `$brand-*` variables 
- `offset-*` classes have been removed. I've added back `offset-md-1` and `offset-sm-1` manually. The same effect cannot be recreated with the new alignment classes, although they do open up new possibilities - https://getbootstrap.com/docs/4.0/layout/grid/#alignment 
- `btn-secondary` has been changed to a dark gray color. This affects the new student 'toggle' button. I've changed it to `btn-outline-primary` instead 
- `hidden-*` responsive utilities have been removed. `d-*` utilities can replace them in some limit cases, but not for `hidden-xs-down`, so I fixed it by writing the media query into `nav.scss` itself. 

Also fixed some off-by-one bugs with responsive layout - don't use media query `max/min-width` directly with `$grid-breakpoint`, but rather use the `media-breakpoint-*` utilities provided by Bootstrap. There's no size regression - BS4 beta's final CSS is about 700 bytes smaller than alpha-6. 

