### PR TITLE
Add LinkModuleCodes component

### DIFF
--- a/v3/src/js/views/browse/ModulePageContainer.jsx
+++ b/v3/src/js/views/browse/ModulePageContainer.jsx
@@ -12,6 +12,7 @@ import type { Module } from 'types/modules';
 import type { FetchRequest } from 'types/reducers';
 import { formatExamDate } from 'utils/modules';
 import type { TimetableConfig } from 'types/timetables';
+import LinkModuleCodes from 'views/components/LinkModuleCodes';
 import AddModuleButton from './AddModuleButton';
 import RemoveModuleButton from './RemoveModuleButton';
 import CorsBiddingStatsTableControl from './CorsBiddingStatsTableControl';
@@ -116,33 +117,52 @@ export class ModulePageContainer extends Component {
           {this.props.fetchModuleRequest.isPending && !module ?
             <p>Loading...</p> : null
           }
-          {this.props.fetchModuleRequest.isFailure ? <p>Module not found</p> : null}
-          {this.props.fetchModuleRequest.isSuccessful || module ?
+          {this.props.fetchModuleRequest.isFailure && <p>Module not found</p> }
+          {(this.props.fetchModuleRequest.isSuccessful || module) &&
             <div>
               <h1 className="page-title">{module.ModuleCode} {module.ModuleTitle}</h1>
               <hr />
               <dl className="row">
-                {module.ModuleDescription ? <dt className="col-sm-3">Description</dt> : null}
-                {module.ModuleDescription ?
-                  <dd className="col-sm-9">{module.ModuleDescription}</dd> : null}
+                {module.ModuleDescription && [
+                  <dt className="col-sm-3">Description</dt>,
+                  <dd className="col-sm-9">{module.ModuleDescription}</dd>,
+                ]}
 
-                {module.ModuleCredit ? <dt className="col-sm-3">Module Credits (MCs)</dt> : null}
-                {module.ModuleCredit ? <dd className="col-sm-9">{module.ModuleCredit}</dd> : null}
+                {module.ModuleCredit && [
+                  <dt className="col-sm-3">Module Credits (MCs)</dt>,
+                  <dd className="col-sm-9">{module.ModuleCredit}</dd>,
+                ]}
 
-                {module.Prerequisite ? <dt className="col-sm-3">Prerequisite(s)</dt> : null}
-                {module.Prerequisite ? <dd className="col-sm-9">{module.Prerequisite}</dd> : null}
+                {module.Prerequisite && [
+                  <dt className="col-sm-3">Prerequisite(s)</dt>,
+                  <dd className="col-sm-9">
+                    <LinkModuleCodes>{module.Prerequisite}</LinkModuleCodes>
+                  </dd>,
+                ]}
 
-                {module.Corequisite ? <dt className="col-sm-3">Corequisite(s)</dt> : null}
-                {module.Corequisite ? <dd className="col-sm-9">{module.Corequisite}</dd> : null}
+                {module.Corequisite && [
+                  <dt className="col-sm-3">Corequisite(s)</dt>,
+                  <dd className="col-sm-9">
+                    <LinkModuleCodes>{module.Corequisite}</LinkModuleCodes>
+                  </dd>,
+                ]}
 
-                {module.Preclusion ? <dt className="col-sm-3">Preclusion(s)</dt> : null}
-                {module.Preclusion ? <dd className="col-sm-9">{module.Preclusion}</dd> : null}
+                {module.Preclusion && [
+                  <dt className="col-sm-3">Preclusion(s)</dt>,
+                  <dd className="col-sm-9">
+                    <LinkModuleCodes>{module.Preclusion}</LinkModuleCodes>
+                  </dd>,
+                ]}
 
-                {module.Department ? <dt className="col-sm-3">Department</dt> : null}
-                {module.Department ? <dd className="col-sm-9">{module.Department}</dd> : null}
+                {module.Department && [
+                  <dt className="col-sm-3">Department</dt>,
+                  <dd className="col-sm-9">{module.Department}</dd>,
+                ]}
 
-                {module.Workload ? <dt className="col-sm-3">Weekly Workload</dt> : null}
-                {module.Workload ? <dd className="col-sm-9">{module.Workload}</dd> : null}
+                {module.Workload && [
+                  <dt className="col-sm-3">Weekly Workload</dt>,
+                  <dd className="col-sm-9">{module.Workload}</dd>,
+                ]}
 
                 {renderExaminations}
 
@@ -171,9 +191,8 @@ export class ModulePageContainer extends Component {
                 <p>Prerequisites are not available.</p>
               }
 
-              {module.CorsBiddingStats ?
+              {module.CorsBiddingStats &&
                 <CorsBiddingStatsTableControl stats={module.CorsBiddingStats} />
-                : null
               }
 
               <LessonTimetableControl
@@ -188,7 +207,7 @@ export class ModulePageContainer extends Component {
                 url={`https://nusmods.com/modules/${module.ModuleCode}/reviews`}
               />
 
-            </div> : null
+            </div>
           }
         </div>
       </DocumentTitle>

--- a/v3/src/js/views/components/LinkModuleCodes.jsx
+++ b/v3/src/js/views/components/LinkModuleCodes.jsx
@@ -15,20 +15,22 @@ export function LinkModuleCodesComponent(props: Props) {
   const { children, moduleCodes } = props;
 
   // Look for strings that look like module codes - eg.
-  // ACC1010  - 3 chars, 4 digit, no suffix
-  // CS1010FC - 2 chars, 4 digit, 2 char
-  // CS2014R  - 2 chars, 4 digit, 1 char
+  // ACC1010  - 3 chars, 4 digits, no suffix
+  // CS1010FC - 2 chars, 4 digits, 2 chars
+  // CS2014R  - 2 chars, 4 digits, 1 char
+  // BMA 5001 - 3 chars, space, 4 digits
 
   // Add a space in front to force regex matches to be even
   // Otherwise if the first character is part of a match, the matches will be
   // odd elements
-  const parts = (' ' + children).split(/\b(\w{2,3}\d{4}\w{0,2})\b/g); // eslint-disable-line prefer-template
+  const parts = (' ' + children).split(/\b(\w{2,3}\s*\d{4}\w{0,2})\b/g); // eslint-disable-line prefer-template
   parts[0] = parts[0].slice(1);
   return (
     <span>{parts.map((part, i) => {
       if (i % 2 === 0) return part;
-      if (!moduleCodes.has(part)) return part;
-      return <Link to={modulePagePath(part)} key={part}>{part}</Link>;
+      const code = part.replace(/\s*/g, '');
+      if (!moduleCodes.has(code)) return part;
+      return <Link to={modulePagePath(code)} key={code}>{part}</Link>;
     })}</span>
   );
 }

--- a/v3/src/js/views/components/LinkModuleCodes.jsx
+++ b/v3/src/js/views/components/LinkModuleCodes.jsx
@@ -11,20 +11,25 @@ type Props = {
   moduleCodes: Set<ModuleCode>,
 };
 
+// Look for strings that look like module codes - eg.
+// ACC1010  - 3 chars, 4 digits, no suffix
+// CS1010FC - 2 chars, 4 digits, 2 chars
+// CS2014R  - 2 chars, 4 digits, 1 char
+// BMA 5001 - 3 chars, space, 4 digits
+const MODULE_CODE_REGEX = /\b(\w{2,3}\s*\d{4}\w{0,2})\b/g;
+
 export function LinkModuleCodesComponent(props: Props) {
   const { children, moduleCodes } = props;
 
-  // Look for strings that look like module codes - eg.
-  // ACC1010  - 3 chars, 4 digits, no suffix
-  // CS1010FC - 2 chars, 4 digits, 2 chars
-  // CS2014R  - 2 chars, 4 digits, 1 char
-  // BMA 5001 - 3 chars, space, 4 digits
+  const parts = children.split(MODULE_CODE_REGEX);
 
-  // Add a space in front to force regex matches to be even
-  // Otherwise if the first character is part of a match, the matches will be
-  // odd elements
-  const parts = (' ' + children).split(/\b(\w{2,3}\s*\d{4}\w{0,2})\b/g); // eslint-disable-line prefer-template
-  parts[0] = parts[0].slice(1);
+  // We want to ensure the resulting array always has ModuleCode at even position
+  // eg. ['Some text ', 'CS1010S', ' more text ', 'CS3216', 'more text'].
+  // This allows us to replace the even position elements with <Link> components.
+  // However, if the string starts with a module code, then the first element will be a module
+  // so we add in an empty string to pad module codes to even positions
+  if (parts.length && MODULE_CODE_REGEX.test(parts[0])) parts.unshift('');
+
   return (
     <span>{parts.map((part, i) => {
       if (i % 2 === 0) return part;

--- a/v3/src/js/views/components/LinkModuleCodes.jsx
+++ b/v3/src/js/views/components/LinkModuleCodes.jsx
@@ -1,0 +1,38 @@
+// @flow
+
+import React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import type { ModuleCode } from 'types/modules';
+import { modulePagePath } from 'utils/modules';
+
+type Props = {
+  children: string,
+  moduleCodes: Set<ModuleCode>,
+};
+
+export function LinkModuleCodesComponent(props: Props) {
+  const { children, moduleCodes } = props;
+
+  // Look for strings that look like module codes - eg.
+  // ACC1010  - 3 chars, 4 digit, no suffix
+  // CS1010FC - 2 chars, 4 digit, 2 char
+  // CS2014R  - 2 chars, 4 digit, 1 char
+
+  // Add a space in front to force regex matches to be even
+  // Otherwise if the first character is part of a match, the matches will be
+  // odd elements
+  const parts = (' ' + children).split(/\b(\w{2,3}\d{4}\w{0,2})\b/g); // eslint-disable-line prefer-template
+  parts[0] = parts[0].slice(1);
+  return (
+    <span>{parts.map((part, i) => {
+      if (i % 2 === 0) return part;
+      if (!moduleCodes.has(part)) return part;
+      return <Link to={modulePagePath(part)} key={part}>{part}</Link>;
+    })}</span>
+  );
+}
+
+export default connect(state => ({
+  moduleCodes: state.entities.moduleBank.moduleCodes,
+}))(LinkModuleCodesComponent);

--- a/v3/src/js/views/components/LinkModuleCodes.test.jsx
+++ b/v3/src/js/views/components/LinkModuleCodes.test.jsx
@@ -17,23 +17,25 @@ describe('LinkModuleCodesComponent', () => {
 
   test('should convert module codes to links', () => {
     const modules = ['CS1010FC', 'CS1020', 'ACC1000', 'BMA5000A'];
-    const component = create('CS1010FC, CS1020, ACC1000, BMA5000A', modules);
+    const component = create('CS1010FC, CS1020, ACC1000, BMA 5000A', modules);
     const links = component.find('Link');
     expect(links).toHaveLength(4);
 
     links.forEach((a, index) => {
-      expect(a.text()).toEqual(modules[index]);
+      expect(a.text().replace(' ', '')).toEqual(modules[index]);
       expect(a.prop('to')).toContain(modules[index]);
     });
   });
 
   test('should keep text unchanged', () => {
-    const noModules = create('This text does not contain module codes');
-    expect(noModules.text()).toEqual('This text does not contain module codes');
+    const noModulesText = 'This text does not contain module codes';
+    const noModules = create(noModulesText);
+    expect(noModules.text()).toEqual(noModulesText);
 
-    const mixedModules = create('LSM1000This text has CS1010S random module coPS1101Edes in it',
+    const mixedModulesText = 'LSM1000This text has CS 1010S random module coPS1101Edes in it';
+    const mixedModules = create(mixedModulesText,
       ['LSM1000', 'CS1010S', 'PS1101E']);
-    expect(mixedModules.text()).toEqual('LSM1000This text has CS1010S random module coPS1101Edes in it');
+    expect(mixedModules.text()).toEqual(mixedModulesText);
   });
 
   test('should check words only', () => {

--- a/v3/src/js/views/components/LinkModuleCodes.test.jsx
+++ b/v3/src/js/views/components/LinkModuleCodes.test.jsx
@@ -1,0 +1,51 @@
+// @flow
+
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { mount } from 'enzyme';
+import type { ModuleCode } from 'types/modules';
+import { LinkModuleCodesComponent } from './LinkModuleCodes';
+
+describe('LinkModuleCodesComponent', () => {
+  function create(content: string, modules: ModuleCode[] = []) {
+    return mount(
+      <MemoryRouter>
+        <LinkModuleCodesComponent moduleCodes={new Set(modules)}>{ content }</LinkModuleCodesComponent>
+      </MemoryRouter>,
+    );
+  }
+
+  test('should convert module codes to links', () => {
+    const modules = ['CS1010FC', 'CS1020', 'ACC1000', 'BMA5000A'];
+    const component = create('CS1010FC, CS1020, ACC1000, BMA5000A', modules);
+    const links = component.find('Link');
+    expect(links).toHaveLength(4);
+
+    links.forEach((a, index) => {
+      expect(a.text()).toEqual(modules[index]);
+      expect(a.prop('to')).toContain(modules[index]);
+    });
+  });
+
+  test('should keep text unchanged', () => {
+    const noModules = create('This text does not contain module codes');
+    expect(noModules.text()).toEqual('This text does not contain module codes');
+
+    const mixedModules = create('LSM1000This text has CS1010S random module coPS1101Edes in it',
+      ['LSM1000', 'CS1010S', 'PS1101E']);
+    expect(mixedModules.text()).toEqual('LSM1000This text has CS1010S random module coPS1101Edes in it');
+  });
+
+  test('should check words only', () => {
+    const component = create('ACC1010FCThis teACC1010FCxt contains module codes in wordsACC1010FC',
+      ['ACC1010FC']);
+    expect(component.find('Link')).toHaveLength(0);
+  });
+
+  test('should ignore modules that are not available', (() => {
+    const component = create('CS1010FC, CS1020, ACC1000', ['ACC1000']);
+    expect(component.find('Link')).toHaveLength(1);
+    const acc1000 = component.find('Link').at(0);
+    expect(acc1000.text()).toEqual('ACC1000');
+  }));
+});

--- a/v3/src/js/views/layout/Footer.test.jsx
+++ b/v3/src/js/views/layout/Footer.test.jsx
@@ -12,11 +12,9 @@ test('is a footer element', () => {
 test('contains guards against target_blank', () => {
   const footer = shallow(<Footer />);
   const links = footer.find('a');
-  let result = true;
   links.forEach((a) => {
-    if (result && a.prop('target') === '_blank') {
-      result = a.prop('rel') === 'noopener noreferrer';
+    if (a.prop('target') === '_blank') {
+      expect(a.prop('rel')).toEqual('noopener noreferrer');
     }
   });
-  expect(result).toBe(true);
 });


### PR DESCRIPTION
This component automatically create links for valid module codes in its `children` to their module pages, bringing another feature from v2 to v3. 

- Valid module codes are cached under `moduleBank.moduleCodes`, a `Set<ModuleCode>` 
- Split string using regex to match any word that looks like a module code - we look for `\w{2,3}\d{4}\w{0,2}`
- Check that the code is valid, and if it is, replace it with a `<Link>` 

![screenshot from 2017-08-20 09-44-44](https://user-images.githubusercontent.com/445650/29491372-410a40ba-858c-11e7-9de0-6f7147b6f4bb.png)

The only annoying thing is to use `split` we need a hack to work around cases where module codes are at the start of the string - if you split the string 

    CS1010, ... 
    Some text CS1010, ...

you get 

    ['CS1010', ...]
    ['Some text ', 'CS1010', ...]

So to make things even, we add a ` ` character to the front of the string, then remove it after the split. This is annoying, but I can't find a better way to do this.  

