### PR TITLE
Minor style fixes

### DIFF
--- a/v3/src/js/views/AppShell.jsx
+++ b/v3/src/js/views/AppShell.jsx
@@ -1,11 +1,11 @@
 // @flow
-import type { TimetableConfig, SemTimetableConfig } from 'types/timetables';
-import type { FetchRequest, ModuleList, ModuleSelectList } from 'types/reducers';
-
 import React, { Component } from 'react';
 import { NavLink, withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import NUSModerator from 'nusmoderator';
+
+import type { TimetableConfig, SemTimetableConfig } from 'types/timetables';
+import type { FetchRequest, ModuleList, ModuleSelectList } from 'types/reducers';
 
 import config from 'config';
 import { fetchModuleList, loadModule } from 'actions/moduleBank';

--- a/v3/src/js/views/LoadingSpinner.jsx
+++ b/v3/src/js/views/LoadingSpinner.jsx
@@ -4,8 +4,7 @@ import React from 'react';
 export default function LoadingSpinner() {
   return (
     <div className="loading-spinner">
-      <i className="fa fa-4x fa-fw fa-circle-o-notch fa-spin" aria-hidden="true" />
-      <p className="loading-text">Loading...</p>
+      <i className="fa fa-3x fa-fw fa-circle-o-notch fa-spin" aria-hidden="true" />
     </div>
   );
 }

--- a/v3/src/js/views/browse/CorsBiddingStatsTable.jsx
+++ b/v3/src/js/views/browse/CorsBiddingStatsTable.jsx
@@ -1,6 +1,8 @@
 // @flow
 import React from 'react';
+
 import type { BiddingStat } from 'types/modules';
+
 import Table from 'views/components/Table';
 
 type Props = {

--- a/v3/src/js/views/browse/CorsBiddingStatsTableControl.jsx
+++ b/v3/src/js/views/browse/CorsBiddingStatsTableControl.jsx
@@ -3,11 +3,12 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 
+import type { AccountType, BiddingStat, Faculty, Student } from 'types/modules';
+
 import { selectNewStudent, selectFaculty } from 'actions/settings';
 import AccountSelect from 'views/components/AccountSelect';
 import FacultySelect from 'views/components/FacultySelect';
 import NewStudentSelect from 'views/components/NewStudentSelect';
-import type { AccountType, BiddingStat, Faculty, Student } from 'types/modules';
 import ButtonGroupSelector from 'views/components/ButtonGroupSelector';
 import { isStatRelevantForStudent } from 'utils/cors';
 import CorsBiddingStatsTable from './CorsBiddingStatsTable';

--- a/v3/src/js/views/browse/LessonTimetable.jsx
+++ b/v3/src/js/views/browse/LessonTimetable.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import type { LessonType, RawLesson } from 'types/modules';
+
 import Table from 'views/components/Table';
 
 type Props = {

--- a/v3/src/js/views/browse/LessonTimetableControl.jsx
+++ b/v3/src/js/views/browse/LessonTimetableControl.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import _ from 'lodash';
 
 import type { SemesterData } from 'types/modules';
+
 import ButtonGroupSelector from 'views/components/ButtonGroupSelector';
 import LessonTimetable from './LessonTimetable';
 

--- a/v3/src/js/views/browse/ModuleFinderContainer.jsx
+++ b/v3/src/js/views/browse/ModuleFinderContainer.jsx
@@ -1,9 +1,11 @@
 // @flow
-import React from 'react';
+import React, { Component } from 'react';
 import DocumentTitle from 'react-document-title';
 import { withRouter } from 'react-router-dom';
 import axios from 'axios';
 import update from 'immutability-helper';
+
+import type { Module } from 'types/modules';
 
 import ModuleFinderList from 'views/browse/ModuleFinderList';
 import ChecklistFilters from 'views/components/filters/ChecklistFilters';
@@ -19,9 +21,8 @@ import {
 import config from 'config';
 import nusmods from 'apis/nusmods';
 import FilterGroup from 'utils/filters/FilterGroup';
-import type { Module } from 'types/modules';
 
-class ModuleFinderContainer extends React.Component {
+class ModuleFinderContainer extends Component {
   state: {
     loading: boolean,
     modules: Array<Module>,
@@ -61,13 +62,17 @@ class ModuleFinderContainer extends React.Component {
     return (
       <DocumentTitle title={`Modules - ${config.brandName}`}>
         <div className="modules-page-container page-container">
+          <h1 className="page-title">Module Finder</h1>
           <div className="row">
             <div className="col-md-9">
-              <h1 className="page-title">Module Finder</h1>
-              {loading ? <LoadingSpinner /> : <ModuleFinderList
-                filterGroups={Object.values(filterGroups)}
-                modules={modules}
-              />}
+              {loading ?
+                <LoadingSpinner />
+                :
+                <ModuleFinderList
+                  filterGroups={Object.values(filterGroups)}
+                  modules={modules}
+                />
+              }
             </div>
 
             <div className="col-md-3">

--- a/v3/src/js/views/browse/ModuleFinderList.jsx
+++ b/v3/src/js/views/browse/ModuleFinderList.jsx
@@ -1,8 +1,9 @@
 // @flow
-
 import React from 'react';
-import FilterGroup from 'utils/filters/FilterGroup';
+
 import type { Module } from 'types/modules';
+
+import FilterGroup from 'utils/filters/FilterGroup';
 import ModuleFinderItem from 'views/components/ModuleFinderItem';
 
 type Props = {
@@ -16,9 +17,9 @@ export default function ModuleFinderList(props: Props) {
 
   return (
     <ul className="modules-list">
-      {filteredModules.slice(0, 30).map((module) => {
-        return <ModuleFinderItem key={module.ModuleCode} module={module} />;
-      })}
+      {filteredModules.slice(0, 30).map(module =>
+        <ModuleFinderItem key={module.ModuleCode} module={module} />,
+      )}
     </ul>
   );
 }

--- a/v3/src/js/views/browse/ModulePageContainer.jsx
+++ b/v3/src/js/views/browse/ModulePageContainer.jsx
@@ -6,12 +6,13 @@ import ReactDisqusThread from 'react-disqus-thread';
 import DocumentTitle from 'react-document-title';
 import config from 'config';
 
-import { loadModule } from 'actions/moduleBank';
-import { addModule, removeModule } from 'actions/timetables';
 import type { Module, Semester } from 'types/modules';
 import type { FetchRequest } from 'types/reducers';
-import { formatExamDate } from 'utils/modules';
 import type { TimetableConfig } from 'types/timetables';
+
+import { loadModule } from 'actions/moduleBank';
+import { addModule, removeModule } from 'actions/timetables';
+import { formatExamDate } from 'utils/modules';
 import LinkModuleCodes from 'views/components/LinkModuleCodes';
 import AddModuleButton from './AddModuleButton';
 import RemoveModuleButton from './RemoveModuleButton';
@@ -114,10 +115,8 @@ export class ModulePageContainer extends Component {
     return (
       <DocumentTitle title={documentTitle}>
         <div className="module-container">
-          {this.props.fetchModuleRequest.isPending && !module ?
-            <p>Loading...</p> : null
-          }
-          {this.props.fetchModuleRequest.isFailure && <p>Module not found</p> }
+          {this.props.fetchModuleRequest.isPending && !module && <p>Loading...</p>}
+          {this.props.fetchModuleRequest.isFailure && <p>Module not found</p>}
           {(this.props.fetchModuleRequest.isSuccessful || module) &&
             <div>
               <h1 className="page-title">{module.ModuleCode} {module.ModuleTitle}</h1>
@@ -127,86 +126,69 @@ export class ModulePageContainer extends Component {
                   <dt className="col-sm-3">Description</dt>,
                   <dd className="col-sm-9">{module.ModuleDescription}</dd>,
                 ]}
-
                 {module.ModuleCredit && [
                   <dt className="col-sm-3">Module Credits (MCs)</dt>,
                   <dd className="col-sm-9">{module.ModuleCredit}</dd>,
                 ]}
-
                 {module.Prerequisite && [
                   <dt className="col-sm-3">Prerequisite(s)</dt>,
                   <dd className="col-sm-9">
                     <LinkModuleCodes>{module.Prerequisite}</LinkModuleCodes>
                   </dd>,
                 ]}
-
                 {module.Corequisite && [
                   <dt className="col-sm-3">Corequisite(s)</dt>,
                   <dd className="col-sm-9">
                     <LinkModuleCodes>{module.Corequisite}</LinkModuleCodes>
                   </dd>,
                 ]}
-
                 {module.Preclusion && [
                   <dt className="col-sm-3">Preclusion(s)</dt>,
                   <dd className="col-sm-9">
                     <LinkModuleCodes>{module.Preclusion}</LinkModuleCodes>
                   </dd>,
                 ]}
-
                 {module.Department && [
                   <dt className="col-sm-3">Department</dt>,
                   <dd className="col-sm-9">{module.Department}</dd>,
                 ]}
-
                 {module.Workload && [
                   <dt className="col-sm-3">Weekly Workload</dt>,
                   <dd className="col-sm-9">{module.Workload}</dd>,
                 ]}
-
                 {renderExaminations}
-
                 <dt className="col-sm-3">Semesters Offered</dt>
                 <dd className="col-sm-9">{semsOffered}</dd>
-
-                <dt className="col-sm-3">Offical Links</dt>
+                <dt className="col-sm-3">Official Links</dt>
                 <dd className="col-sm-9">
                   <ul className="nm-footer-links">
                     {ivleLink ? <li><a href={ivleLink}>IVLE</a></li> : null}
                     {corsLink ? <li><a href={corsLink}>CORS</a></li> : null}
                   </ul>
                 </dd>
-
                 <div>
                   {addOrRemoveToTimetableLinks}
                 </div>
-
               </dl>
-
               <hr />
-
               {module.ModmavenTree ?
                 <ModuleTree module={module} />
                 :
                 <p>Prerequisites are not available.</p>
               }
-
               {module.CorsBiddingStats &&
                 <CorsBiddingStatsTableControl stats={module.CorsBiddingStats} />
               }
-
               <LessonTimetableControl
                 semestersOffered={this.semestersOffered()}
                 history={module.History}
               />
-
               <ReactDisqusThread
                 shortname={config.disqusShortname}
                 identifier={module.ModuleCode}
                 title={`${module.ModuleCode} ${module.ModuleTitle}`}
                 url={`https://nusmods.com/modules/${module.ModuleCode}/reviews`}
               />
-
             </div>
           }
         </div>

--- a/v3/src/js/views/browse/ModulePageContainer.jsx
+++ b/v3/src/js/views/browse/ModulePageContainer.jsx
@@ -162,8 +162,8 @@ export class ModulePageContainer extends Component {
                 <dt className="col-sm-3">Official Links</dt>
                 <dd className="col-sm-9">
                   <ul className="nm-footer-links">
-                    {ivleLink ? <li><a href={ivleLink}>IVLE</a></li> : null}
-                    {corsLink ? <li><a href={corsLink}>CORS</a></li> : null}
+                    {ivleLink && <li><a href={ivleLink}>IVLE</a></li>}
+                    {corsLink && <li><a href={corsLink}>CORS</a></li>}
                   </ul>
                 </dd>
                 <div>

--- a/v3/src/js/views/browse/ModuleTree.jsx
+++ b/v3/src/js/views/browse/ModuleTree.jsx
@@ -1,9 +1,10 @@
 // @flow
-import type { Module } from 'types/modules';
 
 import React, { Component } from 'react';
-import d3 from 'd3/build/d3';
 import _ from 'lodash';
+import d3 from 'd3/build/d3';
+
+import type { Module } from 'types/modules';
 
 type Props = {
   module: Module,

--- a/v3/src/js/views/browse/module-filters.js
+++ b/v3/src/js/views/browse/module-filters.js
@@ -1,12 +1,13 @@
 // @flow
-
 import _ from 'lodash';
+
+import type { Day, Time } from 'types/modules';
+
 import LevelFilter from 'utils/filters/LevelFilter';
 import TimeslotFilter from 'utils/filters/TimeslotFilter';
 import Filter from 'utils/filters/ModuleFilter';
 import FilterGroup from 'utils/filters/FilterGroup';
 import { DaysOfWeek, TimesOfDay } from 'types/modules';
-import type { Day, Time } from 'types/modules';
 
 const timeslots: [Day, Time][] = _.flatMap(DaysOfWeek, (day): [Day, Time][] => {
   return TimesOfDay.map(time => [day, time]);

--- a/v3/src/js/views/browse/module-filters.test.js
+++ b/v3/src/js/views/browse/module-filters.test.js
@@ -1,6 +1,6 @@
 // @flow
-
 import _ from 'lodash';
+
 import FilterGroup from 'utils/filters/FilterGroup';
 import * as groups from './module-filters';
 

--- a/v3/src/js/views/components/ButtonGroupSelector.jsx
+++ b/v3/src/js/views/components/ButtonGroupSelector.jsx
@@ -1,10 +1,8 @@
 // @flow
-
 import React from 'react';
 import classnames from 'classnames';
 
 type ButtonChoice = string;
-
 type Props = {
   choices: ButtonChoice[],
   attrs?: { [ButtonChoice]: Object },

--- a/v3/src/js/views/components/FacultySelect.jsx
+++ b/v3/src/js/views/components/FacultySelect.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import type { Faculty } from 'types/modules';
+
 import facultyList from 'data/faculty-list.json';
 
 type Props = {

--- a/v3/src/js/views/components/LinkModuleCodes.jsx
+++ b/v3/src/js/views/components/LinkModuleCodes.jsx
@@ -3,7 +3,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+
 import type { ModuleCode } from 'types/modules';
+
 import { modulePagePath } from 'utils/modules';
 
 type Props = {

--- a/v3/src/js/views/components/LinkModuleCodes.test.jsx
+++ b/v3/src/js/views/components/LinkModuleCodes.test.jsx
@@ -1,9 +1,10 @@
 // @flow
-
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { mount } from 'enzyme';
+
 import type { ModuleCode } from 'types/modules';
+
 import { LinkModuleCodesComponent } from './LinkModuleCodes';
 
 describe('LinkModuleCodesComponent', () => {

--- a/v3/src/js/views/components/ModuleFinderItem.jsx
+++ b/v3/src/js/views/components/ModuleFinderItem.jsx
@@ -25,11 +25,11 @@ export default function ModuleFinderItem(props: Props) {
                 {module.ModuleCode} {module.ModuleTitle}
               </Link>
             </h2>
+            <p>
+              <a>{module.Department}</a> &middot;&nbsp;
+              <a>{module.ModuleCredit} MCs</a>
+            </p>
           </header>
-          <p>
-            <a>{module.Department}</a> &middot;&nbsp;
-            <a>{module.ModuleCredit} MCs</a>
-          </p>
           <p>{module.ModuleDescription}</p>
           <dl>
             {module.Preclusion && ([

--- a/v3/src/js/views/components/ModuleFinderItem.jsx
+++ b/v3/src/js/views/components/ModuleFinderItem.jsx
@@ -2,8 +2,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { modulePagePath } from 'utils/modules';
 import type { Module } from 'types/modules';
+
+import { modulePagePath } from 'utils/modules';
 import ModuleSemesterInfo from './module-info/ModuleSemesterInfo';
 import ModuleWorkload from './module-info/ModuleWorkload';
 
@@ -25,28 +26,28 @@ export default function ModuleFinderItem(props: Props) {
               </Link>
             </h2>
           </header>
-
-          <p>{ module.ModuleDescription }</p>
-
+          <p>
+            <a>{module.Department}</a> &middot;&nbsp;
+            <a>{module.ModuleCredit} MCs</a>
+          </p>
+          <p>{module.ModuleDescription}</p>
           <dl>
-            { module.Preclusion && ([
+            {module.Preclusion && ([
               <dt key="preclusions-dt">Preclusions</dt>,
               <dd key="preclusions-dd">{module.Preclusion}</dd>,
             ])}
 
-            { module.Prerequisite && ([
+            {module.Prerequisite && ([
               <dt key="prerequisite-dt">Prerequisite</dt>,
               <dd key="prerequisite-dd">{module.Prerequisite}</dd>,
             ])}
 
-            { module.Corequisite && ([
+            {module.Corequisite && ([
               <dt key="corequisite-dt">Corequisite</dt>,
               <dd key="corequisite-dd">{module.Corequisite}</dd>,
             ])}
           </dl>
-
         </div>
-
         <div className="col-lg-4 col-md-12 col-sm-4">
           <ModuleSemesterInfo semesters={module.History} />
           {module.Workload &&
@@ -54,13 +55,6 @@ export default function ModuleFinderItem(props: Props) {
           }
         </div>
       </div>
-
-      <footer>
-        <p>
-          <a>{ module.Department }</a> &middot;&nbsp;
-          <a>{ module.ModuleCredit } MC</a>
-        </p>
-      </footer>
     </li>
   );
 }

--- a/v3/src/js/views/components/ModulesSelect.jsx
+++ b/v3/src/js/views/components/ModulesSelect.jsx
@@ -1,11 +1,12 @@
 // @flow
-import type { ModuleSelectList } from 'types/reducers';
-
 import React, { Component } from 'react';
 import _ from 'lodash';
 import VirtualizedSelect from 'react-virtualized-select';
 import createFilterOptions from 'react-select-fast-filter-options';
 import { PrefixIndexStrategy } from 'js-search';
+
+import type { ModuleSelectList } from 'types/reducers';
+
 import { ModulesSearchIndex, ModulesTokenizer } from 'utils/modules-search';
 
 type Props = {

--- a/v3/src/js/views/components/Table.jsx
+++ b/v3/src/js/views/components/Table.jsx
@@ -36,7 +36,7 @@ export default function Table(props: Props) {
     <p>{props.noDataText}</p>
     :
     <div className="table-responsive">
-      {props.title ? <h3 className="table-title">{props.title}</h3> : null }
+      {props.title && <h3 className="table-title">{props.title}</h3>}
       <table className="table table-sm">
         {tableHeader}
         {tableBody}

--- a/v3/src/js/views/components/color-picker/ColorPicker.jsx
+++ b/v3/src/js/views/components/color-picker/ColorPicker.jsx
@@ -1,13 +1,15 @@
 // @flow
 import React, { Component } from 'react';
+import _ from 'lodash';
+
 import type { ColorIndex } from 'types/reducers';
 
-import _ from 'lodash';
 import { NUM_DIFFERENT_COLORS } from 'reducers/theme';
 
 import './color-picker.scss';
 
 const ESCAPE_KEYCODE = 27;
+const EVENT_TYPE = 'keydown';
 
 type Props = {
   onChooseColor: Function,
@@ -18,11 +20,11 @@ class ColorPicker extends Component {
   props: Props;
 
   componentWillMount() {
-    window.addEventListener('keydown', this.handleKeyDown);
+    window.addEventListener(EVENT_TYPE, this.handleKeyDown);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('keydown', this.handleKeyDown);
+    window.removeEventListener(EVENT_TYPE, this.handleKeyDown);
   }
 
   handleKeyDown = (event: KeyboardEvent) => {

--- a/v3/src/js/views/components/filters/ChecklistFilters.jsx
+++ b/v3/src/js/views/components/filters/ChecklistFilters.jsx
@@ -1,8 +1,10 @@
 // @flow
 import React from 'react';
 import { values } from 'lodash';
+
 import type { Module } from 'types/modules';
 import type { OnFilterChange } from 'types/views';
+
 import FilterGroup from 'utils/filters/FilterGroup';
 import ModuleFilter from 'utils/filters/ModuleFilter';
 
@@ -17,7 +19,7 @@ export default function ChecklistFilters(props: Props) {
 
   return (
     <div>
-      <h4>{ group.label }</h4>
+      <h4>{group.label}</h4>
       <ul className="list-unstyled">
         {values(group.filters).map((filter: ModuleFilter) => (
           <li key={filter.label}>

--- a/v3/src/js/views/components/module-info/ModuleSemesterInfo.jsx
+++ b/v3/src/js/views/components/module-info/ModuleSemesterInfo.jsx
@@ -1,19 +1,20 @@
 // @flow
-
 import React from 'react';
-import type { Node } from 'react';
 import _ from 'lodash';
-import config from 'config';
+
+import type { Node } from 'react';
 import type { SemesterData } from 'types/modules';
+
+import config from 'config';
 import { getFirstAvailableSemester, formatExamDate } from 'utils/modules';
 import ButtonGroupSelector from 'views/components/ButtonGroupSelector';
 import TimeslotTable from './TimeslotTable';
 
-const semesterNames = config.shortSemesterNames;
-
 type Props = {
   semesters: SemesterData[],
 };
+
+const semesterNames = config.shortSemesterNames;
 
 export default class ModuleSemesterInfo extends React.Component {
   props: Props;

--- a/v3/src/js/views/components/module-info/ModuleWorkload.jsx
+++ b/v3/src/js/views/components/module-info/ModuleWorkload.jsx
@@ -1,10 +1,11 @@
 // @flow
-
 import React from 'react';
 import classnames from 'classnames';
 import _ from 'lodash';
-import { parseWorkload } from 'utils/modules';
+
 import type { WorkloadComponent } from 'types/modules';
+
+import { parseWorkload } from 'utils/modules';
 
 const ROW_MAX = 10;
 

--- a/v3/src/js/views/components/module-info/TimeslotTable.jsx
+++ b/v3/src/js/views/components/module-info/TimeslotTable.jsx
@@ -1,10 +1,11 @@
 // @flow
-
 import React from 'react';
-import type { Node } from 'react';
 import { clone } from 'lodash';
-import { DaysOfWeek, TimesOfDay } from 'types/modules';
+
+import type { Node } from 'react';
 import type { Time } from 'types/modules';
+
+import { DaysOfWeek, TimesOfDay } from 'types/modules';
 import { getTimeslot } from 'utils/modules';
 
 type Props = {

--- a/v3/src/js/views/components/module-info/TimeslotTable.test.jsx
+++ b/v3/src/js/views/components/module-info/TimeslotTable.test.jsx
@@ -1,12 +1,12 @@
 // @flow
-
 import React from 'react';
-import type { Node } from 'react';
 import { shallow } from 'enzyme';
 import { cartesianProduct } from 'js-combinatorics';
 
-import { DaysOfWeek, TimesOfDay } from 'types/modules';
+import type { Node } from 'react';
 import type { Day, Time } from 'types/modules';
+
+import { DaysOfWeek, TimesOfDay } from 'types/modules';
 import { getTimeslot } from 'utils/modules';
 import TimeslotTable from './TimeslotTable';
 

--- a/v3/src/js/views/layout/Footer.test.jsx
+++ b/v3/src/js/views/layout/Footer.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+
 import Footer from 'views/layout/Footer';
 
 test('is a footer element', () => {

--- a/v3/src/js/views/settings/SettingsContainer.jsx
+++ b/v3/src/js/views/settings/SettingsContainer.jsx
@@ -1,17 +1,16 @@
 // @flow
-import type { Faculty } from 'types/modules';
-
 import React from 'react';
 import { connect } from 'react-redux';
 import DocumentTitle from 'react-document-title';
-import config from 'config';
 
+import type { Faculty } from 'types/modules';
+
+import config from 'config';
 import { selectTheme } from 'actions/theme';
 import { selectNewStudent, selectFaculty } from 'actions/settings';
 import availableThemes from 'data/themes.json';
 import FacultySelect from 'views/components/FacultySelect';
 import NewStudentSelect from 'views/components/NewStudentSelect';
-
 import ThemeOption from './ThemeOption';
 
 type Props = {

--- a/v3/src/js/views/settings/ThemeOption.jsx
+++ b/v3/src/js/views/settings/ThemeOption.jsx
@@ -1,9 +1,9 @@
 // @flow
-import type { Theme } from 'types/views';
-
 import React from 'react';
 import _ from 'lodash';
 import classnames from 'classnames';
+
+import type { Theme } from 'types/views';
 
 import { NUM_DIFFERENT_COLORS } from 'reducers/theme';
 

--- a/v3/src/js/views/static/AboutContainer.jsx
+++ b/v3/src/js/views/static/AboutContainer.jsx
@@ -7,7 +7,6 @@ export default function AboutContainer() {
       <div className="row">
         <div className="col-md-8 offset-md-1">
           <h3>A Brief History</h3>
-
           <p>
             NUSModifications (NUSMods) was founded in 2012 by <a href="http://benghee.eu/">Beng</a> to
             provide a better way for students to plan their school timetables.
@@ -18,7 +17,6 @@ export default function AboutContainer() {
           </p>
 
           <h3>Goals</h3>
-
           <p>
             In the long term, NUSMods strives to enhance the quality of students&apos;
             lives in school by serving as a one-stop platform that provides useful
@@ -34,7 +32,6 @@ export default function AboutContainer() {
           </p>
 
           <h3>Connect with Us!</h3>
-
           <p>
             We would love to hear your feedback and suggestions on how to make NUSMods even better.
             Please let us know them by leaving a comment

--- a/v3/src/js/views/static/DevelopersContainer.jsx
+++ b/v3/src/js/views/static/DevelopersContainer.jsx
@@ -55,9 +55,7 @@ class DevelopersContainer extends Component {
             </em></p>
             <br /><br />
 
-            {this.state.isLoading &&
-              Loader
-            }
+            {this.state.isLoading && <Loader />}
             {this.state.isError &&
               <div className="alert alert-danger">
                 <strong>Something went wrong!</strong>

--- a/v3/src/js/views/timetable/Timetable.jsx
+++ b/v3/src/js/views/timetable/Timetable.jsx
@@ -1,10 +1,10 @@
 // @flow
-import type { Lesson } from 'types/modules';
-import type { TimetableArrangement } from 'types/timetables';
-
 import React, { Component } from 'react';
 import _ from 'lodash';
 import classnames from 'classnames';
+
+import type { Lesson } from 'types/modules';
+import type { TimetableArrangement } from 'types/timetables';
 
 import {
   SCHOOLDAYS,

--- a/v3/src/js/views/timetable/TimetableCell.jsx
+++ b/v3/src/js/views/timetable/TimetableCell.jsx
@@ -1,8 +1,9 @@
 // @flow
-import type { ModifiableLesson } from 'types/modules';
-
 import React from 'react';
 import classnames from 'classnames';
+
+import type { ModifiableLesson } from 'types/modules';
+
 import { LESSON_TYPE_ABBREV } from 'utils/timetables';
 
 type Props = {

--- a/v3/src/js/views/timetable/TimetableContainer.jsx
+++ b/v3/src/js/views/timetable/TimetableContainer.jsx
@@ -1,4 +1,10 @@
 // @flow
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import DocumentTitle from 'react-document-title';
+import _ from 'lodash';
+import config from 'config';
+
 import type {
   ThemeState,
   TimetableOrientation,
@@ -17,11 +23,6 @@ import type {
 } from 'types/modules';
 import type { SemTimetableConfig, TimetableArrangement } from 'types/timetables';
 
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import DocumentTitle from 'react-document-title';
-import _ from 'lodash';
-import config from 'config';
 import classnames from 'classnames';
 import { getSemModuleSelectList } from 'reducers/entities/moduleBank';
 import { downloadAsJpeg, downloadAsIcal } from 'actions/export';

--- a/v3/src/js/views/timetable/TimetableDay.jsx
+++ b/v3/src/js/views/timetable/TimetableDay.jsx
@@ -1,7 +1,7 @@
 // @flow
-import type { TimetableDayArrangement } from 'types/timetables';
-
 import React from 'react';
+
+import type { TimetableDayArrangement } from 'types/timetables';
 
 import TimetableRow from './TimetableRow';
 

--- a/v3/src/js/views/timetable/TimetableModulesTable.jsx
+++ b/v3/src/js/views/timetable/TimetableModulesTable.jsx
@@ -1,13 +1,14 @@
 // @flow
-import type { ModuleWithColor, ModuleCode, Semester } from 'types/modules';
-import type { ColorIndex } from 'types/reducers';
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import classnames from 'classnames';
-import ColorPicker from 'views/components/color-picker/ColorPicker';
 
+import type { ModuleWithColor, ModuleCode, Semester } from 'types/modules';
+import type { ColorIndex } from 'types/reducers';
+
+import ColorPicker from 'views/components/color-picker/ColorPicker';
 import { selectModuleColor, modifyModuleColor, cancelModifyModuleColor } from 'actions/theme';
 import { hideLessonInTimetable, showLessonInTimetable } from 'actions/settings';
 import { getModuleSemExamDate, modulePagePath } from 'utils/modules';

--- a/v3/src/js/views/timetable/TimetableRow.jsx
+++ b/v3/src/js/views/timetable/TimetableRow.jsx
@@ -1,8 +1,8 @@
 // @flow
-import type { Lesson, LessonTime, ModifiableLesson } from 'types/modules';
-
 import React from 'react';
 import _ from 'lodash';
+
+import type { Lesson, LessonTime, ModifiableLesson } from 'types/modules';
 
 import { convertIndexToTime, convertTimeToIndex } from 'utils/timify';
 import TimetableCell from './TimetableCell';

--- a/v3/src/styles/components/loading-spinner.scss
+++ b/v3/src/styles/components/loading-spinner.scss
@@ -2,12 +2,12 @@
   color: theme-color();
   text-align: center;
 
-  i.fa {
+  .fa {
     margin-bottom: 0.5rem;
   }
 
   .loading-text {
-    font-weight: bold;
     font-size: 1.4rem;
+    font-weight: bold;
   }
 }

--- a/v3/src/styles/constants.scss
+++ b/v3/src/styles/constants.scss
@@ -16,7 +16,7 @@ $material-sharp-curve: cubic-bezier(0.4, 0, 0.6, 1);
 $page-entering-duration: $fullscreen-duration;
 $page-entering-animation: fadeIn;
 
-//
+// Workload colors map
 $workload-colors: (
   lecture: #bbdefb,
   tutorial: #dcedc8,

--- a/v3/src/styles/layout/site.scss
+++ b/v3/src/styles/layout/site.scss
@@ -8,6 +8,12 @@ body {
   }
 }
 
+a {
+  &:hover {
+    text-decoration: none;
+  }
+}
+
 .main-content {
   @include media-breakpoint-down(sm) {
     padding-top: 1rem;

--- a/v3/src/styles/pages/module-finder.scss
+++ b/v3/src/styles/pages/module-finder.scss
@@ -27,14 +27,13 @@
 
     footer {
       border-top: 1px solid $gray-lighter;
-      padding-top: 0.8rem;
       margin-top: 0.8rem;
+      padding-top: 0.8rem;
     }
   }
 
   .modules-title {
     font-size: 1.25rem;
-    font-weight: normal;
   }
 }
 
@@ -58,8 +57,8 @@
 
   h4 {
     font-size: $font-size-sm;
-    margin-bottom: 0;
     font-weight: bold;
+    margin-bottom: 0;
   }
 }
 
@@ -69,8 +68,8 @@
 
   h4 {
     font-size: $font-size-sm;
-    margin-bottom: 0;
     font-weight: bold;
+    margin-bottom: 0;
   }
 }
 
@@ -83,8 +82,8 @@
   }
 
   .module-workload-label {
-    font-weight: bold;
     font-size: $font-size-xs;
+    font-weight: bold;
   }
 
   .module-workload-blocks {
@@ -142,8 +141,8 @@
       // with a skew to show that it is on the same day (if the edge is straight
       // it may look like the edge of a cell)
       &.workload-lecture-bg + .workload-tutorial-bg {
-        z-index: 1;
         transform: skewX(-45deg) translateX(50%);
+        z-index: 1;
       }
     }
   }


### PR DESCRIPTION
Just some minor style fixes as I was reviewing the latest code. It's not documented anywhere and it's not exactly important, but let's try to follow this format for imports:

1. NPM imports
2. Our own `type` imports
3. Our own non-`type` imports
  3.1 Absolute imports
  3.2 Relative imports

For CSS, sort property names alphabetically. There are a few schools of thoughts regarding sorting order but sorting it alphabetically makes it easier for binary scanning a list of properties. In the event of overrides occurring because of alphabetical order, this rule can be ignored (or perhaps don't use the shorthand).