### PR TITLE
Page layout realignment 

### DIFF
--- a/v3/src/js/views/AppShell.jsx
+++ b/v3/src/js/views/AppShell.jsx
@@ -27,28 +27,24 @@ type Props = {
 // Put outside render because this only needs to computed on page load.
 const weekText = (() => {
   const acadWeekInfo = NUSModerator.academicCalendar.getAcadWeekInfo(new Date());
-  const year = `AY20${acadWeekInfo.year}`;
-  let semester = '';
-  let semesterType = '';
-  let week = '';
+  const parts = [`AY20${acadWeekInfo.year}`];
 
   // Check for null value (ie. during vacation)
   if (acadWeekInfo.sem) {
-    semester = `, ${acadWeekInfo.sem}`;
+    parts.push(acadWeekInfo.sem);
   }
 
   // Hide semester if semester type is 'Instructional'
   if (acadWeekInfo.type !== 'Instructional') {
-    semesterType = `, ${acadWeekInfo.type} Week`;
+    parts.push(`${acadWeekInfo.type} Week`);
   }
 
   // Do not show the week number if there is only one week, eg. recess
   if (acadWeekInfo.num > 0) {
-    week = `, Week ${acadWeekInfo.num}`;
+    parts.push(`Week ${acadWeekInfo.num}`);
   }
 
-  const acadWeekString = `${year}${semester}${semesterType}${week}`;
-  return acadWeekString;
+  return parts.join(', ');
 })();
 
 export class AppShell extends Component {

--- a/v3/src/js/views/AppShell.jsx
+++ b/v3/src/js/views/AppShell.jsx
@@ -61,12 +61,16 @@ export class AppShell extends Component {
     }
   }
 
-  /* eslint-disable jsx-a11y/anchor-has-content */
   render() {
+    const isModuleListLoading = this.props.fetchModuleListRequest.isPending && !this.props.moduleList.length;
+    const isModuleListReady = this.props.fetchModuleListRequest.isSuccessful || this.props.moduleList.length;
+
     return (
       <div className="app-container">
         <nav className="nm-navbar fixed-top">
-          <NavLink className="nm-navbar-brand" to="/" title="Home" />
+          <NavLink className="nm-navbar-brand" to="/" title="Home">
+            <span className="sr-only">NUSMods</span>
+          </NavLink>
           <form className="nm-navbar-form">
             <ModulesSelect
               moduleList={this.props.moduleSelectList}
@@ -96,12 +100,9 @@ export class AppShell extends Component {
           </nav>
 
           <main className="main-content">
-            {this.props.fetchModuleListRequest.isPending && !this.props.moduleList.length ?
-              <p>Loading...</p> : null
-            }
-            {this.props.fetchModuleListRequest.isSuccessful || this.props.moduleList.length ?
-              this.props.children : null
-            }
+            {isModuleListLoading && <p>Loading...</p>}
+
+            {isModuleListReady && this.props.children}
             <Routes />
           </main>
         </div>

--- a/v3/src/js/views/AppShell.jsx
+++ b/v3/src/js/views/AppShell.jsx
@@ -82,41 +82,34 @@ export class AppShell extends Component {
           </form>
           <span className="nm-navbar-text"><small>{weekText}</small></span>
         </nav>
-        <div className="container-fluid">
-          <div className="row">
-            <div className="col-md-2">
-              <ul className="nm-nav-tabs">
-                <li role="presentation" className="nm-nav-item">
-                  <NavLink className="nav-link" activeClassName="active" to="/timetable">
-                    <i className="fa fa-fw fa-lg fa-table" />
-                    <span className="nm-link-title"> Timetable</span>
-                  </NavLink>
-                </li>
-                <li role="presentation" className="nm-nav-item">
-                  <NavLink className="nav-link" activeClassName="active" to="/modules">
-                    <i className="fa fa-fw fa-lg fa-list" />
-                    <span className="nm-link-title"> Browse</span>
-                  </NavLink>
-                </li>
-                <li role="presentation" className="nm-nav-item">
-                  <NavLink className="nav-link" activeClassName="active" to="/settings">
-                    <i className="fa fa-fw fa-lg fa-gear" />
-                    <span className="nm-link-title"> Settings</span>
-                  </NavLink>
-                </li>
-              </ul>
-            </div>
-            <div className="col-md-10 main-content">
-              {this.props.fetchModuleListRequest.isPending && !this.props.moduleList.length ?
-                <p>Loading...</p> : null
-              }
-              {this.props.fetchModuleListRequest.isSuccessful || this.props.moduleList.length ?
-                this.props.children : null
-              }
-              <Routes />
-            </div>
-          </div>
+
+        <div className="main-container">
+          <nav className="nm-nav-tabs">
+            <NavLink className="nav-link" activeClassName="active" to="/timetable">
+              <i className="fa fa-fw fa-lg fa-table" />
+              <span className="nm-link-title">Timetable</span>
+            </NavLink>
+            <NavLink className="nav-link" activeClassName="active" to="/modules">
+              <i className="fa fa-fw fa-lg fa-list" />
+              <span className="nm-link-title">Browse</span>
+            </NavLink>
+            <NavLink className="nav-link" activeClassName="active" to="/settings">
+              <i className="fa fa-fw fa-lg fa-gear" />
+              <span className="nm-link-title">Settings</span>
+            </NavLink>
+          </nav>
+
+          <main className="main-content">
+            {this.props.fetchModuleListRequest.isPending && !this.props.moduleList.length ?
+              <p>Loading...</p> : null
+            }
+            {this.props.fetchModuleListRequest.isSuccessful || this.props.moduleList.length ?
+              this.props.children : null
+            }
+            <Routes />
+          </main>
         </div>
+
         <Footer />
       </div>
     );

--- a/v3/src/js/views/browse/ModulePageContainer.jsx
+++ b/v3/src/js/views/browse/ModulePageContainer.jsx
@@ -114,7 +114,7 @@ export class ModulePageContainer extends Component {
 
     return (
       <DocumentTitle title={documentTitle}>
-        <div className="module-container">
+        <div className="module-container page-container">
           {this.props.fetchModuleRequest.isPending && !module && <p>Loading...</p>}
           {this.props.fetchModuleRequest.isFailure && <p>Module not found</p>}
           {(this.props.fetchModuleRequest.isSuccessful || module) &&

--- a/v3/src/styles/layout/nav.scss
+++ b/v3/src/styles/layout/nav.scss
@@ -62,7 +62,6 @@
   .nav-link {
     color: $gray-light;
     display: block;
-    padding: 0.7rem;
 
     &.active {
       color: theme-color(primary);
@@ -113,6 +112,10 @@
   }
 
   @include media-breakpoint-up(lg) {
+    .nav-link {
+      padding: 0.7rem 0 0.7rem 2rem;
+    }
+
     .nm-link-title {
       margin-left: 0.3rem;
     }

--- a/v3/src/styles/layout/nav.scss
+++ b/v3/src/styles/layout/nav.scss
@@ -41,9 +41,10 @@
   .nm-navbar-text {
     flex: 1 1 auto;
     text-align: right;
+    line-height: 1.15;
   }
 
-  @include media-breakpoint-down('xs') {
+  @include media-breakpoint-down(xs) {
     .nm-navbar-text,
     .nm-navbar-form {
       display: none;
@@ -54,7 +55,9 @@
 .nm-nav-tabs {
   display: flex;
   flex-direction: column;
-  padding: 0;
+  padding: 2rem 0 0;
+  position: fixed;
+  top: $navbar-height;
 
   .nav-link {
     color: $gray-light;
@@ -62,12 +65,12 @@
     padding: 0.7rem;
 
     &.active {
-      color: theme-color('primary');
+      color: theme-color(primary);
     }
-  }
 
-  .nm-nav-item {
-    list-style: none;
+    &:hover .nm-link-title {
+      text-decoration: underline;
+    }
   }
 
   @include media-breakpoint-down(sm) {
@@ -76,23 +79,42 @@
     flex-direction: row;
     height: $navbar-height;
     left: 0;
-    position: fixed;
-    top: $navbar-height;
+    padding: 0;
     width: 100%;
     z-index: 1;
 
-    .nm-nav-item {
-      flex-grow: 1;
-    }
-
     .nav-link {
       display: block;
+      flex: 1 auto;
       padding: 1rem 0;
       text-align: center;
     }
 
     .nm-link-title {
       display: none;
+    }
+  }
+
+  @include media-breakpoint-only(md) {
+    .nav-link {
+      text-align: center;
+      font-size: 0.7rem;
+      padding: 1rem 0;
+
+      .fa {
+        font-size: 1.6rem;
+        margin-bottom: 0.2rem;
+      }
+
+      .nm-link-title {
+        display: block;
+      }
+    }
+  }
+
+  @include media-breakpoint-up(lg) {
+    .nm-link-title {
+      margin-left: 0.3rem;
     }
   }
 }

--- a/v3/src/styles/layout/nav.scss
+++ b/v3/src/styles/layout/nav.scss
@@ -40,8 +40,9 @@
 
   .nm-navbar-text {
     flex: 1 1 auto;
-    text-align: right;
     line-height: 1.15;
+    padding-left: $grid-gutter-width / 2;
+    text-align: right;
   }
 
   @include media-breakpoint-down(xs) {
@@ -53,6 +54,7 @@
 }
 
 .nm-nav-tabs {
+  // See site.scss for width on md and lg sizes
   display: flex;
   flex-direction: column;
   padding: 2rem 0 0;
@@ -72,9 +74,11 @@
     }
   }
 
+  // For breakpoint-sm and below (phones), show the links as icon tabs fixed
+  // below the top navbar
   @include media-breakpoint-down(sm) {
     background-color: #fff;
-    box-shadow: 0 0 15px -3px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 0 15px -3px rgba(#000, 0.4);
     flex-direction: row;
     height: $navbar-height;
     left: 0;
@@ -83,7 +87,6 @@
     z-index: 1;
 
     .nav-link {
-      display: block;
       flex: 1 auto;
       padding: 1rem 0;
       text-align: center;
@@ -94,11 +97,13 @@
     }
   }
 
+  // For breakpoint-md (tablets), show the links as compact buttons with labels
+  // below icons.
   @include media-breakpoint-only(md) {
     .nav-link {
-      text-align: center;
       font-size: 0.7rem;
       padding: 1rem 0;
+      text-align: center;
 
       .fa {
         font-size: 1.6rem;
@@ -111,6 +116,8 @@
     }
   }
 
+  // For breakpoint-lg (desktop), show the links as traditional link with icon
+  // to the left
   @include media-breakpoint-up(lg) {
     .nav-link {
       padding: 0.7rem 0 0.7rem 2rem;

--- a/v3/src/styles/layout/site.scss
+++ b/v3/src/styles/layout/site.scss
@@ -71,14 +71,20 @@ a {
 }
 
 // Recreate Bootstrap v3 offsets
-@include media-breakpoint-up('md') {
+@include media-breakpoint-up(sm) {
+  .offset-sm-1 {
+    margin-left: percentage(1 / $grid-columns);
+  }
+}
+
+@include media-breakpoint-up(md) {
   .offset-md-1 {
     margin-left: percentage(1 / $grid-columns);
   }
 }
 
-@include media-breakpoint-up('sm') {
-  .offset-sm-1 {
+@include media-breakpoint-up(lg) {
+  .offset-lg-1 {
     margin-left: percentage(1 / $grid-columns);
   }
 }

--- a/v3/src/styles/layout/site.scss
+++ b/v3/src/styles/layout/site.scss
@@ -1,4 +1,11 @@
 // This file contains the styles for the overall site
+html,
+body,
+#app,
+.app-container {
+  height: 100%;
+}
+
 body {
   padding-top: 4rem;
 
@@ -14,14 +21,48 @@ a {
   }
 }
 
-.main-content {
+.app-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.main-container {
+  $side-nav-width-md: 4rem;
+  $side-nav-width-lg: 10rem;
+
+  flex: 1 auto;
+
   @include media-breakpoint-down(sm) {
-    padding-top: 1rem;
+    .main-content {
+      padding-top: 1rem;
+    }
+  }
+
+  @include media-breakpoint-up(md) {
+    > nav {
+      width: calc(#{$side-nav-width-md} + #{($grid-gutter-width / 2)});
+    }
+
+    .main-content {
+      padding-left: $side-nav-width-md;
+    }
+  }
+
+  @include media-breakpoint-up(lg) {
+    > nav {
+      width: $side-nav-width-lg;
+    }
+
+    .main-content {
+      padding-left: $side-nav-width-lg;
+    }
   }
 }
 
 .page-container {
   animation-duration: $page-entering-duration;
+
+  @extend .container-fluid;
 }
 
 .page-title {

--- a/v3/src/styles/layout/site.scss
+++ b/v3/src/styles/layout/site.scss
@@ -3,6 +3,9 @@ html,
 body,
 #app,
 .app-container {
+  // Ensures the page always fill the height of the page. Combined with the
+  // flexbox on .app-container, this allows the footer to be aligned to the
+  // page bottom when there's insufficient page content
   height: 100%;
 }
 

--- a/v3/src/styles/main.scss
+++ b/v3/src/styles/main.scss
@@ -9,7 +9,6 @@
 @import 'constants';
 
 // Utils
-@import 'utils/hacks';
 @import 'utils/mixins';
 @import 'utils/animations';
 @import 'utils/workload';

--- a/v3/src/styles/pages/timetable.scss
+++ b/v3/src/styles/pages/timetable.scss
@@ -69,7 +69,10 @@ $timetable-day-rows-height: calc(100% - #{$timetable-day-cell-height});
 
   .timetable-container {
     &.horizontal-mode {
+      // On Chrome this provides space for the horizontal scrollbar's height,
+      // otherwise there will be a ugly vertical scrollbar
       overflow-y: hidden;
+      padding-bottom: 5px;
 
       .timetable-inner-container {
         min-width: $timetable-min-width;
@@ -128,7 +131,6 @@ $timetable-day-rows-height: calc(100% - #{$timetable-day-cell-height});
       .timetable-content-container {
         float: left;
         height: 100%;
-        overflow-x: scroll;
         width: 100% - $timetable-time-width;
 
         .timetable-day {

--- a/v3/src/styles/pages/timetable.scss
+++ b/v3/src/styles/pages/timetable.scss
@@ -27,7 +27,6 @@ $timetable-day-rows-height: calc(100% - #{$timetable-day-cell-height});
 
   .timetable-wrapper {
     -webkit-overflow-scrolling: touch;
-    overflow-x: scroll;
   }
 
   .timetable-bg {

--- a/v3/src/styles/utils/hacks.scss
+++ b/v3/src/styles/utils/hacks.scss
@@ -1,3 +1,0 @@
-::-webkit-scrollbar {
-  display: none;
-}


### PR DESCRIPTION
### Context 

Currently v3 uses Bootstrap grid for all layout. Unfortunately Bootstrap is not sufficiently flexible for all layout needs - for instance, it doesn't support mixed fixed and flexible width columns, resulting in awkward sizes for fixed width content like the navigation sidebar:

At the lower end of breakpoint-md, the column is too narrow, causing ugly line breaks to appear 

![screenshot from 2017-08-27 11-42-49](https://user-images.githubusercontent.com/445650/29746954-6d81a5de-8b1d-11e7-94be-c5cb8862c4a4.png)

At large screen widths, the column becomes uncomfortably large (screenshot with 1920px wide screen)

![screenshot from 2017-08-27 11-45-54](https://user-images.githubusercontent.com/445650/29746962-a130d56c-8b1d-11e7-8881-affbb2b6bd2b.png)

### Approach 

This PR swaps BS4 grids for the side nav with a fixed width solution using a mix of flexbox and `calc()`.

**breakpoint-lg** 

![screenshot from 2017-08-27 11-49-40](https://user-images.githubusercontent.com/445650/29746983-28f25214-8b1e-11e7-85c1-7499d63345b9.png)

![screenshot from 2017-08-27 11-50-01](https://user-images.githubusercontent.com/445650/29746984-290c8134-8b1e-11e7-8ea3-be20d471af82.png)

**breakpoint-md**

![screenshot from 2017-08-27 11-50-14](https://user-images.githubusercontent.com/445650/29746982-28e118f0-8b1e-11e7-9aa6-3ea5ef441a19.png)

![screenshot from 2017-08-27 11-50-35](https://user-images.githubusercontent.com/445650/29746981-28d4020a-8b1e-11e7-8e38-32b28de09859.png)

The main benefit of this in addition to the aforementioned improvement in layout is that it reduces the level of nesting and amount of boilerplate markup. The downside is that the CSS is slightly more complicated.

We also use `position: fixed` for the sidebar so that it scrolls with content. 

