### PR TITLE
Fix various bugs on timetable

### DIFF
--- a/v3/src/js/views/timetable/TimetableCell.jsx
+++ b/v3/src/js/views/timetable/TimetableCell.jsx
@@ -11,7 +11,7 @@ import styles from './TimetableCell.scss';
 type Props = {
   lesson: Lesson,
   style: Object,
-  onModifyCell: Function,
+  onModifyCell?: Function,
 };
 
 function TimetableCell(props: Props) {

--- a/v3/src/js/views/timetable/TimetableRow.jsx
+++ b/v3/src/js/views/timetable/TimetableRow.jsx
@@ -50,10 +50,11 @@ function TimetableRow(props: Props) {
         };
         return (
           <TimetableCell
-            key={lesson.ModuleCode + lesson.ClassNo}
+            key={lesson.StartTime}
             style={style}
             lesson={lesson}
-            onModifyCell={onModifyCell}
+            // $FlowFixMe When object spread type actually works
+            {...lesson.isModifiable && { onModifyCell }}
           />
         );
       })}


### PR DESCRIPTION
Actually just one lol. Since we sort and arrange by start time, we would never had 2 same lessons with same start time on the same row.

Now we only pass `onModifyCell` if it's actually modifiable.