### PR TITLE
Add prereq tree visualization

### DIFF
--- a/v3/package.json
+++ b/v3/package.json
@@ -98,7 +98,6 @@
     "bootstrap": "4.0.0-beta.2",
     "classnames": "^2.2.5",
     "core-js": "^2.5.1",
-    "d3": "^4.10.0",
     "dom-to-image": "^2.5.2",
     "downshift": "^1.22.3",
     "ical-generator": "^0.2.9",

--- a/v3/src/js/types/modules.js
+++ b/v3/src/js/types/modules.js
@@ -71,6 +71,13 @@ export type SemesterData = {
   TutorialPeriods?: Array<string>,
 };
 
+// Recursive definition for walking a module tree
+export type TreeFragment = {
+  name: string,
+  // TreeFragment[] will result in infinite loop
+  children: Array<TreeFragment>,
+};
+
 // Information for a module for a particular academic year.
 // This is probably the only model you need to be concerned with.
 // For some reason es6 object literal property value shorthand is not recognized >_<
@@ -88,6 +95,8 @@ export type Module = {
   Prerequisite?: string,
   Types: Array<string>,
   Workload?: string,
+  ModmavenTree: TreeFragment,
+  LockedModules?: Array<ModuleCode>,
 };
 
 export type ModuleWithColor = Module & {

--- a/v3/src/js/utils/filters/ModuleFilter.test.js
+++ b/v3/src/js/utils/filters/ModuleFilter.test.js
@@ -15,6 +15,7 @@ export function createModule(code: ModuleCode): Module {
     ModuleCredit: '4',
     AcadYear: '16/17',
     CorsBiddingStats: [],
+    ModmavenTree: { name: 'Test Module', children: [] },
   };
 }
 

--- a/v3/src/js/views/components/LinkModuleCodes.jsx
+++ b/v3/src/js/views/components/LinkModuleCodes.jsx
@@ -24,13 +24,13 @@ type Props = {
 const MODULE_CODE_REGEX = /\b(\w{2,3}\s*\d{4}\w{0,2})\b/g;
 
 export function LinkModuleCodesComponent(props: Props) {
-  const { children, moduleCodes } = props;
+  const { children, moduleCodes, ...otherProps } = props;
 
   return (<span>{replaceWithNode(children, MODULE_CODE_REGEX, (part, i) => {
     const code = part.replace(/\s*/g, '');
     const module = moduleCodes[code];
     if (!module) return part;
-    return <Link to={modulePage(code, module.ModuleTitle)} key={i}>{part}</Link>;
+    return <Link {...otherProps} to={modulePage(code, module.ModuleTitle)} key={i}>{part}</Link>;
   })}</span>);
 }
 

--- a/v3/src/js/views/components/LinkModuleCodes.jsx
+++ b/v3/src/js/views/components/LinkModuleCodes.jsx
@@ -26,12 +26,12 @@ const MODULE_CODE_REGEX = /\b(\w{2,3}\s*\d{4}\w{0,2})\b/g;
 export function LinkModuleCodesComponent(props: Props) {
   const { children, moduleCodes, ...otherProps } = props;
 
-  return (<span>{replaceWithNode(children, MODULE_CODE_REGEX, (part, i) => {
+  return replaceWithNode(children, MODULE_CODE_REGEX, (part, i) => {
     const code = part.replace(/\s*/g, '');
     const module = moduleCodes[code];
     if (!module) return part;
     return <Link {...otherProps} to={modulePage(code, module.ModuleTitle)} key={i}>{part}</Link>;
-  })}</span>);
+  });
 }
 
 // Type annotation is workaround for https://github.com/flowtype/flow-typed/issues/1269

--- a/v3/src/js/views/components/LinkModuleCodes.test.jsx
+++ b/v3/src/js/views/components/LinkModuleCodes.test.jsx
@@ -70,7 +70,7 @@ describe('LinkModuleCodesComponent', () => {
     const noModules = create(noModulesText, testModules);
     expect(noModules.text()).toEqual(noModulesText);
 
-    const mixedModulesText = 'ACC1002This text has CS 1010S random module coPS1101Edes in it';
+    const mixedModulesText = 'ACC1002This text has CS-1010S random module coPS1101Edes in it';
     const mixedModules = create(mixedModulesText, testModules);
     expect(mixedModules.text()).toEqual(mixedModulesText);
   });

--- a/v3/src/js/views/modules/ModulePageContent.jsx
+++ b/v3/src/js/views/modules/ModulePageContent.jsx
@@ -13,6 +13,7 @@ import { formatExamDate, getSemestersOffered } from 'utils/modules';
 import { intersperse } from 'utils/array';
 import { BULLET } from 'utils/react';
 import { NAVTAB_HEIGHT } from 'views/layout/Navtabs';
+import ModuleTree from 'views/modules/ModuleTree';
 import LinkModuleCodes from 'views/components/LinkModuleCodes';
 import DisqusComments from 'views/components/DisqusComments';
 import Online from 'views/components/Online';
@@ -36,8 +37,7 @@ type State = {
 
 export const SIDE_MENU_LABELS = {
   details: 'Details',
-  // TODO: Remove this when the prerequisite tree is ready
-  // prerequisites: 'Prerequisites',
+  prerequisites: 'Prerequisites',
   timetable: 'Timetable',
   cors: 'Bidding Stats',
   reviews: 'Reviews',
@@ -163,11 +163,11 @@ export class ModulePageContentComponent extends Component<Props, State> {
                 </div>
               </div>
             </section>
-            {/* TODO: Add in prereq tree when it is ready
-            <section className={styles.section} id={SIDE_MENU_ITEMS.prerequisites}>
-              <h2 className={styles.sectionHeading}>Prerequisite Tree</h2>
+
+            <section id="prerequisites">
+              <h2>Prerequisite Tree</h2>
+              <ModuleTree module={module} />
             </section>
-            */}
 
             <section className={styles.section} id="timetable">
               <h2 className={styles.sectionHeading}>Timetable</h2>

--- a/v3/src/js/views/modules/ModulePageContent.jsx
+++ b/v3/src/js/views/modules/ModulePageContent.jsx
@@ -164,8 +164,8 @@ export class ModulePageContentComponent extends Component<Props, State> {
               </div>
             </section>
 
-            <section id="prerequisites">
-              <h2>Prerequisite Tree</h2>
+            <section className={styles.section} id={SIDE_MENU_ITEMS.prerequisites}>
+              <h2 className={styles.sectionHeading}>Prerequisite Tree</h2>
               <ModuleTree module={module} />
             </section>
 

--- a/v3/src/js/views/modules/ModuleTree.jsx
+++ b/v3/src/js/views/modules/ModuleTree.jsx
@@ -68,7 +68,7 @@ function Tree({ layer, name, branches, isPrereq = false }: TreeDisplay) {
       >
         {isConditional ? formatConditional(name) : <LinkModuleCodes className={styles.link}>{name}</LinkModuleCodes>}
       </div>
-      {branches && <Branch layer={incrementLayer(layer, name)} branches={branches} />}
+      {branches && branches.length > 0 && <Branch layer={incrementLayer(layer, name)} branches={branches} />}
     </li>
   );
 }

--- a/v3/src/js/views/modules/ModuleTree.jsx
+++ b/v3/src/js/views/modules/ModuleTree.jsx
@@ -1,193 +1,97 @@
 // @flow
-
-import React, { Component } from 'react';
+import React from 'react';
+import classnames from 'classnames';
 import _ from 'lodash';
-import d3 from 'd3/build/d3';
+
+import { NUM_DIFFERENT_COLORS } from 'utils/colors';
+import LinkModuleCodes from 'views/components/LinkModuleCodes';
 
 import type { Module } from 'types/modules';
+
+import styles from './ModuleTree.scss';
 
 type Props = {
   module: Module,
 };
 
-export default class ModuleTree extends Component<Props> {
-  prereqRoot: ?HTMLDivElement;
+type TreeDisplay = {
+  layer: number,
+  name: string,
+  isPrereq?: boolean,
+  // TreeDisplay[] will result in infinite loop
+  branches: ?Array<TreeDisplay>,
+};
 
-  componentDidMount() {
-    const isOrAnd = d => d.name === 'or' || d.name === 'and';
-    const modsFilter = d => !isOrAnd(d);
-    const andOrFilter = d => isOrAnd(d);
-    const getHeight = d => (isOrAnd(d) ? 35 : 60);
-    const getWidth = d => (isOrAnd(d) ? 50 : 120);
-    const getX = d => (isOrAnd(d) ? -25 : -60);
-    const getY = d => (isOrAnd(d) ? -17.5 : -35);
-
-    const prereqRoot = this.prereqRoot;
-    if (!prereqRoot) return;
-
-    const SVGHeight = 400;
-    let SVGWidth = prereqRoot.clientWidth;
-    let rectangles;
-    let interact;
-
-    const getDefaultTranslation = () => [(SVGWidth) / 2, 180].join(',');
-
-    function mouseOver(d) {
-      if (!isOrAnd(d)) {
-        rectangles.filter(modsFilter)
-          .classed({ 'active-rect': false, opaque: false, translucent: true });
-        d3.select(this)
-          .selectAll('rect')
-          .classed({ 'active-rect': true, opaque: true, translucent: false });
-      }
-    }
-
-    function mouseOut() {
-      rectangles.filter(modsFilter)
-        .classed({ 'active-rect': false, opaque: true, translucent: false });
-    }
-
-    function clicked(d) {
-      if (!isOrAnd(d)) {
-      // TODO: Use React Router to navigate.
-        window.location.href = `/modules/${d.name}`;
-      }
-    }
-
-    function resized() {
-      SVGWidth = prereqRoot.clientWidth;
-      d3.select('#svg').attr('width', SVGWidth);
-
-      interact.translate(getDefaultTranslation());
-      d3.select('#drawarea')
-        .transition()
-        .delay(1)
-        .attr('transform', `translate(${getDefaultTranslation()}) scale(${interact.scale()})`);
-    }
-
-    const module = this.props.module;
-
-    // early return so we don't draw a huge blank canvas
-    if (!module.ModmavenTree) {
-      return;
-    }
-
-    let canvas = d3.select(this.prereqRoot)
-      .append('svg')
-      .attr('id', 'svg')
-      .attr('width', SVGWidth)
-      .attr('height', SVGHeight);
-    canvas = canvas.append('g')
-      .attr('id', 'drawarea');
-    interact = d3.behavior.zoom()
-      .scaleExtent([0.0, 5.0])
-      .size([960, 500])
-      .on('zoom', () => (
-        d3.select('#drawarea')
-          .attr('transform', `translate(${d3.event.translate}) scale(${d3.event.scale})`)
-      ));
-    window.addEventListener('resize', _.debounce(resized.bind(this), 100));
-    resized.bind(this)();
-    interact(d3.select('svg'));
-
-    const modCode = module.ModuleCode;
-    // $FlowFixMe: Suppressing this error until we change the Module type.
-    const modmavenTree = module.ModmavenTree;
-    const lockedModules = {
-      name: modmavenTree.name,
-      // $FlowFixMe: Suppressing this error until we change the Module type.
-      children: module.LockedModules.map(lm => ({ name: lm, children: [] })),
-    };
-    const prereqs = modmavenTree;
-    const tree = d3.layout.tree().nodeSize([130, 130]);
-    const nodes = tree.nodes(prereqs);
-    const links = tree.links(nodes);
-    const diagonal = d3.svg.diagonal().projection(d => [d.x, d.y]);
-
-    const treeLm = d3.layout.tree().nodeSize([130, 130]);
-    const nodesLm = treeLm.nodes(lockedModules);
-    const linksLm = treeLm.links(nodesLm);
-    const diagonalLm = d3.svg.diagonal().projection(d => [d.x, -d.y]);
-
-    canvas.selectAll('.link')
-      .data(links)
-      .enter()
-      .append('path')
-      .classed({ link: true, test: true })
-      .attr('d', diagonal);
-
-    canvas.selectAll('.link.locked-modules')
-      .data(linksLm)
-      .enter()
-      .append('path')
-      .classed({ link: true, 'locked-modules': true })
-      .attr('d', diagonalLm);
-
-    canvas.selectAll('.node')
-      .data(nodes)
-      .enter()
-      .append('g')
-      .attr('class', 'node')
-      .attr('transform', d => `translate(${d.x}, ${d.y})`);
-    canvas.selectAll('.node.locked-modules')
-      .data(nodesLm)
-      .enter()
-      .append('g')
-      .classed({ node: true, 'locked-modules': true })
-      .attr('transform', d => `translate(${d.x}, ${-d.y})`);
-
-    const nodeAll = canvas.selectAll('.node');
-
-    rectangles = nodeAll.append('rect')
-      .attr('width', 0)
-      .attr('height', 0)
-      .attr('x', getX)
-      .attr('y', getY)
-      .attr('rx', 20)
-      .attr('ry', 20)
-      .classed({ rect: true, opaque: true })
-      .attr('nodeValue', d => d.name);
-
-    rectangles.filter(modsFilter)
-      .classed({ 'mod-rect': true, 'non-linkable-mod': true })
-      .filter(() => true)
-      .classed({ 'non-linkable-mod': false, 'linkable-mod': true });
-    rectangles.filter(andOrFilter)
-      .classed({ 'andor-rect': true });
-    rectangles.filter(d => d.name === modCode)
-      .classed({ 'current-mod-rect': true });
-
-    const labels = nodeAll.append('text')
-      .text(d => d.name)
-      .classed({ 'rect-label': true, lead: true, transparent: true })
-      .attr('dy', d => (isOrAnd(d) ? '10' : ''));
-
-    labels.filter(andOrFilter)
-      .classed({ 'andor-label': true });
-
-    labels.filter(modsFilter)
-      .classed({ 'non-linkable-mod': true })
-      .filter(() => true)
-      .classed({ 'non-linkable-mod': false, 'linkable-mod': true });
-
-    canvas.selectAll('path')
-      .classed({ 'opacity-transition': true, opaque: true, transparent: false });
-
-    nodeAll.selectAll('rect')
-      .transition()
-      .duration(1000)
-      .attr('width', getWidth)
-      .attr('height', getHeight)
-      .ease('elastic');
-
-    nodeAll.selectAll('text')
-      .classed({ 'opacity-transition': true, opaque: true, transparent: false });
-    nodeAll.on('mouseover', mouseOver);
-    nodeAll.on('mouseout', mouseOut);
-    nodeAll.on('click', clicked);
-  }
-
-  render() {
-    return <div ref={(div) => { this.prereqRoot = div; }} className="nm-prerequisites-tree" />;
-  }
+function isConditionalNode(name) {
+  return name === 'or' || name === 'and';
 }
+function formatConditional(name) {
+  return name === 'or' ? 'one of' : 'all of';
+}
+function incrementLayer(layer: number, name: string) {
+  return isConditionalNode(name) ? layer : (layer + 1) % NUM_DIFFERENT_COLORS;
+}
+
+function Branch({ layer, branches }: { layer: number, branches: TreeDisplay[] }) {
+  return (
+    <ul className={styles.tree}>
+      {branches.map((child) => {
+        return _.castArray(child).map((subchild, i) => {
+          return (
+            <Tree
+              key={i}
+              layer={incrementLayer(layer, subchild.name)}
+              name={subchild.name}
+              branches={subchild.children}
+            />
+          );
+        });
+      })}
+    </ul>
+  );
+}
+
+function Tree({ layer, name, branches, isPrereq = false }: TreeDisplay) {
+  const isConditional = isConditionalNode(name);
+  return (
+    <li
+      className={classnames(styles.branch, {
+        [styles.prereqBranch]: isPrereq,
+      })}
+    >
+      <div
+        className={classnames(styles.node, {
+          [`color-${layer}`]: !isConditional,
+          [styles.conditional]: isConditional,
+          [styles.prereqNode]: isPrereq,
+        })}
+      >
+        {isConditional ? formatConditional(name) : <LinkModuleCodes className={styles.link}>{name}</LinkModuleCodes>}
+      </div>
+      {branches && <Branch layer={incrementLayer(layer, name)} branches={branches} />}
+    </li>
+  );
+}
+
+function ModuleTree(props: Props) {
+  // $FlowFixMe when we can add properties
+  const modTree = props.module.ModmavenTree;
+  // $FlowFixMe when we can add properties
+  const lockedModules = props.module.LockedModules;
+  const isPrereq = !_.isEmpty(lockedModules);
+  return (
+    <div className={styles.container}>
+      {isPrereq && (
+        <ul className={styles.prereqTree}>
+          {lockedModules.map(name => <Tree layer={0} name={name} branches={null} isPrereq />)}
+        </ul>
+      )}
+      {isPrereq && <div className={classnames(styles.node, styles.conditional)}>needs</div>}
+      <ul className={classnames(styles.tree, styles.root)}>
+        <Tree layer={1} name={modTree.name} branches={_.castArray(modTree.children)} />
+      </ul>
+    </div>
+  );
+}
+
+export default ModuleTree;

--- a/v3/src/js/views/modules/ModuleTree.jsx
+++ b/v3/src/js/views/modules/ModuleTree.jsx
@@ -36,10 +36,10 @@ function Branch({ layer, branches }: { layer: number, branches: TreeDisplay[] })
   return (
     <ul className={styles.tree}>
       {branches.map((child) => {
-        return _.castArray(child).map((subchild, i) => {
+        return _.castArray(child).map((subchild) => {
           return (
             <Tree
-              key={i}
+              key={subchild.name}
               layer={incrementLayer(layer, subchild.name)}
               name={subchild.name}
               branches={subchild.children}
@@ -83,7 +83,7 @@ function ModuleTree(props: Props) {
     <div className={styles.container}>
       {isPrereq && (
         <ul className={styles.prereqTree}>
-          {lockedModules.map(name => <Tree layer={0} name={name} branches={null} isPrereq />)}
+          {lockedModules.map(name => <Tree key={name} layer={0} name={name} branches={null} isPrereq />)}
         </ul>
       )}
       {isPrereq && <div className={classnames(styles.node, styles.conditional)}>needs</div>}
@@ -95,3 +95,5 @@ function ModuleTree(props: Props) {
 }
 
 export default ModuleTree;
+// For testing
+export { incrementLayer };

--- a/v3/src/js/views/modules/ModuleTree.jsx
+++ b/v3/src/js/views/modules/ModuleTree.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { Fragment } from 'react';
 import classnames from 'classnames';
 import _ from 'lodash';
 
@@ -74,19 +74,18 @@ function Tree({ layer, name, branches, isPrereq = false }: TreeDisplay) {
 }
 
 function ModuleTree(props: Props) {
-  // $FlowFixMe when we can add properties
   const modTree = props.module.ModmavenTree;
-  // $FlowFixMe when we can add properties
   const lockedModules = props.module.LockedModules;
-  const isPrereq = !_.isEmpty(lockedModules);
   return (
     <div className={styles.container}>
-      {isPrereq && (
-        <ul className={styles.prereqTree}>
-          {lockedModules.map(name => <Tree key={name} layer={0} name={name} branches={null} isPrereq />)}
-        </ul>
+      {lockedModules && lockedModules.length > 0 && (
+        <Fragment>
+          <ul className={styles.prereqTree}>
+            {lockedModules.map(name => <Tree key={name} layer={0} name={name} branches={null} isPrereq />)}
+          </ul>
+          <div className={classnames(styles.node, styles.conditional)}>needs</div>
+        </Fragment>
       )}
-      {isPrereq && <div className={classnames(styles.node, styles.conditional)}>needs</div>}
       <ul className={classnames(styles.tree, styles.root)}>
         <Tree layer={1} name={modTree.name} branches={_.castArray(modTree.children)} />
       </ul>

--- a/v3/src/js/views/modules/ModuleTree.scss
+++ b/v3/src/js/views/modules/ModuleTree.scss
@@ -41,7 +41,6 @@ $connector-size: 0.75rem;
   justify-content: center;
   padding: 0.125rem 0.25rem;
   margin: 0 0 1px $connector-size;
-  border: 1px solid $gray-light;
   border-radius: $btn-border-radius;
 
   &::before {
@@ -53,6 +52,8 @@ $connector-size: 0.75rem;
 }
 
 .link {
+  display: block;
+  width: 100%;
   color: currentColor;
 
   &:hover {

--- a/v3/src/js/views/modules/ModuleTree.scss
+++ b/v3/src/js/views/modules/ModuleTree.scss
@@ -1,0 +1,126 @@
+@import '~styles/utils/modules-entry.scss';
+
+$connector-size: 0.75rem;
+
+.container {
+  display: flex;
+  align-items: center;
+  overflow-y: auto;
+
+  @include media-breakpoint-up(sm) {
+    justify-content: center;
+  }
+}
+
+.root {
+  // Current viewing module
+  :global(.color-1) {
+    margin: 0;
+    font-size: 1.1rem;
+
+    &::before {
+      display: none;
+    }
+  }
+}
+
+.tree,
+.prereqTree {
+  position: relative;
+  padding: 0;
+  margin: 0.125rem 0;
+  text-align: center;
+  list-style: none;
+}
+
+.node {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: center;
+  padding: 0.125rem 0.25rem;
+  margin: 0 0 1px $connector-size;
+  border: 1px solid $gray-light;
+  border-radius: $btn-border-radius;
+
+  &::before {
+    top: 50%;
+    left: -$connector-size;
+    width: $connector-size;
+    height: 1px;
+  }
+}
+
+.link {
+  color: currentColor;
+
+  &:hover {
+    color: currentColor;
+  }
+}
+
+.node::before,
+.conditional::after,
+.branch::before,
+.branch::after {
+  content: '';
+  position: absolute;
+  background: var(--gray-light);
+}
+
+.conditional {
+  flex: 0 0 auto;
+  margin-right: $connector-size;
+  border: 0;
+
+  &::after {
+    top: 50%;
+    right: -$connector-size;
+    width: $connector-size;
+    height: 1px;
+  }
+}
+
+.branch {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  &::before,
+  &::after {
+    left: 0;
+    width: 1px;
+    height: 50%;
+  }
+
+  &::before {
+    top: 0;
+  }
+
+  &::after {
+    bottom: 0;
+  }
+
+  &:first-child::before,
+  &:last-child::after {
+    display: none;
+  }
+}
+
+.prereqBranch {
+  &::before,
+  &::after {
+    right: 0;
+    left: auto;
+  }
+}
+
+.prereqNode {
+  margin: 0 $connector-size 1px 0;
+
+  &::before {
+    right: -$connector-size;
+    left: auto;
+  }
+}

--- a/v3/src/js/views/modules/ModuleTree.scss
+++ b/v3/src/js/views/modules/ModuleTree.scss
@@ -36,7 +36,7 @@ $connector-size: 0.75rem;
 .node {
   position: relative;
   display: flex;
-  flex: 1 1 auto;
+  flex: 0 1 5rem;
   align-items: center;
   justify-content: center;
   padding: 0.125rem 0.25rem;

--- a/v3/src/js/views/modules/ModuleTree.test.jsx
+++ b/v3/src/js/views/modules/ModuleTree.test.jsx
@@ -6,7 +6,7 @@ import { render } from 'enzyme';
 import ModuleTree, { incrementLayer } from './ModuleTree';
 
 jest.mock('views/components/LinkModuleCodes', () => {
-  return 'MockedLink';
+  return 'mockedlink';
 });
 
 describe('<ModuleTree>', () => {

--- a/v3/src/js/views/modules/ModuleTree.test.jsx
+++ b/v3/src/js/views/modules/ModuleTree.test.jsx
@@ -1,0 +1,104 @@
+// @flow
+
+import React from 'react';
+import { render } from 'enzyme';
+
+import ModuleTree, { incrementLayer } from './ModuleTree';
+
+jest.mock('views/components/LinkModuleCodes', () => {
+  return 'MockedLink';
+});
+
+describe('<ModuleTree>', () => {
+  test('should render prereq tree of module', () => {
+    const mod = {
+      ModmavenTree: { name: 'ACC1002', children: [] },
+      LockedModules: [
+        'ACC1006',
+        'ACC2002',
+        'ACC3601',
+        'ACC3603',
+        'ACC3605',
+        'ACC3616',
+        'FIN2004',
+        'FIN2004X',
+        'FIN3113',
+        'FIN3130',
+        'IS5116',
+        'ACC3611',
+        'FIN3132',
+        'FIN4115',
+      ],
+    };
+    // $FlowFixMe just the two is enough
+    const component = render(<ModuleTree module={mod} />);
+    expect(component).toMatchSnapshot('ACC1002');
+  });
+
+  test('should render prereq tree of module', () => {
+    const mod = {
+      ModmavenTree: {
+        name: 'CS3244',
+        children: [
+          {
+            name: 'and',
+            children: [
+              [
+                {
+                  name: 'or',
+                  children: [
+                    { name: 'CS2010', children: [] },
+                    { name: 'CS2020', children: [] },
+                    { name: 'CS2040', children: [] },
+                    { name: 'CS2040C', children: [] },
+                  ],
+                },
+              ],
+              [
+                {
+                  name: 'or',
+                  children: [
+                    { name: 'ESP1107', children: [] },
+                    { name: 'ESP2107', children: [] },
+                    { name: 'ST1232', children: [] },
+                    { name: 'ST2131', children: [] },
+                    { name: 'ST2132', children: [] },
+                    { name: 'ST2334', children: [] },
+                  ],
+                },
+              ],
+              [
+                {
+                  name: 'or',
+                  children: [
+                    { name: 'MA1101R', children: [] },
+                    { name: 'MA1311', children: [] },
+                    { name: 'MA1506', children: [] },
+                  ],
+                },
+              ],
+              [
+                {
+                  name: 'or',
+                  children: [
+                    { name: 'MA1102R', children: [] },
+                    { name: 'MA1505', children: [] },
+                    { name: 'MA1521', children: [] },
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+      },
+      LockedModules: ['CS5242', 'CS5339', 'CS6281'],
+    };
+    // $FlowFixMe just the two is enough
+    const component = render(<ModuleTree module={mod} />);
+    expect(component).toMatchSnapshot('CS3244');
+  });
+});
+
+describe('incrementLayer to mod when exceed number mods', () => {
+  expect(incrementLayer(7, 'MOD')).toBe(0);
+});

--- a/v3/src/js/views/modules/__snapshots__/ModuleTree.test.jsx.snap
+++ b/v3/src/js/views/modules/__snapshots__/ModuleTree.test.jsx.snap
@@ -1,0 +1,616 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ACC1002 1`] = `
+<div
+  class="container"
+>
+  <ul
+    class="prereqTree"
+  >
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          ACC1006
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          ACC2002
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          ACC3601
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          ACC3603
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          ACC3605
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          ACC3616
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          FIN2004
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          FIN2004X
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          FIN3113
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          FIN3130
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          IS5116
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          ACC3611
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          FIN3132
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          FIN4115
+        </mockedlink>
+      </div>
+    </li>
+  </ul>
+  <div
+    class="node conditional"
+  >
+    needs
+  </div>
+  <ul
+    class="tree root"
+  >
+    <li
+      class="branch"
+    >
+      <div
+        class="node color-1"
+      >
+        <mockedlink
+          class="link"
+        >
+          ACC1002
+        </mockedlink>
+      </div>
+      <ul
+        class="tree"
+      />
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`CS3244 1`] = `
+<div
+  class="container"
+>
+  <ul
+    class="prereqTree"
+  >
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          CS5242
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          CS5339
+        </mockedlink>
+      </div>
+    </li>
+    <li
+      class="branch prereqBranch"
+    >
+      <div
+        class="node color-0 prereqNode"
+      >
+        <mockedlink
+          class="link"
+        >
+          CS6281
+        </mockedlink>
+      </div>
+    </li>
+  </ul>
+  <div
+    class="node conditional"
+  >
+    needs
+  </div>
+  <ul
+    class="tree root"
+  >
+    <li
+      class="branch"
+    >
+      <div
+        class="node color-1"
+      >
+        <mockedlink
+          class="link"
+        >
+          CS3244
+        </mockedlink>
+      </div>
+      <ul
+        class="tree"
+      >
+        <li
+          class="branch"
+        >
+          <div
+            class="node conditional"
+          >
+            all of
+          </div>
+          <ul
+            class="tree"
+          >
+            <li
+              class="branch"
+            >
+              <div
+                class="node conditional"
+              >
+                one of
+              </div>
+              <ul
+                class="tree"
+              >
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      CS2010
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      CS2020
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      CS2040
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      CS2040C
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+              </ul>
+            </li>
+            <li
+              class="branch"
+            >
+              <div
+                class="node conditional"
+              >
+                one of
+              </div>
+              <ul
+                class="tree"
+              >
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      ESP1107
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      ESP2107
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      ST1232
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      ST2131
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      ST2132
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      ST2334
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+              </ul>
+            </li>
+            <li
+              class="branch"
+            >
+              <div
+                class="node conditional"
+              >
+                one of
+              </div>
+              <ul
+                class="tree"
+              >
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      MA1101R
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      MA1311
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      MA1506
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+              </ul>
+            </li>
+            <li
+              class="branch"
+            >
+              <div
+                class="node conditional"
+              >
+                one of
+              </div>
+              <ul
+                class="tree"
+              >
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      MA1102R
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      MA1505
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+                <li
+                  class="branch"
+                >
+                  <div
+                    class="node color-3"
+                  >
+                    <mockedlink
+                      class="link"
+                    >
+                      MA1521
+                    </mockedlink>
+                  </div>
+                  <ul
+                    class="tree"
+                  />
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+`;

--- a/v3/src/js/views/modules/__snapshots__/ModuleTree.test.jsx.snap
+++ b/v3/src/js/views/modules/__snapshots__/ModuleTree.test.jsx.snap
@@ -210,9 +210,6 @@ exports[`<ModuleTree> should render prereq tree of module: ACC1002 1`] = `
           ACC1002
         </mockedlink>
       </div>
-      <ul
-        class="tree"
-      />
     </li>
   </ul>
 </div>
@@ -322,9 +319,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       CS2010
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -338,9 +332,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       CS2020
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -354,9 +345,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       CS2040
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -370,9 +358,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       CS2040C
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
               </ul>
             </li>
@@ -399,9 +384,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       ESP1107
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -415,9 +397,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       ESP2107
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -431,9 +410,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       ST1232
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -447,9 +423,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       ST2131
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -463,9 +436,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       ST2132
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -479,9 +449,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       ST2334
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
               </ul>
             </li>
@@ -508,9 +475,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       MA1101R
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -524,9 +488,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       MA1311
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -540,9 +501,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       MA1506
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
               </ul>
             </li>
@@ -569,9 +527,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       MA1102R
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -585,9 +540,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       MA1505
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
                 <li
                   class="branch"
@@ -601,9 +553,6 @@ exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
                       MA1521
                     </mockedlink>
                   </div>
-                  <ul
-                    class="tree"
-                  />
                 </li>
               </ul>
             </li>

--- a/v3/src/js/views/modules/__snapshots__/ModuleTree.test.jsx.snap
+++ b/v3/src/js/views/modules/__snapshots__/ModuleTree.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ACC1002 1`] = `
+exports[`<ModuleTree> should render prereq tree of module: ACC1002 1`] = `
 <div
   class="container"
 >
@@ -218,7 +218,7 @@ exports[`ACC1002 1`] = `
 </div>
 `;
 
-exports[`CS3244 1`] = `
+exports[`<ModuleTree> should render prereq tree of module: CS3244 1`] = `
 <div
   class="container"
 >

--- a/v3/yarn.lock
+++ b/v3/yarn.lock
@@ -1933,7 +1933,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2, commander@2.9.x, commander@^2.8.1, commander@^2.9.0:
+commander@2.9.x, commander@^2.8.1, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -2300,216 +2300,6 @@ currently-unhandled@^0.4.1:
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
-
-d3-array@1, d3-array@1.2.0, d3-array@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.0.tgz#147d269720e174c4057a7f42be8b0f3f2ba53108"
-
-d3-axis@1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.8.tgz#31a705a0b535e65759de14173a31933137f18efa"
-
-d3-brush@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.0.4.tgz#00c2f238019f24f6c0a194a26d41a1530ffe7bc4"
-  dependencies:
-    d3-dispatch "1"
-    d3-drag "1"
-    d3-interpolate "1"
-    d3-selection "1"
-    d3-transition "1"
-
-d3-chord@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.4.tgz#7dec4f0ba886f713fe111c45f763414f6f74ca2c"
-  dependencies:
-    d3-array "1"
-    d3-path "1"
-
-d3-collection@1, d3-collection@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.4.tgz#342dfd12837c90974f33f1cc0a785aea570dcdc2"
-
-d3-color@1, d3-color@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.3.tgz#bc7643fca8e53a8347e2fbdaffa236796b58509b"
-
-d3-dispatch@1, d3-dispatch@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.3.tgz#46e1491eaa9b58c358fce5be4e8bed626e7871f8"
-
-d3-drag@1, d3-drag@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.1.1.tgz#b5155304433b18ba38726b2184d0098e820dc64b"
-  dependencies:
-    d3-dispatch "1"
-    d3-selection "1"
-
-d3-dsv@1, d3-dsv@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.0.5.tgz#419f7db47f628789fc3fdb636e678449d0821136"
-  dependencies:
-    commander "2"
-    iconv-lite "0.4"
-    rw "1"
-
-d3-ease@1, d3-ease@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.3.tgz#68bfbc349338a380c44d8acc4fbc3304aa2d8c0e"
-
-d3-force@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.0.6.tgz#ea7e1b7730e2664cd314f594d6718c57cc132b79"
-  dependencies:
-    d3-collection "1"
-    d3-dispatch "1"
-    d3-quadtree "1"
-    d3-timer "1"
-
-d3-format@1, d3-format@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.0.tgz#6b480baa886885d4651dc248a8f4ac9da16db07a"
-
-d3-geo@1.6.4:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.6.4.tgz#f20e1e461cb1845f5a8be55ab6f876542a7e3199"
-  dependencies:
-    d3-array "1"
-
-d3-hierarchy@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.5.tgz#a1c845c42f84a206bcf1c01c01098ea4ddaa7a26"
-
-d3-interpolate@1, d3-interpolate@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.5.tgz#69e099ff39214716e563c9aec3ea9d1ea4b8a79f"
-  dependencies:
-    d3-color "1"
-
-d3-path@1, d3-path@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.5.tgz#241eb1849bd9e9e8021c0d0a799f8a0e8e441764"
-
-d3-polygon@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.3.tgz#16888e9026460933f2b179652ad378224d382c62"
-
-d3-quadtree@1, d3-quadtree@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.3.tgz#ac7987e3e23fe805a990f28e1b50d38fcb822438"
-
-d3-queue@3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/d3-queue/-/d3-queue-3.0.7.tgz#c93a2e54b417c0959129d7d73f6cf7d4292e7618"
-
-d3-random@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.0.tgz#6642e506c6fa3a648595d2b2469788a8d12529d3"
-
-d3-request@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-request/-/d3-request-1.0.5.tgz#4daae946d1dd0d57dfe01f022956354958d51f23"
-  dependencies:
-    d3-collection "1"
-    d3-dispatch "1"
-    d3-dsv "1"
-    xmlhttprequest "1"
-
-d3-scale@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.6.tgz#bce19da80d3a0cf422c9543ae3322086220b34ed"
-  dependencies:
-    d3-array "^1.2.0"
-    d3-collection "1"
-    d3-color "1"
-    d3-format "1"
-    d3-interpolate "1"
-    d3-time "1"
-    d3-time-format "2"
-
-d3-selection@1, d3-selection@1.1.0, d3-selection@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.1.0.tgz#1998684896488f839ca0372123da34f1d318809c"
-
-d3-shape@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.0.tgz#45d01538f064bafd05ea3d6d2cb748fd8c41f777"
-  dependencies:
-    d3-path "1"
-
-d3-time-format@2, d3-time-format@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.0.5.tgz#9d7780204f7c9119c9170b1a56db4de9a8af972e"
-  dependencies:
-    d3-time "1"
-
-d3-time@1, d3-time@1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.7.tgz#94caf6edbb7879bb809d0d1f7572bc48482f7270"
-
-d3-timer@1, d3-timer@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.6.tgz#4044bf15d7025c06ce7d1149f73cd07b54dbd784"
-
-d3-transition@1, d3-transition@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.1.0.tgz#cfc85c74e5239324290546623572990560c3966f"
-  dependencies:
-    d3-color "1"
-    d3-dispatch "1"
-    d3-ease "1"
-    d3-interpolate "1"
-    d3-selection "^1.1.0"
-    d3-timer "1"
-
-d3-voronoi@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.2.tgz#1687667e8f13a2d158c80c1480c5a29cb0d8973c"
-
-d3-zoom@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.5.0.tgz#8417de9a077f98f9ce83b1998efb8ee12b4db26e"
-  dependencies:
-    d3-dispatch "1"
-    d3-drag "1"
-    d3-interpolate "1"
-    d3-selection "1"
-    d3-transition "1"
-
-d3@^4.10.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/d3/-/d3-4.10.0.tgz#0bcca3a3b614e2fd45b1b5bd0b9164d57352a862"
-  dependencies:
-    d3-array "1.2.0"
-    d3-axis "1.0.8"
-    d3-brush "1.0.4"
-    d3-chord "1.0.4"
-    d3-collection "1.0.4"
-    d3-color "1.0.3"
-    d3-dispatch "1.0.3"
-    d3-drag "1.1.1"
-    d3-dsv "1.0.5"
-    d3-ease "1.0.3"
-    d3-force "1.0.6"
-    d3-format "1.2.0"
-    d3-geo "1.6.4"
-    d3-hierarchy "1.1.5"
-    d3-interpolate "1.1.5"
-    d3-path "1.0.5"
-    d3-polygon "1.0.3"
-    d3-quadtree "1.0.3"
-    d3-queue "3.0.7"
-    d3-random "1.1.0"
-    d3-request "1.0.5"
-    d3-scale "1.0.6"
-    d3-selection "1.1.0"
-    d3-shape "1.2.0"
-    d3-time "1.0.7"
-    d3-time-format "2.0.5"
-    d3-timer "1.0.6"
-    d3-transition "1.1.0"
-    d3-voronoi "1.1.2"
-    d3-zoom "1.5.0"
 
 d@1:
   version "1.0.0"
@@ -4217,17 +4007,13 @@ icalendar@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/icalendar/-/icalendar-0.7.1.tgz#d0d3486795f8f1c5cf4f8cafac081b4b4e7a32ae"
 
-iconv-lite@0.4, iconv-lite@~0.4.13:
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
-
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@^0.4.17:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+iconv-lite@^0.4.17, iconv-lite@~0.4.13:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
 
 icss-replace-symbols@^1.0.2:
   version "1.0.2"
@@ -7538,10 +7324,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rw@1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
-
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
@@ -8837,10 +8619,6 @@ xml-char-classes@^1.0.0:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
-
-xmlhttprequest@1:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Implements prereq tree by presenting it horizontally. Doing this greatly preserves space, where even in worst case results in:
<img width="610" alt="screenshot 2017-12-22 02 34 14" src="https://user-images.githubusercontent.com/14850387/34284433-cf63825e-e70c-11e7-9240-2a27c994eb91.png">
