### PR TITLE
Add redirection rules for netlify

### DIFF
--- a/v3/static/_redirects
+++ b/v3/static/_redirects
@@ -1,0 +1,2 @@
+# Push state to get Netlify working for all urls
+/*    /index.html   200


### PR DESCRIPTION
Objective is to get links like https://deploy-preview-460--nusmods.netlify.com/modules to work.