### PR TITLE
Load module data from API regardless of whether it is cached

### DIFF
--- a/v3/src/js/actions/__snapshots__/moduleBank.test.js.snap
+++ b/v3/src/js/actions/__snapshots__/moduleBank.test.js.snap
@@ -25,16 +25,3 @@ Object {
   "type": "FETCH_MODULE_LIST",
 }
 `;
-
-exports[`loadModule should dispatch a request if module is not found 1`] = `
-Object {
-  "meta": Object {
-    Symbol(API_REQUEST): true,
-  },
-  "payload": Object {
-    "method": "GET",
-    "url": "https://nusmods.com/api/2017-2018/modules/test.json",
-  },
-  "type": "FETCH_MODULE",
-}
-`;

--- a/v3/src/js/actions/moduleBank.js
+++ b/v3/src/js/actions/moduleBank.js
@@ -34,14 +34,3 @@ export function fetchModule(moduleCode: ModuleCode): FSA {
     },
   };
 }
-
-export const LOAD_MODULE: string = 'LOAD_MODULE';
-export function loadModule(moduleCode: ModuleCode) {
-  return (dispatch: Function, getState: Function): Promise<*> => {
-    // Module has been fetched before and cached. Don't have to fetch again.
-    if (getState().entities.moduleBank.modules[moduleCode]) {
-      return Promise.resolve();
-    }
-    return dispatch(fetchModule(moduleCode));
-  };
-}

--- a/v3/src/js/actions/moduleBank.test.js
+++ b/v3/src/js/actions/moduleBank.test.js
@@ -12,35 +12,3 @@ test('fetchModule should return a request action', () => {
   const resultOfAction: FSA = actions.fetchModule('CS1010S');
   expect(resultOfAction).toMatchSnapshot();
 });
-
-test('loadModule should dispatch a request if module is not found', () => {
-  const dispatch = jest.fn();
-  const getState = () => {
-    return {
-      entities: {
-        moduleBank: {
-          modules: {},
-        },
-      },
-    };
-  };
-  actions.loadModule('test')(dispatch, getState);
-  expect(dispatch.mock.calls[0][0]).toMatchSnapshot();
-});
-
-test('loadModule should resolve immediately if module is found', () => {
-  const dispatch = jest.fn();
-  const getState = () => {
-    return {
-      entities: {
-        moduleBank: {
-          modules: {
-            test: {},
-          },
-        },
-      },
-    };
-  };
-  actions.loadModule('test')(dispatch, getState);
-  expect(dispatch).not.toHaveBeenCalled();
-});

--- a/v3/src/js/actions/timetables.js
+++ b/v3/src/js/actions/timetables.js
@@ -9,14 +9,14 @@ import type {
   Lesson,
 } from 'types/modules';
 
-import { loadModule } from 'actions/moduleBank';
+import { fetchModule } from 'actions/moduleBank';
 import { randomModuleLessonConfig } from 'utils/timetables';
 import { getModuleTimetable } from 'utils/modules';
 
 export const ADD_MODULE: string = 'ADD_MODULE';
 export function addModule(semester: Semester, moduleCode: ModuleCode) {
   return (dispatch: Function, getState: Function) => {
-    return dispatch(loadModule(moduleCode)).then(() => {
+    return dispatch(fetchModule(moduleCode)).then(() => {
       const module: Module = getState().entities.moduleBank.modules[moduleCode];
       const lessons: Array<RawLesson> = getModuleTimetable(module, semester);
       let moduleLessonConfig: ModuleLessonConfig = {};

--- a/v3/src/js/views/AppShell.jsx
+++ b/v3/src/js/views/AppShell.jsx
@@ -67,7 +67,6 @@ export class AppShell extends Component<Props> {
     this.props.fetchModuleList();
 
     const semesterTimetable = this.props.timetables[config.semester];
-    console.log('semesterTimetable', semesterTimetable);
     if (semesterTimetable) {
       Object.keys(semesterTimetable).forEach((moduleCode) => {
         // TODO: Handle failed loading of module.

--- a/v3/src/js/views/AppShell.jsx
+++ b/v3/src/js/views/AppShell.jsx
@@ -12,7 +12,7 @@ import type { ModuleList, ModuleSelectList } from 'types/reducers';
 import type { ModuleCode } from 'types/modules';
 
 import config from 'config';
-import { fetchModuleList, loadModule } from 'actions/moduleBank';
+import { fetchModuleList, fetchModule } from 'actions/moduleBank';
 import { noBreak } from 'utils/react';
 import { roundStart } from 'utils/cors';
 import ModulesSelect from 'views/components/ModulesSelect';
@@ -34,7 +34,7 @@ type Props = {
   timetables: TimetableConfig,
   theme: string,
 
-  loadModule: (ModuleCode) => void,
+  fetchModule: (ModuleCode) => void,
   fetchModuleList: () => void,
 };
 
@@ -67,11 +67,11 @@ export class AppShell extends Component<Props> {
     this.props.fetchModuleList();
 
     const semesterTimetable = this.props.timetables[config.semester];
-
+    console.log('semesterTimetable', semesterTimetable);
     if (semesterTimetable) {
       Object.keys(semesterTimetable).forEach((moduleCode) => {
         // TODO: Handle failed loading of module.
-        this.props.loadModule(moduleCode);
+        this.props.fetchModule(moduleCode);
       });
     }
   }
@@ -135,6 +135,6 @@ const mapStateToProps = state => ({
 export default withRouter(
   connect(mapStateToProps, {
     fetchModuleList,
-    loadModule,
+    fetchModule,
   })(AppShell),
 );

--- a/v3/src/js/views/browse/ModulePageContainer.jsx
+++ b/v3/src/js/views/browse/ModulePageContainer.jsx
@@ -7,7 +7,7 @@ import Raven from 'raven-js';
 import type { FetchRequest } from 'types/reducers';
 import type { Module, ModuleCode } from 'types/modules';
 
-import { loadModule, FETCH_MODULE } from 'actions/moduleBank';
+import { fetchModule, FETCH_MODULE } from 'actions/moduleBank';
 import { getRequestName } from 'reducers/requests';
 import NotFoundPage from 'views/errors/NotFoundPage';
 import ErrorPage from 'views/errors/ErrorPage';
@@ -18,7 +18,7 @@ type Props = {
   moduleCodes: Set<ModuleCode>,
   module: ?Module,
   request: ?FetchRequest,
-  loadModule: (ModuleCode) => void,
+  fetchModule: (ModuleCode) => void,
 };
 
 type State = {
@@ -47,7 +47,7 @@ export class ModulePageContainerComponent extends PureComponent<Props, State> {
   };
 
   componentWillMount() {
-    this.loadModule(this.props.moduleCode);
+    this.fetchModule(this.props.moduleCode);
 
     import('views/browse/ModulePageContent')
       .then(module => this.setState({ ModulePageContent: module.default }))
@@ -59,13 +59,13 @@ export class ModulePageContainerComponent extends PureComponent<Props, State> {
 
   componentWillReceiveProps(nextProps: Props) {
     if (nextProps.moduleCode !== this.props.moduleCode) {
-      this.loadModule(nextProps.moduleCode);
+      this.fetchModule(nextProps.moduleCode);
     }
   }
 
-  loadModule(moduleCode: ModuleCode) {
+  fetchModule(moduleCode: ModuleCode) {
     if (this.doesModuleExist(moduleCode)) {
-      this.props.loadModule(moduleCode);
+      this.props.fetchModule(moduleCode);
     }
   }
 
@@ -106,5 +106,5 @@ const mapStateToProps = (state, ownState) => {
 };
 
 export default withRouter(
-  connect(mapStateToProps, { loadModule })(ModulePageContainerComponent),
+  connect(mapStateToProps, { fetchModule })(ModulePageContainerComponent),
 );


### PR DESCRIPTION
A module's timetable data is only loaded the first time we add the module to the timetable. But if the module timetable data changes somehow later on, the app does not fetch it again because it relies only on the cached version. 

The "fix" is that we're just gonna make an API request either way. It should be fine because if the module data didn't change the server just returns a 304.