### PR TITLE
Public holidays scraper

### DIFF
--- a/v3/package.json
+++ b/v3/package.json
@@ -61,6 +61,7 @@
     "flow-status-webpack-plugin": "^0.1.6",
     "graceful-fs": "^4.1.11",
     "html-webpack-plugin": "^2.30.1",
+    "icalendar": "^0.7.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^21.2.1",
     "js-combinatorics": "^0.5.2",

--- a/v3/scripts/holidays/2015_singapore_holidays.csv
+++ b/v3/scripts/holidays/2015_singapore_holidays.csv
@@ -1,0 +1,13 @@
+Date,Name,Day,Observance,Observance Strategy
+2015-01-01,New Year's Day,Thursday,2015-01-01,actual_day
+2015-02-19,Chinese New Year,Thursday,2015-02-19,actual_day
+2015-04-03,Good Friday,Friday,2015-04-03,actual_day
+2015-05-01,Labour Day,Friday,2015-05-01,actual_day
+2015-06-01,Vesak Day,Monday,2015-06-01,actual_day
+2015-07-17,Hari Raya Puasa,Friday,2015-07-17,actual_day
+2015-08-07,SG50 Public Holiday,Friday,2015-08-07,actual_day
+2015-08-09,National Day,Sunday,2015-08-10,next_monday
+2015-09-11,Polling Day,Friday,2015-09-11,actual_day
+2015-09-24,Hari Raya Haji,Thursday,2015-09-24,actual_day
+2015-11-10,Deepavali,Tuesday,2015-11-10,actual_day
+2015-12-25,Christmas Day,Friday,2015-12-25,actual_day

--- a/v3/scripts/holidays/2016_singapore_holidays.csv
+++ b/v3/scripts/holidays/2016_singapore_holidays.csv
@@ -1,0 +1,11 @@
+Date,Name,Day,Observance,Observance Strategy
+2016-01-01,New Year's Day,Friday,2016-01-01,actual_day
+2016-02-08,Chinese New Year,Monday,2016-02-08,actual_day
+2016-03-25,Good Friday,Friday,2016-03-25,actual_day
+2016-05-01,Labour Day,Sunday,2016-05-02,next_monday
+2016-05-21,Vesak Day,Saturday,2016-05-21,actual_day
+2016-07-06,Hari Raya Puasa,Wednesday,2016-07-06,actual_day
+2016-08-09,National Day,Tuesday,2016-08-09,actual_day
+2016-09-12,Hari Raya Haji,Monday,2016-09-12,actual_day
+2016-10-29,Deepavali,Saturday,2016-10-29,actual_day
+2016-12-25,Christmas Day,Sunday,2016-12-26,next_monday

--- a/v3/scripts/holidays/2017_singapore_holidays.csv
+++ b/v3/scripts/holidays/2017_singapore_holidays.csv
@@ -1,0 +1,12 @@
+Date,Name,Day,Observance,Observance Strategy
+2017-01-01,New Year's Day,Sunday,2017-01-02,next_monday
+2017-01-28,Chinese New Year,Saturday,2017-01-28,actual_day
+2017-01-29,Chinese New Year,Sunday,2017-01-30,next_monday
+2017-04-14,Good Friday,Friday,2017-04-14,actual_day
+2017-05-01,Labour Day,Monday,2017-05-01,actual_day
+2017-05-10,Vesak Day,Wednesday,2017-05-10,actual_day
+2017-06-25,Hari Raya Puasa,Sunday,2017-06-26,next_monday
+2017-08-09,National Day,Wednesday,2017-08-09,actual_day
+2017-09-01,Hari Raya Haji,Friday,2017-09-01,actual_day
+2017-10-18,Deepavali,Wednesday,2017-10-18,actual_day
+2017-12-25,Christmas Day,Monday,2017-12-25,actual_day

--- a/v3/scripts/holidays/2018_singapore_holidays.csv
+++ b/v3/scripts/holidays/2018_singapore_holidays.csv
@@ -1,0 +1,12 @@
+Date,Name,Day,Observance,Observance Strategy
+2018-01-01,New Year's Day,Monday,2018-01-01,actual_day
+2018-02-16,Chinese New Year,Friday,2018-02-16,actual_day
+2018-02-17,Chinese New Year,Saturday,2018-02-17,actual_day
+2018-03-30,Good Friday,Friday,2018-03-30,actual_day
+2018-05-01,Labour Day,Tuesday,2018-05-01,actual_day
+2018-05-29,Vesak Day,Tuesday,2018-05-29,actual_day
+2018-06-15,Hari Raya Puasa,Friday,2018-06-15,actual_day
+2018-08-09,National Day,Thursday,2018-08-09,actual_day
+2018-08-22,Hari Raya Haji,Wednesday,2018-08-22,actual_day
+2018-11-06,Deepavali,Tuesday,2018-11-06,actual_day
+2018-12-25,Christmas Day,Tuesday,2018-12-25,actual_day

--- a/v3/scripts/public-holidays-ics-to-csv.js
+++ b/v3/scripts/public-holidays-ics-to-csv.js
@@ -31,10 +31,10 @@ async function fetchPublicHolidaysIcs(year) {
   return res.data;
 }
 
-years.split(',').map(s => s.trim()).forEach(year => {
-  fetchPublicHolidaysIcs(year).then(icsData => {
+years.split(',').map(s => s.trim()).forEach((year) => {
+  fetchPublicHolidaysIcs(year).then((icsData) => {
     // This trailing newline is needed by the parser else it's an invalid format.
-    const ical = icalendar.parse_calendar(icsData + '\n');
+    const ical = icalendar.parse_calendar(`${icsData}\n`);
     const calendarEvents = ical.events().map(event => ({
       date: moment(event.getPropertyValue('DTSTART').valueOf()),
       name: event.getPropertyValue('SUMMARY'),
@@ -54,7 +54,7 @@ years.split(',').map(s => s.trim()).forEach(year => {
         i < calendarEvents.length &&
         calendarEvents[i + 1].name !== 'Chinese New Year') {
         actualDay = false;
-        i++; // Skip because the next event is the observance event.
+        i += 1; // Skip because the next event is the observance event.
       }
       data.push({
         date: date.format(DATE_FORMAT),
@@ -67,13 +67,13 @@ years.split(',').map(s => s.trim()).forEach(year => {
 
     const HEADERS = ['Date', 'Name', 'Day', 'Observance', 'Observance Strategy'];
     const rows = [HEADERS];
-    data.forEach(row => {
+    data.forEach((row) => {
       rows.push([row.date, row.name, row.day, row.observance, row.observance_strategy]);
     });
     const outPath = path.join(OUT_DIR, `${year}_singapore_holidays.csv`);
     console.log(`Writing holidays CSV for ${year} to ${outPath}`);
-    fs.writeFileSync(outPath, rows.join('\n') + '\n');
-  }).catch(err => {
+    fs.writeFileSync(outPath, `${rows.join('\n')}\n`);
+  }).catch((err) => {
     console.error(err);
   });
 });

--- a/v3/scripts/public-holidays-ics-to-csv.js
+++ b/v3/scripts/public-holidays-ics-to-csv.js
@@ -33,7 +33,8 @@ async function fetchPublicHolidaysIcs(year) {
 
 years.split(',').map(s => s.trim()).forEach(year => {
   fetchPublicHolidaysIcs(year).then(icsData => {
-    const ical = icalendar.parse_calendar(icsData + '\n'); // This trailing newline is needed by the parser else it's an invalid format.
+    // This trailing newline is needed by the parser else it's an invalid format.
+    const ical = icalendar.parse_calendar(icsData + '\n');
     const calendarEvents = ical.events().map(event => ({
       date: moment(event.getPropertyValue('DTSTART').valueOf()),
       name: event.getPropertyValue('SUMMARY'),

--- a/v3/scripts/public-holidays-ics-to-csv.js
+++ b/v3/scripts/public-holidays-ics-to-csv.js
@@ -1,0 +1,71 @@
+// Usage: $ node public-holidays-ics-to-csv.js 2016,2017,2018
+
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+const icalendar = require('icalendar');
+const moment = require('moment');
+
+const args = process.argv.slice(2);
+const years = args[0];
+if (!years) {
+  console.error('Please specify the year(s).');
+  process.exit(1);
+}
+
+const OUT_DIR = path.join(__dirname, 'holidays');
+if (!fs.existsSync(OUT_DIR)) {
+  fs.mkdirSync(OUT_DIR);
+}
+
+async function fetchPublicHolidaysIcs(year) {
+  const URL = 'http://www.mom.gov.sg/~/media/mom/documents/employment-practices/' +
+   `public-holidays/public-holidays-sg-${year}.ics`;
+
+  const res = await axios.get(URL);
+  return res.data;
+}
+
+years.split(',').map(s => s.trim()).forEach(year => {
+  fetchPublicHolidaysIcs(year).then(icsData => {
+    const ical = icalendar.parse_calendar(icsData + '\n'); // This trailing newline is needed by the parser else it's an invalid format.
+    const calendarEvents = ical.events().map(event => ({
+      date: moment(event.getPropertyValue('DTSTART').valueOf()),
+      name: event.getPropertyValue('SUMMARY'),
+    })).sort((a, b) => {
+      // Order not guaranteed. Have to sort.
+      return a.date.isBefore(b.date) ? -1 : 1;
+    });
+
+    const data = [];
+    const DATE_FORMAT = 'YYYY-MM-DD';
+    for (let i = 0; i < calendarEvents.length; i++) {
+      const event = calendarEvents[i];
+      const { name, date } = event;
+      let actualDay = true;
+      if (date.format('dddd') === 'Sunday' &&
+        i < calendarEvents.length &&
+        calendarEvents[i + 1].name !== 'Chinese New Year') {
+        // Sunday that is not first day of CNY.
+        actualDay = false;
+        i++; // Skip because the next event is the observance event.
+      }
+      data.push({
+        date: date.format(DATE_FORMAT),
+        name: name,
+        day: date.format('dddd'), // The day in text, e.g. Monday.
+        observance: date.add(actualDay ? 0 : 1, 'day').format(DATE_FORMAT),
+        observance_strategy: actualDay ? 'actual_day' : 'next_monday',
+      });
+    }
+
+    const HEADERS = ['Date', 'Name', 'Day', 'Observance', 'Observance Strategy'];
+    const rows = [HEADERS];
+    data.forEach(row => {
+      rows.push([row.date, row.name, row.day, row.observance, row.observance_strategy]);
+    });
+    fs.writeFileSync(path.join(OUT_DIR, `${year}_singapore_holidays.csv`), rows.join('\n') + '\n');
+  }).catch(err => {
+    console.error(err);
+  });
+});

--- a/v3/yarn.lock
+++ b/v3/yarn.lock
@@ -3570,6 +3570,10 @@ ical-generator@^0.2.9:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/ical-generator/-/ical-generator-0.2.9.tgz#67312e484a8681c7abc1bbe77237b13faa5b1eb8"
 
+icalendar@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/icalendar/-/icalendar-0.7.1.tgz#d0d3486795f8f1c5cf4f8cafac081b4b4e7a32ae"
+
 iconv-lite@0.4, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"


### PR DESCRIPTION
A supporting PR for #469 . This PR adds a scraper to fetch public holiday ICS files from MOM website and converts them into a CSV format that is similar to https://github.com/rjchow/singapore_public_holidays, which reduces our external reliance.