### PR TITLE
Port Apps page to v3

### DIFF
--- a/v3/src/js/views/Routes.jsx
+++ b/v3/src/js/views/Routes.jsx
@@ -10,6 +10,7 @@ import AboutContainer from 'views/static/AboutContainer';
 import TeamContainer from 'views/static/TeamContainer';
 import DevelopersContainer from 'views/static/DevelopersContainer';
 import FaqContainer from 'views/static/FaqContainer';
+import AppsContainer from 'views/static/AppsContainer';
 import NotFoundPage from 'views/errors/NotFoundPage';
 
 export default function Routes() {
@@ -24,6 +25,7 @@ export default function Routes() {
       <Route path="/settings" component={SettingsContainer} />
       <Route path="/team" component={TeamContainer} />
       <Route path="/developers" component={DevelopersContainer} />
+      <Route path="/apps" component={AppsContainer} />
       <Route component={NotFoundPage} />
     </Switch>
   );

--- a/v3/src/js/views/layout/Footer.jsx
+++ b/v3/src/js/views/layout/Footer.jsx
@@ -12,6 +12,7 @@ function Footer() {
           <li><a href="https://twitter.com/nusmods">Twitter</a></li>
           <li><a href="http://blog.nusmods.com/">Blog</a></li>
           <li><a href="https://github.com/nusmodifications/nusmods-api">API</a></li>
+          <li><Link to="/apps">Apps</Link></li>
           <li><Link to="/about">About</Link></li>
           <li><Link to="/team">Team</Link></li>
           <li><Link to="/developers">Developers</Link></li>

--- a/v3/src/js/views/static/AppsContainer.jsx
+++ b/v3/src/js/views/static/AppsContainer.jsx
@@ -1,0 +1,128 @@
+// @flow
+
+import React, { Component } from 'react';
+import axios from 'axios';
+
+import Loader from 'views/components/LoadingSpinner';
+
+import StaticPage from './StaticPage';
+import styles from './AppsContainer.scss';
+
+const APPS_URL = 'https://nusmodifications.github.io/nusmods-apps/apps.json';
+
+type Props = {};
+
+type State = {
+  appsData: ?[Object],
+  isLoading: boolean,
+  isError: boolean,
+  errorMessage: string,
+};
+
+type AppEntryProps = {
+  app: {
+    name: string,
+    description: string,
+    author: string,
+    url: string,
+    repository_url?: string,
+    icon_url: string,
+    tags: Array<string>,
+  },
+};
+
+function AppEntry({ app }: AppEntryProps) {
+  return (
+    <section className={styles.appEntry} key={app.name}>
+      <div className="row">
+        <div className="col-lg-2 col-sm-3 text-center-md">
+          <a href={app.url} className={styles.appIcon}>
+            <img
+              className="rounded-circle img-fluid img-thumbnail"
+              src={app.icon_url}
+              alt={app.name}
+            />
+          </a>
+        </div>
+        <div className="col-lg-10 col-sm-9">
+          <h4>{app.name}</h4>
+          <p>{app.description}</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+class AppsContainer extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      appsData: null,
+      isLoading: true,
+      isError: false,
+      errorMessage: '',
+    };
+  }
+
+  componentWillMount() {
+    const config = {
+      transformResponse: [
+        (data) => {
+          // Remove "callback(" prefix and ")" suffix in apps "json" file
+          // so that resulting string is parsable JSON. Then parse it.
+
+          if (!(typeof data === 'string' || data instanceof String)) {
+            // Not a string. Maybe the json file is actually json now?
+            return data;
+          }
+
+          const prefix = 'callback(';
+          const suffix = ')';
+          let trimmedData = data.trim(); // data might have a trailing newline
+          if (trimmedData.startsWith(prefix)) trimmedData = trimmedData.slice(prefix.length);
+          if (trimmedData.endsWith(suffix)) trimmedData = trimmedData.slice(0, -suffix.length);
+          return JSON.parse(trimmedData);
+        },
+      ],
+    };
+
+    axios.get(APPS_URL, config)
+      .then((response) => {
+        this.setState({
+          appsData: response.data,
+          isLoading: false,
+        });
+      })
+      .catch((err) => {
+        this.setState({
+          isError: true,
+          errorMessage: err.message,
+          isLoading: false,
+        });
+      });
+  }
+
+  render() {
+    return (
+      <StaticPage title="Apps">
+        <h2>Apps</h2>
+        <hr />
+        <p>A collection of NUS-related apps that may come in handy.</p>
+        <p>Have an NUS app that you want added to the list? Simply add it to
+          our <a href="https://github.com/nusmodifications/nusmods-apps">Apps repository</a>!</p>
+
+        {this.state.isLoading && <Loader />}
+        {this.state.isError &&
+          <div className="alert alert-danger">
+            <strong>Something went wrong!</strong>
+            {this.state.errorMessage}
+          </div>
+        }
+        {this.state.appsData && this.state.appsData.map(app => <AppEntry key={app.name} app={app} />)}
+      </StaticPage>
+    );
+  }
+}
+
+export default AppsContainer;

--- a/v3/src/js/views/static/AppsContainer.jsx
+++ b/v3/src/js/views/static/AppsContainer.jsx
@@ -47,6 +47,7 @@ function AppEntry({ app }: AppEntryProps) {
         <div className="col-lg-10 col-sm-9">
           <h4>{app.name}</h4>
           <p>{app.description}</p>
+          {app.tags.map(tag => <span><span className="badge badge-info">{tag}</span> </span>)}
         </div>
       </div>
     </section>

--- a/v3/src/js/views/static/AppsContainer.scss
+++ b/v3/src/js/views/static/AppsContainer.scss
@@ -19,3 +19,7 @@
     text-align: center;
   }
 }
+
+.tagBadge:not(:last-child) {
+  margin-right: 3px;
+}

--- a/v3/src/js/views/static/AppsContainer.scss
+++ b/v3/src/js/views/static/AppsContainer.scss
@@ -7,6 +7,7 @@
   @include media-breakpoint-down(xs) {
     display: block;
     width: 128px;
+    text-align: center;
   }
 }
 
@@ -16,7 +17,6 @@
 
   @include media-breakpoint-down(xs) {
     margin: 3rem 0;
-    text-align: center;
   }
 }
 

--- a/v3/src/js/views/static/AppsContainer.scss
+++ b/v3/src/js/views/static/AppsContainer.scss
@@ -1,0 +1,25 @@
+@import "~utils/modules-entry";
+
+.heading {
+  margin: 3rem 0;
+}
+
+.appIcon {
+  max-width: 256px;
+  margin: 0 auto 1rem;
+
+  @include media-breakpoint-down(xs) {
+    display: block;
+    width: 128px;
+  }
+}
+
+.appEntry {
+  width: 100%;
+  margin: 2rem 0;
+
+  @include media-breakpoint-down(xs) {
+    margin: 3rem 0;
+    text-align: center;
+  }
+}

--- a/v3/src/js/views/static/AppsContainer.scss
+++ b/v3/src/js/views/static/AppsContainer.scss
@@ -1,9 +1,5 @@
 @import "~utils/modules-entry";
 
-.heading {
-  margin: 3rem 0;
-}
-
 .appIcon {
   max-width: 256px;
   margin: 0 auto 1rem;

--- a/v3/src/styles/bootstrap/bootstrap.scss
+++ b/v3/src/styles/bootstrap/bootstrap.scss
@@ -30,7 +30,7 @@
 // @import "~bootstrap/scss/card";
 // @import "~bootstrap/scss/breadcrumb";
 // @import "~bootstrap/scss/pagination";
-// @import "~bootstrap/scss/badge";
+@import "~bootstrap/scss/badge";
 // @import "~bootstrap/scss/jumbotron";
 // @import "~bootstrap/scss/alert";
 // @import "~bootstrap/scss/progress";


### PR DESCRIPTION
### Description

Closes #313. All existing functionality in the old V2 apps page has been replicated; only the filter suggested in the issue has yet to be implemented.

![localhost-8080-apps 1](https://user-images.githubusercontent.com/12784593/32686280-01033804-c6dd-11e7-9d13-9484c4b8fc2b.png)

The link to the new Apps page is in the footer between API and About.

![image](https://user-images.githubusercontent.com/12784593/32686327-fafba594-c6dd-11e7-84eb-e56a18cfb27f.png)

### Notes

- Enabled import of Bootstrap's badge scss
- Implementation is based heavily on DevelopersContainer and TeamContainer.

### Tasks

- [x] Display apps
- [x] Display app tags