### PR TITLE
Implement exam clash alert

### DIFF
--- a/v3/src/js/utils/timetables.js
+++ b/v3/src/js/utils/timetables.js
@@ -19,7 +19,7 @@ import type {
 import type { ModulesMap } from 'reducers/entities/moduleBank';
 
 import _ from 'lodash';
-import { getModuleTimetable } from 'utils/modules';
+import { getModuleTimetable, getModuleSemExamDate } from 'utils/modules';
 
 type LessonTypeAbbrev = { [LessonType]: string };
 export const LESSON_TYPE_ABBREV: LessonTypeAbbrev = {
@@ -196,4 +196,26 @@ export function colorLessonsByType(lessons: Lesson[]) {
 
     return { ...lesson, colorIndex };
   });
+}
+
+// Find all exam clashes between modules in semester
+// Returns object associating exam dates with the modules clashing on those dates
+export function findExamClashes(modules: Array<Module>, semester: Semester): { string: Array<Module> } {
+  const examDates = modules
+    .map(module => getModuleSemExamDate(module, semester))
+    .filter(date => date !== '-');
+  const uniqueExamDates = _.uniq(examDates);
+
+  // Iteratively remove unique exam dates from exam dates.
+  // Not using library/lodash diff functions since they remove
+  // _all_ instances of a unique exam date from examDates.
+  const duplicateDates = examDates; // Array eventually containing clashing exam dates
+  for (let i = 0; i < uniqueExamDates.length; i++) {
+    _.pullAt(duplicateDates, duplicateDates.indexOf(uniqueExamDates[i]));
+  }
+
+  // Fetch modules having exams on the clash dates
+  const clashingModules = duplicateDates.map(date =>
+    modules.filter(module => date === getModuleSemExamDate(module, semester)));
+  return _.zipObject(duplicateDates, clashingModules);
 }

--- a/v3/src/js/utils/timetables.test.js
+++ b/v3/src/js/utils/timetables.test.js
@@ -31,12 +31,19 @@ import {
   lessonsForLessonType,
   randomModuleLessonConfig,
   timetableLessonsArray,
+  findExamClashes,
 } from 'utils/timetables';
 import {
   getModuleTimetable,
 } from 'utils/modules';
 
+/** @var {Module} */
 import cs1010s from '__mocks__/modules/CS1010S.json';
+/** @var {Module} */
+import cs3216 from '__mocks__/modules/CS3216.json';
+/** @var {Module} */
+import pc1222 from '__mocks__/modules/PC1222.json';
+
 import timetable from '__mocks__/sem-timetable.json';
 import lessonsArray from '__mocks__/lessons-array.json';
 
@@ -295,3 +302,17 @@ test('areOtherClassesAvailable', () => {
   expect(areOtherClassesAvailable(lessons3, 'Lecture')).toBe(false);
   expect(areOtherClassesAvailable(lessons3, 'Tutorial')).toBe(true);
 });
+
+test('findExamClashes should return non-empty object if exams clash', () => {
+  const sem: Semester = 1;
+  const examClashes = findExamClashes([cs1010s, pc1222, cs3216], sem);
+  expect(Object.keys(examClashes)).toHaveLength(1);
+  expect(examClashes).toMatchSnapshot();
+});
+
+test('findExamClashes should return empty object if exams do not clash', () => {
+  const sem: Semester = 2;
+  const examClashes = findExamClashes([cs1010s, pc1222, cs3216], sem);
+  expect(examClashes).toEqual({});
+});
+

--- a/v3/src/js/utils/timetables.test.js
+++ b/v3/src/js/utils/timetables.test.js
@@ -35,6 +35,7 @@ import {
 } from 'utils/timetables';
 import {
   getModuleTimetable,
+  getModuleSemesterData,
 } from 'utils/modules';
 
 /** @var {Module} */
@@ -306,8 +307,8 @@ test('areOtherClassesAvailable', () => {
 test('findExamClashes should return non-empty object if exams clash', () => {
   const sem: Semester = 1;
   const examClashes = findExamClashes([cs1010s, pc1222, cs3216], sem);
-  expect(Object.keys(examClashes)).toHaveLength(1);
-  expect(examClashes).toMatchSnapshot();
+  const examDate = _.get(getModuleSemesterData(cs1010s, sem), 'ExamDate');
+  expect(examClashes).toEqual({ [examDate]: [cs1010s, pc1222] });
 });
 
 test('findExamClashes should return empty object if exams do not clash', () => {

--- a/v3/src/js/views/timetable/TimetableContainer.jsx
+++ b/v3/src/js/views/timetable/TimetableContainer.jsx
@@ -32,7 +32,7 @@ import {
   removeModule,
 } from 'actions/timetables';
 import { toggleTimetableOrientation } from 'actions/theme';
-import { getModuleTimetable, areLessonsSameClass } from 'utils/modules';
+import { getModuleTimetable, areLessonsSameClass, formatExamDate } from 'utils/modules';
 import {
   timetableLessonsArray,
   hydrateSemTimetableWithLessons,
@@ -157,20 +157,17 @@ class TimetableContainer extends Component<Props> {
     const nonClashingTable = renderModuleTable(moduleSections[NO_CLASH_SECTION_KEY]);
     delete moduleSections[NO_CLASH_SECTION_KEY];
 
-    // Render sections of clashing modules, with clashing dates in their headers
-    const clashingSections = Object.keys(moduleSections).sort().map(clashDate => (
-      <div key={clashDate}>
-        <h5>Clash on {clashDate}</h5>
-        {renderModuleTable(moduleSections[clashDate])}
-      </div>
-    ));
-
     return (
       <div>
         <div className="alert alert-danger" role="alert">
           <h4>Exam Clashes</h4>
           <p>There are <strong className="clash">clashes</strong> in your exam timetable.</p>
-          {clashingSections}
+          {Object.keys(moduleSections).sort().map(clashDate => (
+            <div key={clashDate}>
+              <h5>Clash on {formatExamDate(clashDate)}</h5>
+              {renderModuleTable(moduleSections[clashDate])}
+            </div>
+          ))}
         </div>
         {nonClashingTable}
       </div>

--- a/v3/src/styles/bootstrap/bootstrap.scss
+++ b/v3/src/styles/bootstrap/bootstrap.scss
@@ -32,7 +32,7 @@
 // @import "~bootstrap/scss/pagination";
 @import "~bootstrap/scss/badge";
 // @import "~bootstrap/scss/jumbotron";
-// @import "~bootstrap/scss/alert";
+@import "~bootstrap/scss/alert";
 // @import "~bootstrap/scss/progress";
 // @import "~bootstrap/scss/media";
 // @import "~bootstrap/scss/list-group";


### PR DESCRIPTION
Resolves #483.

<img width="769" alt="screen shot 2017-11-16 at 6 10 13 pm" src="https://user-images.githubusercontent.com/12784593/32926498-7f4a4ce4-cb82-11e7-8177-f3e9a2cbb6ef.png">

* Displays alert when there are modules which have clashing exam dates/times
* Displays clashing modules grouped by their exam date/times. This makes it easier for the user to resolve clashes. The clashing modules are displayed in the alert itself so that the user can interact with the modules directly.
* Ignores modules without exams
* Handles multiple clashing dates
* Handles >2 clashing modules on any date
* Preserves existing effective behavior when no clashes are present

Unit tests included for the new function that finds exam clashes. Also enabled import of Bootstrap's alerts SCSS.