### PR TITLE
Fix module page infinite loading bug 

### DIFF
--- a/v3/.babelrc
+++ b/v3/.babelrc
@@ -34,7 +34,8 @@
     },
     "test": {
       "plugins": [
-        "transform-es2015-modules-commonjs"
+        "transform-es2015-modules-commonjs",
+        "dynamic-import-node"
       ],
     },
   },

--- a/v3/package.json
+++ b/v3/package.json
@@ -26,6 +26,7 @@
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.1",
+    "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/v3/src/js/views/browse/ModulePageContainer.jsx
+++ b/v3/src/js/views/browse/ModulePageContainer.jsx
@@ -16,7 +16,9 @@ import ErrorPage from 'views/errors/ErrorPage';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import { modulePagePath } from 'utils/modules';
 
-type Props = ContextRouter & {
+type Props = {
+  ...ContextRouter,
+
   moduleCode: ModuleCode,
   moduleCodes: ModuleCodeMap,
   module: ?Module,
@@ -106,11 +108,11 @@ export class ModulePageContainerComponent extends PureComponent<Props, State> {
 }
 
 const mapStateToProps = (state, ownState) => {
-  const moduleCode = ownState.match.params.moduleCode;
+  const moduleCode = ownState.match.params.moduleCode.toUpperCase();
   const requestName = getRequestName(FETCH_MODULE);
 
   return {
-    moduleCode: moduleCode.toUpperCase(),
+    moduleCode,
     moduleCodes: state.entities.moduleBank.moduleCodes,
     module: state.entities.moduleBank.modules[moduleCode],
     request: state.requests[requestName],

--- a/v3/src/js/views/browse/ModulePageContainer.test.jsx
+++ b/v3/src/js/views/browse/ModulePageContainer.test.jsx
@@ -1,0 +1,77 @@
+// @flow
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { noop } from 'lodash';
+import { Redirect } from 'react-router-dom';
+
+import createHistory from 'history/createMemoryHistory'; // eslint-disable-line import/no-extraneous-dependencies
+
+import type { ModuleCodeMap, FetchRequest } from 'types/reducers';
+import type { Module, ModuleCode } from 'types/modules';
+
+/* @var {Module} */
+import cs1010s from '__mocks__/modules/CS1010S.json';
+import NotFoundPage from 'views/errors/NotFoundPage';
+import LoadingSpinner from 'views/components/LoadingSpinner';
+import { ModulePageContainerComponent } from './ModulePageContainer';
+
+const CANONICAL = '/modules/CS1010S/programming-methodology';
+const MODULE_CODE_MAP: ModuleCodeMap = {
+  CS1010S: {
+    ModuleCode: 'CS1010S',
+    ModuleTitle: 'Programming Methodology',
+    Semesters: [1, 2],
+  },
+};
+
+function make(
+  moduleCode: ModuleCode,
+  url: string,
+  module: ?Module = null,
+  request: ?FetchRequest = null,
+  fetchModule: (ModuleCode) => void = noop,
+) {
+  const history = createHistory();
+  const mockMatch = {
+    url,
+    path: url,
+    isExact: true,
+    params: {},
+  };
+
+  return shallow(
+    <ModulePageContainerComponent
+      moduleCode={moduleCode}
+      moduleCodes={MODULE_CODE_MAP}
+      module={module}
+      request={request}
+      fetchModule={fetchModule}
+
+      history={history}
+      location={history.location}
+      match={mockMatch}
+    />,
+  );
+}
+
+function assertRedirect(component, redirectTo = CANONICAL) {
+  expect(component.type()).toEqual(Redirect);
+  expect(component.props()).toMatchObject({ to: redirectTo });
+}
+
+test('should show 404 page when the module code does not exist', () => {
+  expect(make('CS1234', '/modules/CS1234').type()).toEqual(NotFoundPage);
+});
+
+test('should redirect to canonical URL', () => {
+  assertRedirect(make('CS1010S', '/modules/cs1010s/programming-methodology', cs1010s));
+  assertRedirect(make('CS1010S', '/modules/CS1010S', cs1010s));
+});
+
+test('should fetch module if it is not in the module bank', () => {
+  const fetchModule = jest.fn();
+  const component = make('CS1010S', CANONICAL, null, null, fetchModule);
+  expect(component.type()).toEqual(LoadingSpinner);
+  expect(fetchModule).toBeCalledWith('CS1010S');
+});

--- a/v3/yarn.lock
+++ b/v3/yarn.lock
@@ -559,6 +559,12 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-dynamic-import-node@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.2.0.tgz#f91631e703e0595e47d4beafbb088576c87fbeee"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+
 babel-plugin-istanbul@^4.0.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.3.tgz#6ee6280410dcf59c7747518c3dfd98680958f102"


### PR DESCRIPTION
When a modules page URL uses lowercase module code, eg. https://latest.nusmods.com/modules/cs1101s the page never stops loading because of a small bug in how lowercase module code is handled. 

This PR fixes the bug, and adds some unit tests (which doesn't actually help with the bug in question since the bug happened in `mapStateToProps`, but I thought it might be useful to have them anyway). 