### PR TITLE
Additional sharing options and short URL support 

### DIFF
--- a/v3/flow-typed/package-dep-libdefs.js
+++ b/v3/flow-typed/package-dep-libdefs.js
@@ -24,10 +24,10 @@ declare module 'react-modal' {
   declare module.exports: any;
 }
 
-declare module 'react-scrollspy' {
+declare module 'react-qr-svg' {
   declare module.exports: any;
 }
 
-declare module 'select' {
+declare module 'react-scrollspy' {
   declare module.exports: any;
 }

--- a/v3/package.json
+++ b/v3/package.json
@@ -120,8 +120,7 @@
     "react-virtualized-select": "^3.1.0",
     "react-waypoint": "^7.0.4",
     "redux": "^3.7.2",
-    "redux-thunk": "^2.2.0",
-    "select": "^1.1.2"
+    "redux-thunk": "^2.2.0"
   },
   "browserslist": [
     "last 2 versions",

--- a/v3/package.json
+++ b/v3/package.json
@@ -113,6 +113,7 @@
     "react-helmet": "^5.2.0",
     "react-loadable": "^4.0.4",
     "react-modal": "^3.1.7",
+    "react-qr-svg": "^2.1.0",
     "react-redux": "^5.0.5",
     "react-router-dom": "^4.1.2",
     "react-scrollspy": "^3.3.4",

--- a/v3/src/js/views/components/Modal.scss
+++ b/v3/src/js/views/components/Modal.scss
@@ -6,13 +6,16 @@
   right: 1rem;
   left: 1rem;
   max-width: 40rem;
+  max-height: calc(90%);
   padding: 2rem;
   margin: 0 auto;
+  overflow: auto;
   background: var(--body-bg);
   box-shadow: 0 6px 24px rgba(#000, 0.18);
 
   @include media-breakpoint-down(sm) {
-    top: 4rem;
+    top: 1rem;
+    padding: 1rem;
   }
 }
 

--- a/v3/src/js/views/components/icons/index.js
+++ b/v3/src/js/views/components/icons/index.js
@@ -11,7 +11,7 @@ import Facebook from 'react-feather/dist/icons/facebook';
 import GitHub from 'react-feather/dist/icons/github';
 import Image from 'react-feather/dist/icons/image';
 import Map from 'react-feather/dist/icons/map';
-import Mail from 'react-feather/dist/icons/mail'
+import Mail from 'react-feather/dist/icons/mail';
 import MinusSquare from 'react-feather/dist/icons/minus-square';
 import PlusSquare from 'react-feather/dist/icons/plus-square';
 import Repeat from 'react-feather/dist/icons/repeat';

--- a/v3/src/js/views/components/icons/index.js
+++ b/v3/src/js/views/components/icons/index.js
@@ -11,9 +11,10 @@ import Facebook from 'react-feather/dist/icons/facebook';
 import GitHub from 'react-feather/dist/icons/github';
 import Image from 'react-feather/dist/icons/image';
 import Map from 'react-feather/dist/icons/map';
-import Repeat from 'react-feather/dist/icons/repeat';
+import Mail from 'react-feather/dist/icons/mail'
 import MinusSquare from 'react-feather/dist/icons/minus-square';
 import PlusSquare from 'react-feather/dist/icons/plus-square';
+import Repeat from 'react-feather/dist/icons/repeat';
 import Settings from 'react-feather/dist/icons/settings';
 import Search from 'react-feather/dist/icons/search';
 import Sidebar from 'react-feather/dist/icons/sidebar';
@@ -34,6 +35,7 @@ export {
   GitHub,
   Image,
   Map,
+  Mail,
   LinkedIn,
   Repeat,
   MinusSquare,

--- a/v3/src/js/views/timetable/ShareTimetable.jsx
+++ b/v3/src/js/views/timetable/ShareTimetable.jsx
@@ -2,7 +2,6 @@
 
 import React, { PureComponent } from 'react';
 import classnames from 'classnames';
-import select from 'select';
 
 import type { SemTimetableConfig } from 'types/timetables';
 import type { Semester } from 'types/modules';
@@ -28,16 +27,24 @@ export default class ShareTimetable extends PureComponent<Props, State> {
 
   state: State = {
     isOpen: false,
-    action: 'sync',
   };
 
   openModal = () => this.setState({ isOpen: true });
   closeModal = () => this.setState({ isOpen: false });
 
   copyText = () => {
-    if (this.urlInput) {
-      select(this.urlInput);
-      document.execCommand('copy');
+    const input = this.urlInput;
+
+    if (input) {
+      input.select();
+      input.setSelectionRange(0, input.value.length);
+
+      // TODO: Inform the user copy succeeded through the UI, and prompt the user
+      // to manually copy if execCommand fails. Mobile Safari currently doesn't support
+      // execCommand('copy')
+      if (document.execCommand('copy')) {
+        input.blur();
+      }
     }
   };
 

--- a/v3/src/js/views/timetable/ShareTimetable.jsx
+++ b/v3/src/js/views/timetable/ShareTimetable.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { QRCode } from 'react-qr-svg';
 import classnames from 'classnames';
 
 import type { SemTimetableConfig } from 'types/timetables';
@@ -90,6 +91,22 @@ export default class ShareTimetable extends PureComponent<Props, State> {
                 <Copy className={styles.copyIcon} />
               </button>
             </span>
+          </div>
+
+          <div className="row">
+            <div className="col-sm-4">
+              <h3 className={styles.shareHeading}>QR Code</h3>
+
+              <div className={styles.qrCode}>
+                <QRCode value={url} />
+              </div>
+            </div>
+            <div className="col-sm-4">
+              <h3 className={styles.shareHeading}>Via email</h3>
+            </div>
+            <div className="col-sm-4">
+              <h3 className={styles.shareHeading}>Via messaging apps</h3>
+            </div>
           </div>
         </Modal>
       </div>

--- a/v3/src/js/views/timetable/ShareTimetable.jsx
+++ b/v3/src/js/views/timetable/ShareTimetable.jsx
@@ -3,14 +3,15 @@
 import React, { PureComponent } from 'react';
 import { QRCode } from 'react-qr-svg';
 import classnames from 'classnames';
+import qs from 'query-string';
 
 import type { SemTimetableConfig } from 'types/timetables';
 import type { Semester } from 'types/modules';
 
 import { absolutePath, timetableShare } from 'views/routes/paths';
-import { Repeat, Copy } from 'views/components/icons';
+import { Repeat, Copy, Mail } from 'views/components/icons';
 import Modal from 'views/components/Modal';
-
+import config from 'config';
 import styles from './ShareTimetable.scss';
 import actionStyles from './TimetableActions.scss';
 
@@ -54,6 +55,17 @@ export default class ShareTimetable extends PureComponent<Props, State> {
     const { semester, timetable } = this.props;
     const url = absolutePath(timetableShare(semester, timetable));
 
+    const mailto = `mailto:?${qs.stringify({
+      subject: 'NUSMods timetable',
+      body: `My timetable for ${config.academicYear} ${config.semesterNames[semester]} can be found at ${url}`,
+    })}`;
+
+    const whatsApp = `https://api.whatsapp.com/send?${qs.stringify({
+      text: `My timetable: ${url}`,
+    })}`;
+
+    const telegram = `https://t.me/share/url?${qs.stringify({ url })}`;
+
     return (
       <div>
         <button
@@ -88,7 +100,7 @@ export default class ShareTimetable extends PureComponent<Props, State> {
                 aria-label="Copy URL"
                 onClick={this.copyText}
               >
-                <Copy className={styles.copyIcon} />
+                <Copy className={styles.icon} />
               </button>
             </span>
           </div>
@@ -103,9 +115,28 @@ export default class ShareTimetable extends PureComponent<Props, State> {
             </div>
             <div className="col-sm-4">
               <h3 className={styles.shareHeading}>Via email</h3>
+
+              <a
+                className="btn btn-outline-primary btn-block"
+                href={mailto}
+              ><Mail className={styles.icon} /> Send Email</a>
             </div>
             <div className="col-sm-4">
               <h3 className={styles.shareHeading}>Via messaging apps</h3>
+
+              <a
+                className="btn btn-outline-primary btn-block"
+                href={whatsApp}
+                target="_blank"
+                rel="noreferrer noopener"
+              >WhatsApp</a>
+
+              <a
+                className="btn btn-outline-primary btn-block"
+                href={telegram}
+                target="_blank"
+                rel="noreferrer noopener"
+              >Telegram</a>
             </div>
           </div>
         </Modal>

--- a/v3/src/js/views/timetable/ShareTimetable.jsx
+++ b/v3/src/js/views/timetable/ShareTimetable.jsx
@@ -18,7 +18,10 @@ import LoadingSpinner from 'views/components/LoadingSpinner';
 import styles from './ShareTimetable.scss';
 import actionStyles from './TimetableActions.scss';
 
-type CopyState = 'not copied' | 'success' | 'fail';
+type CopyState = 'NOT_COPIED' | 'COPY_SUCCESS' | 'COPY_FAIL';
+const NOT_COPIED: CopyState = 'NOT_COPIED';
+const COPY_SUCCESS: CopyState = 'COPY_SUCCESS';
+const COPY_FAIL: CopyState = 'COPY_FAIL';
 
 type Props = {
   semester: Semester,
@@ -41,18 +44,17 @@ export default class ShareTimetable extends PureComponent<Props, State> {
 
   state: State = {
     isOpen: false,
-    urlCopied: 'not copied',
+    urlCopied: NOT_COPIED,
     shortUrl: null,
   };
 
   loadShortUrl(url: string) {
-    return axios.get('https://nusmods.com/short_url.php', { data: { url } })
+    return axios.get('https://nusmods.com/short_url.php', { data: { url }, timeout: 2000 })
       .then(({ data }) => this.setState({ shortUrl: data.shortUrl }))
       // Cannot get short URL - just use long URL instead
       .catch(() => this.setState({ shortUrl: url }));
   }
 
-  // Event handlers
   openModal = () => {
     const { semester, timetable } = this.props;
     const nextUrl = shareUrl(semester, timetable);
@@ -68,7 +70,7 @@ export default class ShareTimetable extends PureComponent<Props, State> {
 
   closeModal = () => this.setState({
     isOpen: false,
-    urlCopied: 'not copied',
+    urlCopied: NOT_COPIED,
   });
 
   copyText = () => {
@@ -80,9 +82,9 @@ export default class ShareTimetable extends PureComponent<Props, State> {
 
       if (document.execCommand('copy')) {
         input.blur();
-        this.setState({ urlCopied: 'success' });
+        this.setState({ urlCopied: COPY_SUCCESS });
       } else {
-        this.setState({ urlCopied: 'fail' });
+        this.setState({ urlCopied: COPY_FAIL });
       }
     }
   };
@@ -110,8 +112,10 @@ export default class ShareTimetable extends PureComponent<Props, State> {
             </button>
           </span>
 
-          {this.state.urlCopied === 'success' && <p className={styles.copyStatus}>Link copied!</p>}
-          {this.state.urlCopied === 'fail' && <p className={styles.copyStatus}>Press Cmd + C to copy</p>}
+          {this.state.urlCopied === COPY_SUCCESS &&
+            <p className={styles.copyStatus}>Link copied!</p>}
+          {this.state.urlCopied === COPY_FAIL &&
+            <p className={styles.copyStatus}>Press Cmd/Ctrl + C to copy</p>}
         </div>
 
         <div className="row">

--- a/v3/src/js/views/timetable/ShareTimetable.scss
+++ b/v3/src/js/views/timetable/ShareTimetable.scss
@@ -13,8 +13,33 @@
     font-weight: $font-weight-bold;
     font-size: 1.4rem;
   }
+
+  @include media-breakpoint-down(sm) {
+    br {
+      display: none;
+    }
+  }
 }
 
 .copyIcon {
   vertical-align: middle;
+}
+
+.shareHeading {
+  margin: 1rem 0 0.5rem;
+  font-weight: bold;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.qrCode {
+  max-width: 12rem;
+  padding: 0.2rem;
+  margin: 0 auto;
+  background: #fff;
+
+  svg {
+    display: block;
+    margin: 0;
+  }
 }

--- a/v3/src/js/views/timetable/ShareTimetable.scss
+++ b/v3/src/js/views/timetable/ShareTimetable.scss
@@ -21,7 +21,7 @@
   }
 }
 
-.copyIcon {
+.icon {
   vertical-align: middle;
 }
 

--- a/v3/src/js/views/timetable/ShareTimetable.scss
+++ b/v3/src/js/views/timetable/ShareTimetable.scss
@@ -6,6 +6,7 @@
   svg {
     width: 5rem;
     height: 5rem;
+    color: theme-color('success');
   }
 
   h3 {
@@ -18,6 +19,25 @@
     br {
       display: none;
     }
+  }
+}
+
+.linkInputGroup {
+  // Leave some space for the copy status
+  margin-bottom: 2rem;
+}
+
+.copyStatus {
+  position: absolute;
+  right: 0;
+  bottom: -2rem;
+  left: 0;
+  margin: 0;
+  text-align: center;
+  color: theme-color('success');
+
+  :global {
+    animation: fadeIn 0.2s forwards;
   }
 }
 

--- a/v3/src/js/views/timetable/ShareTimetable.test.jsx
+++ b/v3/src/js/views/timetable/ShareTimetable.test.jsx
@@ -8,63 +8,65 @@ import Modal from 'views/components/Modal';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import ShareTimetable from './ShareTimetable';
 
-// Mock axios to stop it from firing API requests
-beforeEach(() => {
-  jest.spyOn(axios, 'get')
-    .mockReturnValue(Promise.resolve({ data: { shortUrl: '' } }));
-});
+describe('ShareTimetable', () => {
+  // Mock axios to stop it from firing API requests
+  beforeEach(() => {
+    jest.spyOn(axios, 'get')
+      .mockReturnValue(Promise.resolve({ data: { shortUrl: '' } }));
+  });
 
-afterEach(() => {
-  axios.get.mockRestore();
-});
+  afterEach(() => {
+    axios.get.mockRestore();
+  });
 
-const timetable = {
-  CS1010S: {
-    Lecture: '1',
-  },
-};
+  const timetable = {
+    CS1010S: {
+      Lecture: '1',
+    },
+  };
 
-const openModal = wrapper => wrapper.find('button').simulate('click');
-const closeModal = wrapper => wrapper.find(Modal).first().props().onRequestClose();
+  const openModal = wrapper => wrapper.find('button').simulate('click');
+  const closeModal = wrapper => wrapper.find(Modal).first().props().onRequestClose();
 
-test('should load short URL when the modal is opened', () => {
-  const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
-  expect(axios.get).not.toHaveBeenCalled();
+  test('should load short URL when the modal is opened', () => {
+    const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
+    expect(axios.get).not.toHaveBeenCalled();
 
-  openModal(wrapper);
-  expect(wrapper.find(Modal).exists()).toBe(true);
-  expect(axios.get).toHaveBeenCalledTimes(1);
-});
+    openModal(wrapper);
+    expect(wrapper.find(Modal).exists()).toBe(true);
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
 
-test('should cache short URL from the API', () => {
-  const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
+  test('should cache short URL from the API', () => {
+    const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
 
-  // Open, close and open the modal again
-  openModal(wrapper);
-  closeModal(wrapper);
-  openModal(wrapper);
+    // Open, close and open the modal again
+    openModal(wrapper);
+    closeModal(wrapper);
+    openModal(wrapper);
 
-  // The second open should not cause a second call
-  expect(axios.get).toHaveBeenCalledTimes(1);
-  closeModal(wrapper);
+    // The second open should not cause a second call
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    closeModal(wrapper);
 
-  // Changing the timetable should cause opening the modal to trigger another API call
-  wrapper.setProps({ timetable: { CS3216: { Lecture: '1' } } });
-  expect(axios.get).toHaveBeenCalledTimes(1);
-  openModal(wrapper);
-  expect(axios.get).toHaveBeenCalledTimes(2);
-  closeModal(wrapper);
+    // Changing the timetable should cause opening the modal to trigger another API call
+    wrapper.setProps({ timetable: { CS3216: { Lecture: '1' } } });
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    openModal(wrapper);
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    closeModal(wrapper);
 
-  // Changing the semester should also trigger another API call
-  wrapper.setProps({ semester: 2 });
-  expect(axios.get).toHaveBeenCalledTimes(2);
-  openModal(wrapper);
-  expect(axios.get).toHaveBeenCalledTimes(3);
-});
+    // Changing the semester should also trigger another API call
+    wrapper.setProps({ semester: 2 });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+    openModal(wrapper);
+    expect(axios.get).toHaveBeenCalledTimes(3);
+  });
 
-test('should show spinner when loading', () => {
-  const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
+  test('should show spinner when loading', () => {
+    const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
 
-  openModal(wrapper);
-  expect(wrapper.find(LoadingSpinner).exists()).toBe(true);
+    openModal(wrapper);
+    expect(wrapper.find(LoadingSpinner).exists()).toBe(true);
+  });
 });

--- a/v3/src/js/views/timetable/ShareTimetable.test.jsx
+++ b/v3/src/js/views/timetable/ShareTimetable.test.jsx
@@ -1,0 +1,70 @@
+// @flow
+
+import React from 'react';
+import axios from 'axios';
+import { shallow } from 'enzyme';
+
+import Modal from 'views/components/Modal';
+import LoadingSpinner from 'views/components/LoadingSpinner';
+import ShareTimetable from './ShareTimetable';
+
+// Mock axios to stop it from firing API requests
+beforeEach(() => {
+  jest.spyOn(axios, 'get')
+    .mockReturnValue(Promise.resolve({ data: { shortUrl: '' } }));
+});
+
+afterEach(() => {
+  axios.get.mockRestore();
+});
+
+const timetable = {
+  CS1010S: {
+    Lecture: '1',
+  },
+};
+
+const openModal = wrapper => wrapper.find('button').simulate('click');
+const closeModal = wrapper => wrapper.find(Modal).first().props().onRequestClose();
+
+test('should load short URL when the modal is opened', () => {
+  const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
+  expect(axios.get).not.toHaveBeenCalled();
+
+  openModal(wrapper);
+  expect(wrapper.find(Modal).exists()).toBe(true);
+  expect(axios.get).toHaveBeenCalledTimes(1);
+});
+
+test('should cache short URL from the API', () => {
+  const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
+
+  // Open, close and open the modal again
+  openModal(wrapper);
+  closeModal(wrapper);
+  openModal(wrapper);
+
+  // The second open should not cause a second call
+  expect(axios.get).toHaveBeenCalledTimes(1);
+  closeModal(wrapper);
+
+  // Changing the timetable should cause opening the modal to trigger another API call
+  wrapper.setProps({ timetable: { CS3216: { Lecture: '1' } } });
+  expect(axios.get).toHaveBeenCalledTimes(1);
+  openModal(wrapper);
+  expect(axios.get).toHaveBeenCalledTimes(2);
+  closeModal(wrapper);
+
+  // Changing the semester should also trigger another API call
+  wrapper.setProps({ semester: 2 });
+  expect(axios.get).toHaveBeenCalledTimes(2);
+  openModal(wrapper);
+  expect(axios.get).toHaveBeenCalledTimes(3);
+});
+
+test('should show spinner when loading', () => {
+  const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
+
+  openModal(wrapper);
+  expect(wrapper.find(LoadingSpinner).exists()).toBe(true);
+});

--- a/v3/yarn.lock
+++ b/v3/yarn.lock
@@ -5995,6 +5995,10 @@ q@^1.1.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 
+qr.js@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"
+
 qs@6.4.0, qs@^6.0.2, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
@@ -6167,6 +6171,13 @@ react-proxy@^3.0.0-alpha.0:
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
   dependencies:
     lodash "^4.6.1"
+
+react-qr-svg@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-qr-svg/-/react-qr-svg-2.1.0.tgz#fceaf0e8bd367f714d89ae46e46b87c5201a99e9"
+  dependencies:
+    prop-types "^15.5.8"
+    qr.js "0.0.0"
 
 react-redux@^5.0.5:
   version "5.0.5"

--- a/v3/yarn.lock
+++ b/v3/yarn.lock
@@ -6710,10 +6710,6 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
-select@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
-
 selfsigned@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.9.1.tgz#cdda4492d70d486570f87c65546023558e1dfa5a"


### PR DESCRIPTION
This PR adds sharing via QR code, email, Telegram and WhatsApp. Additionally, the modal will attempt to shorten the timetable URL when it is opened. 

![screenshot from 2017-12-15 12-10-25](https://user-images.githubusercontent.com/445650/34026421-f4a7dd2a-e190-11e7-8808-a16c6a4a8585.png)

If the shortener service is not available for whatever reason, the original URL will be shown instead. 

### Next steps 

- Load all of the timetable actions asynchronously to improve initial page loading time 
- Add animation/transitions 
- Switch to Font Awesome 5 so we can have access to more icons 