### PR TITLE
Fix module side menu highlighting

### DIFF
--- a/v3/src/js/views/modules/ModulePageContent.jsx
+++ b/v3/src/js/views/modules/ModulePageContent.jsx
@@ -194,8 +194,9 @@ class ModulePageContentComponent extends Component<Props> {
           <aside className="col-md-3">
             <nav className="module-side-menu">
               <ScrollSpy
-                items={['details', 'prerequisites', 'bidding-stats', 'timetable', 'reviews']}
+                items={['details', 'prerequisites', 'timetable', 'bidding-stats', 'reviews']}
                 currentClassName="scroll-menu-link-active"
+                offset={-130}
               >
                 <li><a href="#details">Details</a></li>
                 <li><a href="#prerequisites">Prerequisites</a></li>


### PR DESCRIPTION
Fixes #516.

Clicking the Prerequisites button still highlights Timetable, as the Prerequisites section is too short (since it's not yet implemented). As long as it is eventually >40px tall, there will be no issues.

I tried setting an offset proportional to `window.innerHeight` as well, but it felt weird, so a constant offset it is.