### PR TITLE
Stop HistoryDebouncer when the incoming path is same as current path

### DIFF
--- a/v3/src/js/utils/HistoryDebouncer.test.js
+++ b/v3/src/js/utils/HistoryDebouncer.test.js
@@ -1,74 +1,95 @@
 // @flow
 
+import createHistory from 'history/createMemoryHistory'; // eslint-disable-line import/no-extraneous-dependencies
 import HistoryDebouncer from './HistoryDebouncer';
 
-function createHistoryMock() {
-  return {
-    push: jest.fn(),
-    replace: jest.fn(),
-  };
-}
+describe('HistoryDebouncer', () => {
+  function createHistoryMock(initialEntries = []) {
+    const history = createHistory(initialEntries);
+    jest.spyOn(history, 'push');
+    jest.spyOn(history, 'replace');
 
-beforeEach(() => {
-  jest.spyOn(Date, 'now')
-    .mockReturnValue(0);
-});
+    return history;
+  }
 
-afterEach(() => {
-  Date.now.mockRestore();
-});
+  beforeEach(() => {
+    jest.spyOn(Date, 'now')
+      .mockReturnValue(0);
+  });
 
-test('HistoryDebouncer should call history.push() at the leading edge', () => {
-  const mock = createHistoryMock();
-  const history = new HistoryDebouncer(mock);
+  afterEach(() => {
+    Date.now.mockRestore();
+  });
 
-  history.push('test-1');
-  Date.now.mockReturnValue(30.1 * 1000);
-  history.push('test-2', { test: 'state' });
+  test('should call history.push() at the leading edge', () => {
+    const mock = createHistoryMock();
+    const history = new HistoryDebouncer(mock);
 
-  expect(mock.push.mock.calls).toEqual([
-    ['test-1', undefined],
-    ['test-2', { test: 'state' }],
-  ]);
-  expect(mock.replace).not.toBeCalled();
-});
+    history.push('test-1');
+    Date.now.mockReturnValue(30.1 * 1000);
+    history.push('test-2', { test: 'state' });
 
-test('HistoryDebouncer should call history.replace() within wait', () => {
-  const mock = createHistoryMock();
-  const history = new HistoryDebouncer(mock);
+    expect(mock.push.mock.calls).toEqual([
+      ['test-1', undefined],
+      ['test-2', { test: 'state' }],
+    ]);
+    expect(mock.replace).not.toBeCalled();
+  });
 
-  history.push('test-1');
+  test('should call history.replace() within wait', () => {
+    const mock = createHistoryMock();
+    const history = new HistoryDebouncer(mock);
 
-  Date.now.mockReturnValue(2 * 1000);
-  history.push('test-2', { test: 'state' });
+    history.push('test-1');
 
-  Date.now.mockReturnValue(30.1 * 1000);
-  history.push('test-3');
+    Date.now.mockReturnValue(2 * 1000);
+    history.push('test-2', { test: 'state' });
 
-  Date.now.mockReturnValue(62.2 * 1000);
-  history.push('test-4');
+    Date.now.mockReturnValue(30.1 * 1000);
+    history.push('test-3');
 
-  expect(mock.push.mock.calls).toEqual([
-    ['test-1', undefined],
-    ['test-4', undefined],
-  ]);
+    Date.now.mockReturnValue(62.2 * 1000);
+    history.push('test-4');
 
-  expect(mock.replace.mock.calls).toEqual([
-    ['test-2', { test: 'state' }],
-    ['test-3', undefined],
-  ]);
-});
+    expect(mock.push.mock.calls).toEqual([
+      ['test-1', undefined],
+      ['test-4', undefined],
+    ]);
 
-test('HistoryDebouncer should accept a wait time as second parameter', () => {
-  const mock = createHistoryMock();
-  const history = new HistoryDebouncer(mock, 10 * 1000);
+    expect(mock.replace.mock.calls).toEqual([
+      ['test-2', { test: 'state' }],
+      ['test-3', undefined],
+    ]);
+  });
 
-  history.push('test-1');
-  Date.now.mockReturnValue(10.1 * 1000);
-  history.push('test-2');
+  test('should accept a wait time as second parameter', () => {
+    const mock = createHistoryMock();
+    const history = new HistoryDebouncer(mock, 10 * 1000);
 
-  expect(mock.push.mock.calls).toEqual([
-    ['test-1', undefined],
-    ['test-2', undefined],
-  ]);
+    history.push('test-1');
+    Date.now.mockReturnValue(10.1 * 1000);
+    history.push('test-2');
+
+    expect(mock.push.mock.calls).toEqual([
+      ['test-1', undefined],
+      ['test-2', undefined],
+    ]);
+  });
+
+  test('should not navigate if the provided path is the same as the current one', () => {
+    const mock = createHistoryMock(['/']);
+    const history = new HistoryDebouncer(mock);
+
+    history.push('/');
+    expect(mock.push).not.toHaveBeenCalled();
+    expect(mock.replace).not.toHaveBeenCalled();
+
+    history.push('/new');
+    history.push({ path: '/new' });
+    expect(mock.replace).toHaveBeenCalledTimes(1);
+
+    history.push({ path: '/new', search: 'test=1' });
+    history.push('/new?test=1');
+    expect(mock.replace).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
This fixes #530. The bug was due to the fact that `history.push` will push items into the browser history even when they match the current path. This fixes that by simply ignoring any calls to `HistoryDebouncer#push` when the next path matches the current one. 

Importing `createHistory` from the transitive dependency history is necessary because the API doesn't expose the function we need to otherwise check that the path is the same. 