### PR TITLE
Fix iOS scrolling on sidemenu and other places 

### DIFF
--- a/v3/src/js/utils/no-scroll.js
+++ b/v3/src/js/utils/no-scroll.js
@@ -2,6 +2,11 @@
 
 import noScroll from 'no-scroll';
 
+/**
+ * Wrapper around the simple no-scroll package that also toggles a
+ * class on body because unfortunately toggling the no scroll styles
+ * also affects position: sticky elements
+ */
 export default function (active: boolean) {
   const { body } = document;
   if (!body) return;

--- a/v3/src/js/utils/no-scroll.js
+++ b/v3/src/js/utils/no-scroll.js
@@ -1,0 +1,16 @@
+// @flow
+
+import noScroll from 'no-scroll';
+
+export default function (active: boolean) {
+  const { body } = document;
+  if (!body) return;
+
+  if (active) {
+    noScroll.on();
+    body.classList.add('no-scroll');
+  } else {
+    noScroll.off();
+    body.classList.remove('no-scroll');
+  }
+}

--- a/v3/src/js/views/components/Modal.jsx
+++ b/v3/src/js/views/components/Modal.jsx
@@ -19,8 +19,11 @@ export default class Modal extends Component<Props> {
     noScroll(this.props.isOpen);
   }
 
-  componentDidUpdate() {
-    noScroll(this.props.isOpen);
+  // noScroll must trigger before actual opening of modal
+  componentWillUpdate(nextProps: Props) {
+    if (this.props.isOpen !== nextProps.isOpen) {
+      noScroll(nextProps.isOpen);
+    }
   }
 
   render() {

--- a/v3/src/js/views/components/Modal.jsx
+++ b/v3/src/js/views/components/Modal.jsx
@@ -3,8 +3,9 @@
 import React, { type Node, Component } from 'react';
 import ReactModal from 'react-modal';
 import classnames from 'classnames';
+
+import noScroll from 'utils/no-scroll';
 import styles from './Modal.scss';
-import noScroll from '../../utils/no-scroll';
 
 type Props = {
   isOpen: boolean,

--- a/v3/src/js/views/components/Modal.jsx
+++ b/v3/src/js/views/components/Modal.jsx
@@ -1,26 +1,38 @@
 // @flow
 
-import React, { type Node } from 'react';
+import React, { type Node, Component } from 'react';
 import ReactModal from 'react-modal';
 import classnames from 'classnames';
 import styles from './Modal.scss';
+import noScroll from '../../utils/no-scroll';
 
 type Props = {
+  isOpen: boolean,
   overlayClassName?: string,
   className?: string,
-  onRequestClose: Function,
   children: Node,
 };
 
-export default function ({ className, overlayClassName, children, onRequestClose, ...rest }: Props) {
-  return (
-    <ReactModal
-      onRequestClose={onRequestClose}
-      overlayClassName={classnames(styles.overlay, overlayClassName)}
-      className={classnames(styles.modal, className)}
-      {...rest}
-    >
-      {children}
-    </ReactModal>
-  );
+export default class Modal extends Component<Props> {
+  componentDidMount() {
+    noScroll(this.props.isOpen);
+  }
+
+  componentDidUpdate() {
+    noScroll(this.props.isOpen);
+  }
+
+  render() {
+    const { className, overlayClassName, children, ...rest } = this.props;
+
+    return (
+      <ReactModal
+        overlayClassName={classnames(styles.overlay, overlayClassName)}
+        className={classnames(styles.modal, className)}
+        {...rest}
+      >
+        {children}
+      </ReactModal>
+    );
+  }
 }

--- a/v3/src/js/views/components/Modal.scss
+++ b/v3/src/js/views/components/Modal.scss
@@ -22,9 +22,10 @@
   max-height: calc(100% - #{2 * $spacing});
   padding: 1rem;
   margin: 0 auto;
-  overflow: auto;
   background: var(--body-bg);
   box-shadow: 0 6px 24px rgba(#000, 0.18);
+
+  @include scrollable;
 
   @include media-breakpoint-up(md) {
     top: 10%;

--- a/v3/src/js/views/components/Modal.scss
+++ b/v3/src/js/views/components/Modal.scss
@@ -14,6 +14,7 @@
 .modal {
   $spacing: 1rem;
 
+  composes: scrollable from global;
   position: absolute;
   top: $spacing;
   right: $spacing;
@@ -24,8 +25,6 @@
   margin: 0 auto;
   background: var(--body-bg);
   box-shadow: 0 6px 24px rgba(#000, 0.18);
-
-  @include scrollable;
 
   @include media-breakpoint-up(md) {
     top: 10%;

--- a/v3/src/js/views/components/ModulesSelect.jsx
+++ b/v3/src/js/views/components/ModulesSelect.jsx
@@ -51,10 +51,7 @@ class ModulesSelect extends Component<Props, State> {
   /* Prevent iOS "Done" button from resetting input */
   onBlur = (e: Event) => { e.preventDefault(); };
   onOuterClick = () => this.setState({ isOpen: false });
-  toggleModal = () => {
-    const isModalOpen = !this.state.isModalOpen;
-    this.setState({ isModalOpen });
-  };
+  toggleModal = () => this.setState({ isModalOpen: !this.state.isModalOpen });
 
   getFilteredModules = (inputValue: string) => {
     if (!inputValue) {

--- a/v3/src/js/views/components/ModulesSelect.jsx
+++ b/v3/src/js/views/components/ModulesSelect.jsx
@@ -9,7 +9,6 @@ import { createSearchPredicate, sortModules } from 'utils/moduleSearch';
 import makeResponsive from 'views/hocs/makeResponsive';
 import Modal from 'views/components/Modal';
 import CloseButton from 'views/components/CloseButton';
-import noScroll from 'utils/no-scroll';
 
 import styles from './ModulesSelect.scss';
 
@@ -54,7 +53,7 @@ class ModulesSelect extends Component<Props, State> {
   onOuterClick = () => this.setState({ isOpen: false });
   toggleModal = () => {
     const isModalOpen = !this.state.isModalOpen;
-    this.setState({ isModalOpen }, () => noScroll(isModalOpen));
+    this.setState({ isModalOpen });
   };
 
   getFilteredModules = (inputValue: string) => {

--- a/v3/src/js/views/components/ModulesSelect.jsx
+++ b/v3/src/js/views/components/ModulesSelect.jsx
@@ -1,15 +1,15 @@
 // @flow
 import React, { Component } from 'react';
-import noScroll from 'no-scroll';
 import _ from 'lodash';
 import Downshift from 'downshift';
 import classnames from 'classnames';
 
+import type { ModuleSelectList } from 'types/reducers';
 import { createSearchPredicate, sortModules } from 'utils/moduleSearch';
 import makeResponsive from 'views/hocs/makeResponsive';
 import Modal from 'views/components/Modal';
 import CloseButton from 'views/components/CloseButton';
-import type { ModuleSelectList } from 'types/reducers';
+import noScroll from 'utils/no-scroll';
 
 import styles from './ModulesSelect.scss';
 
@@ -53,8 +53,8 @@ class ModulesSelect extends Component<Props, State> {
   onBlur = (e: Event) => { e.preventDefault(); };
   onOuterClick = () => this.setState({ isOpen: false });
   toggleModal = () => {
-    noScroll.toggle();
-    this.setState({ isModalOpen: !this.state.isModalOpen });
+    const isModalOpen = !this.state.isModalOpen;
+    this.setState({ isModalOpen }, () => noScroll(isModalOpen));
   };
 
   getFilteredModules = (inputValue: string) => {

--- a/v3/src/js/views/components/ModulesSelect.scss
+++ b/v3/src/js/views/components/ModulesSelect.scss
@@ -52,12 +52,11 @@ div > .modal {
 }
 
 .selectList {
+  composes: scrollable from global;
   max-height: calc(100% - #{$input-height});
   padding: 0;
   margin: 0;
-  overflow-y: scroll;
   list-style: none;
-  -webkit-overflow-scrolling: touch;
 }
 
 @include media-breakpoint-up(md) {
@@ -69,7 +68,6 @@ div > .modal {
     left: 0;
     z-index: $module-select-z-index;
     max-height: $module-list-height;
-    overflow-y: auto;
     border: $input-btn-border-width solid $input-border-color;
     border-width: 0 $input-btn-border-width $input-btn-border-width;
     border-radius: 0 0 $btn-border-radius $btn-border-radius;

--- a/v3/src/js/views/components/SideMenu.jsx
+++ b/v3/src/js/views/components/SideMenu.jsx
@@ -28,12 +28,20 @@ export class SideMenuComponent extends PureComponent<Props> {
     closeIcon: <Close aria-label={CLOSE_MENU_LABEL} />,
   };
 
+  componentDidMount() {
+    noScroll(this.isSideMenuShown());
+  }
+
   componentDidUpdate() {
-    noScroll(this.props.isOpen);
+    noScroll(this.isSideMenuShown());
+  }
+
+  isSideMenuShown() {
+    return this.props.isOpen && !this.props.matchBreakpoint;
   }
 
   render() {
-    const { isOpen, matchBreakpoint, toggleMenu, children, openIcon, closeIcon } = this.props;
+    const { isOpen, toggleMenu, children, openIcon, closeIcon } = this.props;
 
     return (
       <Fragment>
@@ -44,7 +52,7 @@ export class SideMenuComponent extends PureComponent<Props> {
           {isOpen ? closeIcon : openIcon}
         </Fab>
 
-        {isOpen && !matchBreakpoint &&
+        {this.isSideMenuShown() &&
           <div
             className={styles.overlay}
             onClick={() => toggleMenu(false)}

--- a/v3/src/js/views/components/SideMenu.jsx
+++ b/v3/src/js/views/components/SideMenu.jsx
@@ -2,8 +2,10 @@
 
 import React, { PureComponent, type Node, Fragment } from 'react';
 import classnames from 'classnames';
+
 import { Menu, Close } from 'views/components/icons';
 import makeResponsive from 'views/hocs/makeResponsive';
+import noScroll from 'utils/no-scroll';
 import Fab from './Fab';
 
 import styles from './SideMenu.scss';
@@ -25,6 +27,10 @@ export class SideMenuComponent extends PureComponent<Props> {
     openIcon: <Menu aria-label={OPEN_MENU_LABEL} />,
     closeIcon: <Close aria-label={CLOSE_MENU_LABEL} />,
   };
+
+  componentDidUpdate() {
+    noScroll(this.props.isOpen);
+  }
 
   render() {
     const { isOpen, matchBreakpoint, toggleMenu, children, openIcon, closeIcon } = this.props;

--- a/v3/src/js/views/components/SideMenu.scss
+++ b/v3/src/js/views/components/SideMenu.scss
@@ -13,7 +13,8 @@ $animation-duration: 0.3s;
 .sideMenu {
   position: fixed;
   max-height: calc(100% - #{$navbar-height});
-  overflow: auto;
+
+  @include scrollable;
 }
 
 .overlay {

--- a/v3/src/js/views/components/SideMenu.scss
+++ b/v3/src/js/views/components/SideMenu.scss
@@ -11,10 +11,9 @@ $animation-duration: 0.3s;
 }
 
 .sideMenu {
+  composes: scrollable from global;
   position: fixed;
   max-height: calc(100% - #{$navbar-height});
-
-  @include scrollable;
 }
 
 .overlay {

--- a/v3/src/js/views/components/filters/styles.scss
+++ b/v3/src/js/views/components/filters/styles.scss
@@ -101,6 +101,7 @@ $h-padding: $grid-gutter-width / 2;
   }
 
   :global(.dropdown-menu) {
+    composes: scrollable from global;
     width: calc(100% - 0.2rem);
     max-height: 17rem;
     padding: 0;
@@ -111,8 +112,6 @@ $h-padding: $grid-gutter-width / 2;
       padding-top: 0.25rem;
       padding-bottom: 0.25rem;
     }
-
-    @include scrollable;
   }
 
   mark {

--- a/v3/src/js/views/components/filters/styles.scss
+++ b/v3/src/js/views/components/filters/styles.scss
@@ -105,13 +105,14 @@ $h-padding: $grid-gutter-width / 2;
     max-height: 17rem;
     padding: 0;
     margin: 0;
-    overflow: auto;
     border-radius: 0 0 3px 3px;
 
     .label {
       padding-top: 0.25rem;
       padding-bottom: 0.25rem;
     }
+
+    @include scrollable;
   }
 
   mark {

--- a/v3/src/js/views/components/filters/styles.scss
+++ b/v3/src/js/views/components/filters/styles.scss
@@ -101,7 +101,6 @@ $h-padding: $grid-gutter-width / 2;
   }
 
   :global(.dropdown-menu) {
-    composes: scrollable from global;
     width: calc(100% - 0.2rem);
     max-height: 17rem;
     padding: 0;

--- a/v3/src/js/views/components/module-info/LessonTimetable.scss
+++ b/v3/src/js/views/components/module-info/LessonTimetable.scss
@@ -1,3 +1,5 @@
+@import "~styles/utils/modules-entry.scss";
+
 .lessonTimetable {
-  overflow: auto;
+  @include scrollable;
 }

--- a/v3/src/js/views/components/module-info/LessonTimetable.scss
+++ b/v3/src/js/views/components/module-info/LessonTimetable.scss
@@ -1,5 +1,5 @@
 @import "~styles/utils/modules-entry.scss";
 
 .lessonTimetable {
-  @include scrollable;
+  composes: scrollable from global;
 }

--- a/v3/src/js/views/layout/Navtabs.scss
+++ b/v3/src/js/views/layout/Navtabs.scss
@@ -47,6 +47,13 @@
   }
 }
 
+@include media-breakpoint-down(sm) {
+  // position sticky doesn't work with no-scroll is active
+  :global(.no-scroll) .nav {
+    position: fixed;
+  }
+}
+
 .link {
   flex: 1 0 auto;
   line-height: 1;

--- a/v3/src/js/views/timetable/TimetableContent.scss
+++ b/v3/src/js/views/timetable/TimetableContent.scss
@@ -1,4 +1,4 @@
-@import './_variables.scss';
+@import '~styles/utils/modules-entry';
 
 .container {
   :global {
@@ -7,9 +7,8 @@
 }
 
 .timetableWrapper {
+  composes: scrollable from global;
   margin-bottom: 1rem;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
 
   @include media-breakpoint-down(sm) {
     // Maximize the space taken by the timetable by overflowing into the grid gutters

--- a/v3/src/js/views/venues/VenueDetailRow.scss
+++ b/v3/src/js/views/venues/VenueDetailRow.scss
@@ -12,5 +12,6 @@
 
 .venueTimetable {
   margin-bottom: 1rem;
-  overflow: auto;
+
+  @include scrollable;
 }

--- a/v3/src/js/views/venues/VenueDetailRow.scss
+++ b/v3/src/js/views/venues/VenueDetailRow.scss
@@ -11,7 +11,6 @@
 }
 
 .venueTimetable {
+  composes: scrollable from global;
   margin-bottom: 1rem;
-
-  @include scrollable;
 }

--- a/v3/src/styles/bootstrap/style-override.scss
+++ b/v3/src/styles/bootstrap/style-override.scss
@@ -16,6 +16,8 @@ body {
   padding: 0.1rem 0;
   background: var(--body-bg);
   box-shadow: 0 2px 6px rgba(#000, 0.25);
+
+  @include scrollable;
 }
 
 .dropdown-item {

--- a/v3/src/styles/components/search-panel.scss
+++ b/v3/src/styles/components/search-panel.scss
@@ -23,3 +23,11 @@
       );
   }
 }
+
+:global(.no-scroll) .search-panel {
+  position: fixed;
+  top: $navbar-height;
+  right: 0;
+  left: 0;
+  margin: 0;
+}

--- a/v3/src/styles/main.scss
+++ b/v3/src/styles/main.scss
@@ -1,14 +1,15 @@
+// Define our own mixins, functions and constants first
+@import 'utils/mixins';
+@import 'utils/functions';
+@import 'constants';
+
 @import 'bootstrap/bootstrap';
 @import 'bootstrap/style-override';
 
 // 3rd-party imports
 @import "material/material";
 
-@import 'constants';
-
 // Utils
-@import 'utils/mixins';
-@import 'utils/functions';
 @import 'utils/animations';
 @import 'utils/workload';
 @import 'utils/themes';

--- a/v3/src/styles/main.scss
+++ b/v3/src/styles/main.scss
@@ -12,6 +12,7 @@
 @import 'utils/animations';
 @import 'utils/workload';
 @import 'utils/themes';
+@import 'utils/scrollable';
 @import 'utils/css-variables';
 
 // Layout

--- a/v3/src/styles/utils/mixins.scss
+++ b/v3/src/styles/utils/mixins.scss
@@ -19,6 +19,9 @@
 @mixin scrollable() {
   overflow: auto;
 
+  // @supports is used here because Safari requires overflow: scroll to be used in conjunction with
+  // -webkit-overflow-scrolling: touch to ensure smooth scrolling on iOS, but this causes ugly
+  // scrollbars to appear in other browsers
   @supports (-webkit-overflow-scrolling: touch) {
     overflow: scroll;
     -webkit-overflow-scrolling: touch;

--- a/v3/src/styles/utils/mixins.scss
+++ b/v3/src/styles/utils/mixins.scss
@@ -15,3 +15,12 @@
     }
   }
 }
+
+@mixin scrollable() {
+  overflow: auto;
+
+  @supports (-webkit-overflow-scrolling: touch) {
+    overflow: scroll;
+    -webkit-overflow-scrolling: touch;
+  }
+}

--- a/v3/src/styles/utils/scrollable.scss
+++ b/v3/src/styles/utils/scrollable.scss
@@ -1,0 +1,3 @@
+.scrollable {
+  @include scrollable;
+}


### PR DESCRIPTION
This fixes #544 

- Uses proprietary `-webkit-overflow-scrolling` property to trigger kinetic scrolling on iOS 
- Uses `no-scroll` package with a wrapper function to disable scrolling when modal and side menu is opened. The wrapper is needed because the scroll disabling hack doesn't play well with our position sticky navigation, so we need to add some additional styles to the sticky elements when it is active. 