### PR TITLE
Fix filter dropdown crash

### DIFF
--- a/v3/src/js/test-utils/filterHelpers.js
+++ b/v3/src/js/test-utils/filterHelpers.js
@@ -1,0 +1,25 @@
+// @flow
+import type { Module, ModuleCode } from 'types/modules';
+import FilterGroup from 'utils/filters/FilterGroup';
+import Filter from 'utils/filters/ModuleFilter';
+
+// eslint-disable-next-line import/prefer-default-export
+export function createModule(code: ModuleCode): Module {
+  return {
+    ModuleCode: code,
+    ModuleTitle: 'Test Module',
+    History: [],
+    Types: [],
+    Department: 'Test Department',
+    ModuleCredit: '4',
+    AcadYear: '16/17',
+    CorsBiddingStats: [],
+  };
+}
+
+export function createGroup(modules: Module[] = []) {
+  return new FilterGroup('test', 'test', [
+    new Filter('a', 'a', () => true),
+    new Filter('b', 'b', () => true),
+  ]).initFilters(modules);
+}

--- a/v3/src/js/test-utils/testFilter.js
+++ b/v3/src/js/test-utils/testFilter.js
@@ -1,7 +1,8 @@
 /* global expect */
 
-// eslint-disable-next-line import/prefer-default-export
-export function testFilter(Filter, module, combinations, valid) {
+// This file is deliberately untyped. Typed filter helper functions should go to
+// filterHelpers.js
+export default function testFilter(Filter, module, combinations, valid) {
   // Checks every possible combination of arguments for a Filter class
   // against ones that should return true
   combinations.forEach((...args) => {

--- a/v3/src/js/utils/filters/FilterGroup.test.js
+++ b/v3/src/js/utils/filters/FilterGroup.test.js
@@ -1,7 +1,7 @@
 // @flow
 import type { Module } from 'types/modules';
 
-import { createModule } from './ModuleFilter.test';
+import { createModule } from 'test-utils/filterHelpers';
 import Group from './FilterGroup';
 import Filter from './ModuleFilter';
 

--- a/v3/src/js/utils/filters/ModuleFilter.test.js
+++ b/v3/src/js/utils/filters/ModuleFilter.test.js
@@ -1,22 +1,8 @@
 // @flow
 
-import type { Module, ModuleCode } from 'types/modules';
+import { createModule } from 'test-utils/filterHelpers';
 
 import Filter from './ModuleFilter';
-
-// eslint-disable-next-line import/prefer-default-export
-export function createModule(code: ModuleCode): Module {
-  return {
-    ModuleCode: code,
-    ModuleTitle: 'Test Module',
-    History: [],
-    Types: [],
-    Department: 'Test Department',
-    ModuleCredit: '4',
-    AcadYear: '16/17',
-    CorsBiddingStats: [],
-  };
-}
 
 describe('count()', () => {
   const modules = ['CS1010S', 'CS1231', 'GET1025', 'GET1029'].map(createModule);

--- a/v3/src/js/utils/filters/TimeslotFilter.test.js
+++ b/v3/src/js/utils/filters/TimeslotFilter.test.js
@@ -7,7 +7,7 @@ import cs3216 from '__mocks__/modules/CS3216.json';
 
 import Combinatorics from 'js-combinatorics';
 import { DaysOfWeek, TimesOfDay, Semesters, Timeslots } from 'types/modules';
-import { testFilter } from 'test-utils/filterTestHelpers';
+import testFilter from 'test-utils/testFilter';
 import TimeslotFilter, { TimeslotTypes } from './TimeslotFilter';
 
 test('test() should filter modules according to their lecture timeslot', () => {

--- a/v3/src/js/views/components/filters/DropdownListFilters.jsx
+++ b/v3/src/js/views/components/filters/DropdownListFilters.jsx
@@ -172,10 +172,11 @@ export class DropdownListFiltersComponent extends PureComponent<Props, State> {
             <option>{placeholder}</option>
             {this.displayedFilters().map(([filter, count]) => (
               <option key={filter.id} value={filter.id}>
-                {/* Use a unicode checkbox to indicate to the user filters that are already enabled */}
-                {filter.enabled && '☑ '}
                 {/* Extra layer of interpolation to workaround https://github.com/facebook/react/issues/11911 */}
-                {`${filter.label} (${count})`}
+                {/* Use a unicode checkbox to indicate to the user filters that are already enabled */}
+                {filter.enabled
+                  ? `☑ ${filter.label} (${count})`
+                  : `${filter.label} (${count})`}
               </option>
             ))}
           </select>}

--- a/v3/src/js/views/components/filters/DropdownListFilters.jsx
+++ b/v3/src/js/views/components/filters/DropdownListFilters.jsx
@@ -43,6 +43,7 @@ export class DropdownListFiltersComponent extends PureComponent<Props, State> {
 
   onSelectItem = (selectedItem: string) => {
     if (!selectedItem) return;
+
     const { group, onFilterChange } = this.props;
     onFilterChange(group.toggle(selectedItem));
     this.setState({ searchedFilters: uniq([...this.state.searchedFilters, selectedItem]) });
@@ -173,7 +174,8 @@ export class DropdownListFiltersComponent extends PureComponent<Props, State> {
               <option key={filter.id} value={filter.id}>
                 {/* Use a unicode checkbox to indicate to the user filters that are already enabled */}
                 {filter.enabled && '☑ '}
-                {filter.label} ({count})
+                {/* Extra layer of interpolation to workaround https://github.com/facebook/react/issues/11911 */}
+                {`${filter.label} (${count})`}
               </option>
             ))}
           </select>}

--- a/v3/src/js/views/components/filters/DropdownListFilters.test.jsx
+++ b/v3/src/js/views/components/filters/DropdownListFilters.test.jsx
@@ -43,17 +43,47 @@ describe('<DropdownListFilters>', () => {
 
     expect(wrapper.find('select').exists()).toBe(true);
     expect(wrapper.find('option')).toHaveLength(3); // One placeholder and two options
+
+    expect(wrapper.find('ul.list-unstyled input')).toHaveLength(0);
   });
 
   test('change value when <select> value changes', () => {
     const group = createGroup(modules);
     const { wrapper, onFilterChange } = make(group, [group], false);
 
+    // Simulate selecting an <option> in the <select>
     wrapper.find('select').simulate('change', { target: { value: 'a' } });
-    const [[nextGroup]] = onFilterChange.mock.calls;
-    expect(nextGroup).toEqual(group.toggle('a'));
+    const [[nextGroup1]] = onFilterChange.mock.calls;
+    expect(nextGroup1).toEqual(group.toggle('a'));
 
-    wrapper.setProps({ group: nextGroup });
+    wrapper.setProps({ group: nextGroup1 });
+
+    // Should render the option inside the <select> with a checkmark
     expect(wrapper.find('option').at(1).text()).toMatch(CHECKBOX);
+
+    // Should render the item in the checklist outside
+    const checklist = wrapper.find('ul.list-unstyled input');
+    expect(checklist).toHaveLength(1);
+    expect(checklist.at(0).prop('checked')).toBe(true);
+  });
+
+  test('render a list of previously selected items outside the <select>', () => {
+    const group = createGroup(modules).toggle('a');
+    const { wrapper, onFilterChange } = make(group, [group], false);
+
+    // Should render the item in the checklist outside
+    const checklist1 = wrapper.find('ul.list-unstyled input');
+    expect(checklist1).toHaveLength(1);
+    expect(checklist1.at(0).prop('checked')).toBe(true);
+
+    // Simulate unchecking the checkbox on the checklist outside
+    checklist1.simulate('change', { target: { value: false } });
+    const [[nextGroup1]] = onFilterChange.mock.calls;
+    expect(nextGroup1).toEqual(group.toggle('a'));
+
+    wrapper.setProps({ group: nextGroup1 });
+    const checklist2 = wrapper.find('ul.list-unstyled input');
+    expect(checklist2).toHaveLength(1);
+    expect(checklist2.at(0).prop('checked')).toBe(false);
   });
 });

--- a/v3/src/js/views/components/filters/DropdownListFilters.test.jsx
+++ b/v3/src/js/views/components/filters/DropdownListFilters.test.jsx
@@ -1,0 +1,59 @@
+// @flow
+
+import React from 'react';
+import { mount } from 'enzyme';
+
+import FilterGroup from 'utils/filters/FilterGroup';
+import { createGroup, createModule } from 'test-utils/filterHelpers';
+import { DropdownListFiltersComponent } from './DropdownListFilters';
+
+describe('<DropdownListFilters>', () => {
+  const CHECKBOX = '☑';
+  const modules = [
+    createModule('CS1010S'),
+    createModule('CS3216'),
+  ];
+
+  function make(
+    filterGroup: FilterGroup<*>,
+    groups: FilterGroup<any>[] = [filterGroup],
+    matchBreakpoint: boolean = true,
+  ) {
+    const onFilterChange = jest.fn();
+
+    return {
+      onFilterChange,
+
+      wrapper: mount(
+        <DropdownListFiltersComponent
+          onFilterChange={onFilterChange}
+          group={filterGroup}
+          groups={groups}
+          matchBreakpoint={matchBreakpoint}
+        />,
+      ),
+    };
+  }
+
+  // TODO: Write some sort of adaptor that reads off both <select> and <Downshift>
+  //       to ensure values in both match
+  test('use native <select> element on mobile', () => {
+    const group = createGroup(modules);
+    const { wrapper } = make(group, [group], false);
+
+    expect(wrapper.find('select').exists()).toBe(true);
+    expect(wrapper.find('option')).toHaveLength(3); // One placeholder and two options
+  });
+
+  test('change value when <select> value changes', () => {
+    const group = createGroup(modules);
+    const { wrapper, onFilterChange } = make(group, [group], false);
+
+    wrapper.find('select').simulate('change', { target: { value: 'a' } });
+    const [[nextGroup]] = onFilterChange.mock.calls;
+    expect(nextGroup).toEqual(group.toggle('a'));
+
+    wrapper.setProps({ group: nextGroup });
+    expect(wrapper.find('option').at(1).text()).toMatch(CHECKBOX);
+  });
+});


### PR DESCRIPTION
Fixes #546, the crash reported in https://sentry.io/share/issue/af793a00e6074c7fba6aa00e25c95480/ and https://github.com/facebook/react/issues/11911 

This PR works around the issue by simply interpolating the string. It also shifts some test code around.to hopefully make testing filters in the future less painful. 