### PR TITLE
Ignores errors from Disqus embed.js 

### DIFF
--- a/v3/src/js/utils/sentry.js
+++ b/v3/src/js/utils/sentry.js
@@ -16,6 +16,8 @@ if (loadRaven) {
         // Chrome extensions
         /extensions\//i,
         /^chrome:\/\//i,
+        // Disqus
+        /embed\.js$/i,
       ],
     })
     .install();


### PR DESCRIPTION
Since [these](https://sentry.io/nusmods/v3/?query=embed.js) are not caused by us, and have no visible impact anyway, we should just silence them from Sentry. 