### PR TITLE
Include module table in timetable image export

### DIFF
--- a/v3/src/js/actions/export.js
+++ b/v3/src/js/actions/export.js
@@ -29,10 +29,15 @@ export function downloadAsJpeg(domElement: Element) {
 
     // Temporarily add a stylesheet to hide the elements that we don't want
     // to show in the exported image.
-    const style = document.createElement('style');
+    const style: HTMLStyleElement = document.createElement('style');
     style.appendChild(document.createTextNode('')); // WebKit hack :(
-    document.head.appendChild(style);
-    style.sheet.insertRule(`.${TIMETABLE_EXPORT_HIDE_CLASS} { display: none; }`, 0);
+    const head = document.head;
+    if (!head) return null;
+    head.appendChild(style);
+    if (style.sheet) {
+      // $FlowFixMe - https://github.com/facebook/flow/issues/2696
+      style.sheet.insertRule(`.${TIMETABLE_EXPORT_HIDE_CLASS} { display: none; }`, 0);
+    }
 
     return domtoimage.toJpeg(domElement,
       {
@@ -55,7 +60,7 @@ export function downloadAsJpeg(domElement: Element) {
         });
       })
       .then(() => {
-        document.head.removeChild(style);
+        head.removeChild(style);
       });
   };
 }

--- a/v3/src/js/actions/export.js
+++ b/v3/src/js/actions/export.js
@@ -20,14 +20,28 @@ function downloadUrl(url: string, filename: string) {
 }
 
 export const DOWNLOAD_AS_JPEG = 'DOWNLOAD_AS_JPEG';
+export const TIMETABLE_EXPORT_HIDE_CLASS = 'timetable-export-hidden';
 export function downloadAsJpeg(domElement: Element) {
   return (dispatch: Function) => {
     dispatch({
       type: `${DOWNLOAD_AS_JPEG}_PENDING`,
     });
 
-    const style = { margin: '0', marginLeft: '-0.25em' };
-    return domtoimage.toJpeg(domElement, { bgcolor: '#fff', style })
+    // Temporarily add a stylesheet to hide the elements that we don't want
+    // to show in the exported image.
+    const style = document.createElement('style');
+    style.appendChild(document.createTextNode('')); // WebKit hack :(
+    document.head.appendChild(style);
+    style.sheet.insertRule(`.${TIMETABLE_EXPORT_HIDE_CLASS} { display: none; }`, 0);
+
+    return domtoimage.toJpeg(domElement,
+      {
+        bgcolor: '#fff',
+        style: {
+          margin: '0',
+          marginLeft: '-0.25em',
+        },
+      })
       .then((dataUrl) => {
         downloadUrl(dataUrl, 'timetable.jpeg');
         dispatch({
@@ -39,6 +53,9 @@ export function downloadAsJpeg(domElement: Element) {
         dispatch({
           type: `${DOWNLOAD_AS_JPEG}_FAILURE`,
         });
+      })
+      .then(() => {
+        document.head.removeChild(style);
       });
   };
 }

--- a/v3/src/js/views/timetable/TimetableContent.jsx
+++ b/v3/src/js/views/timetable/TimetableContent.jsx
@@ -22,7 +22,11 @@ import type { SemTimetableConfig, SemTimetableConfigWithLessons, TimetableArrang
 
 import classnames from 'classnames';
 import { getSemModuleSelectList } from 'reducers/entities/moduleBank';
-import { downloadAsJpeg, downloadAsIcal } from 'actions/export';
+import {
+  downloadAsJpeg,
+  downloadAsIcal,
+  TIMETABLE_EXPORT_HIDE_CLASS,
+} from 'actions/export';
 import {
   addModule,
   cancelModifyLesson,
@@ -72,9 +76,9 @@ type Props = {
   downloadAsIcal: Function,
 };
 
-class TimetableContent extends Component<Props> {
-  timetableDom: ?HTMLElement;
+const TIMETABLE_EXPORT_CONTAINER_ID = 'timetable-export-container';
 
+class TimetableContent extends Component<Props> {
   componentWillUnmount() {
     this.cancelModifyLesson();
   }
@@ -85,7 +89,7 @@ class TimetableContent extends Component<Props> {
     }
   };
 
-  downloadAsJpeg = () => this.props.downloadAsJpeg(this.timetableDom);
+  downloadAsJpeg = () => this.props.downloadAsJpeg(document.getElementById(TIMETABLE_EXPORT_CONTAINER_ID));
 
   downloadAsIcal = () =>
     this.props.downloadAsIcal(this.props.semester, this.props.timetableWithLessons, this.props.modules);
@@ -218,7 +222,7 @@ class TimetableContent extends Component<Props> {
           {this.props.header}
         </div>
 
-        <div className="row">
+        <div className="row" id={TIMETABLE_EXPORT_CONTAINER_ID}>
           <div
             className={classnames({
               'col-md-12': !isVerticalOrientation,
@@ -231,9 +235,6 @@ class TimetableContent extends Component<Props> {
                 lessons={arrangedLessonsWithModifiableFlag}
                 isVerticalOrientation={isVerticalOrientation}
                 onModifyCell={this.modifyCell}
-                ref={(r) => {
-                  this.timetableDom = r && r.timetableDom;
-                }}
               />
             </div>
           </div>
@@ -243,7 +244,7 @@ class TimetableContent extends Component<Props> {
               'col-md-4': isVerticalOrientation,
             })}
           >
-            <div className="row justify-content-between">
+            <div className={classnames('row justify-content-between', TIMETABLE_EXPORT_HIDE_CLASS)}>
               <div className={classnames('col-auto', styles.timetableActions)}>
                 <TimetableActions
                   isVerticalOrientation={!isVerticalOrientation}
@@ -263,13 +264,16 @@ class TimetableContent extends Component<Props> {
             <div className={styles.tableContainer}>
               <div className="col-md-12">
                 {!readOnly &&
-                  <ModulesSelect
-                    moduleList={this.props.semModuleList}
-                    onChange={(moduleCode) => {
-                      this.props.addModule(semester, moduleCode);
-                    }}
-                    placeholder="Add module to timetable"
-                  />}
+                  <div className={TIMETABLE_EXPORT_HIDE_CLASS}>
+                    <ModulesSelect
+                      moduleList={this.props.semModuleList}
+                      onChange={(moduleCode) => {
+                        this.props.addModule(semester, moduleCode);
+                      }}
+                      placeholder="Add module to timetable"
+                    />
+                  </div>
+                }
                 <br />
                 {this.renderModuleSections(!isVerticalOrientation)}
               </div>

--- a/v3/src/js/views/timetable/TimetableModulesTable.jsx
+++ b/v3/src/js/views/timetable/TimetableModulesTable.jsx
@@ -13,6 +13,7 @@ import { Eye, EyeOff, Trash2 } from 'views/components/icons/index';
 import { selectModuleColor } from 'actions/theme';
 import { hideLessonInTimetable, showLessonInTimetable } from 'actions/settings';
 import { getModuleSemExamDate } from 'utils/modules';
+import { TIMETABLE_EXPORT_HIDE_CLASS } from 'actions/export';
 import { modulePage } from 'views/routes/paths';
 
 import styles from './TimetableModulesTable.scss';
@@ -36,7 +37,7 @@ class TimetableModulesTable extends Component<Props> {
 
     return (
       <div className={styles.moduleActionButtons}>
-        <div className="btn-group">
+        <div className={classnames('btn-group', TIMETABLE_EXPORT_HIDE_CLASS)}>
           <button
             type="button"
             className={classnames('btn btn-outline-secondary', styles.moduleAction)}


### PR DESCRIPTION
I think people would complain if the timetable image export didn't include the exam timetable, which students were used to having, so I'm including it here. There are some hacks used:

1. I have to use `document.getElementById` instead of using `ref`. Somehow it crashes when I shift the `ref` higher up. I think the current approach is still feasible.
2. The stuff to be excluded will be temporarily (< 1s) hidden from view while `domtoimage` converts the DOM to an image. It's ugly but it's a reasonable trade-off IMO. Try it out in the Netlify preview and see for yourself.

Thoughts?