### PR TITLE
Module search bug fixes and improvement  

### DIFF
--- a/v3/src/js/utils/moduleSearch.js
+++ b/v3/src/js/utils/moduleSearch.js
@@ -40,7 +40,8 @@ export function createSearchPredicate(searchTerm: string): SearchableModule => b
 export function createSearchFilter(searchTerm: string): FilterGroup<ModuleFilter> {
   const predicate = createSearchPredicate(searchTerm);
   const filter = new ModuleFilter(encodeURIComponent(searchTerm), searchTerm, predicate);
-  return new FilterGroup(SEARCH_QUERY_KEY, 'Search', [filter]).toggle(filter);
+  return new FilterGroup(SEARCH_QUERY_KEY, 'Search', [filter])
+    .toggle(filter, !!searchTerm);
 }
 
 export function sortModules<T: SearchableModule>(searchTerm: string, modules: T[]): T[] {

--- a/v3/src/js/utils/moduleSearch.js
+++ b/v3/src/js/utils/moduleSearch.js
@@ -1,5 +1,5 @@
 // @flow
-import { sortBy, sumBy } from 'lodash';
+import { sortBy } from 'lodash';
 import FilterGroup from 'utils/filters/FilterGroup';
 import ModuleFilter from 'utils/filters/ModuleFilter';
 import type { SearchableModule } from 'types/modules';
@@ -49,14 +49,19 @@ export function createSearchFilter(searchTerm: string): FilterGroup<ModuleFilter
 export function sortModules<T: SearchableModule>(searchTerm: string, modules: T[]): T[] {
   const searchRegexes = tokenize(searchTerm).map(regexify);
 
-  return sortBy(modules, module => sumBy(searchRegexes, (regex) => {
-    if (regex.test(module.ModuleCode) ||
-        regex.test(module.ModuleCode.replace(/\D+/, ''))) {
-      return 1;
+  return sortBy(modules, (module) => {
+    let sum = 0;
+    for (let i = 0; i < searchRegexes.length; i++) {
+      if (searchRegexes[i].test(module.ModuleCode) ||
+          searchRegexes[i].test(module.ModuleCode.replace(/\D+/, ''))) {
+        sum += 1;
+      } else if (searchRegexes[i].test(module.ModuleTitle)) {
+        sum += 2;
+      } else {
+        sum += 3;
+      }
     }
-    if (regex.test(module.ModuleTitle)) {
-      return 2;
-    }
-    return 3;
-  }));
+
+    return sum;
+  });
 }

--- a/v3/src/js/utils/moduleSearch.js
+++ b/v3/src/js/utils/moduleSearch.js
@@ -1,5 +1,5 @@
 // @flow
-import { sortBy } from 'lodash';
+import { sortBy, sumBy } from 'lodash';
 import FilterGroup from 'utils/filters/FilterGroup';
 import ModuleFilter from 'utils/filters/ModuleFilter';
 import type { SearchableModule } from 'types/modules';
@@ -47,16 +47,16 @@ export function createSearchFilter(searchTerm: string): FilterGroup<ModuleFilter
 }
 
 export function sortModules<T: SearchableModule>(searchTerm: string, modules: T[]): T[] {
-  const searchRegex = regexify(searchTerm);
+  const searchRegexes = tokenize(searchTerm).map(regexify);
 
-  return sortBy(modules, (module) => {
-    if (searchRegex.test(module.ModuleCode) ||
-        searchRegex.test(module.ModuleCode.replace(/\D+/, ''))) {
+  return sortBy(modules, module => sumBy(searchRegexes, (regex) => {
+    if (regex.test(module.ModuleCode) ||
+        regex.test(module.ModuleCode.replace(/\D+/, ''))) {
       return 1;
     }
-    if (searchRegex.test(module.ModuleTitle)) {
+    if (regex.test(module.ModuleTitle)) {
       return 2;
     }
     return 3;
-  });
+  }));
 }

--- a/v3/src/js/utils/moduleSearch.test.js
+++ b/v3/src/js/utils/moduleSearch.test.js
@@ -1,53 +1,50 @@
+// @flow
+import type { ModuleCode } from 'types/modules';
 import moduleList from '__mocks__/modules';
+
 import { createSearchFilter, sortModules } from './moduleSearch';
 
-test('it searches by module prefix', () => {
-  const filter = createSearchFilter('CS').initFilters(moduleList);
-  const filtered = [...filter.filteredModules()];
-  expect(filtered).toEqual(['CS1010S', 'CS3216']);
+function testSearchTerm(term: string, expectedModules: ModuleCode[]) {
+  const filter = createSearchFilter(term).initFilters(moduleList);
+  expect(filter.filteredModules())
+    .toEqual(new Set(expectedModules));
+}
+
+test('searches by module prefix', () => {
+  testSearchTerm('CS', ['CS1010S', 'CS3216']);
 });
 
-test('it searches by module code', () => {
-  const filter = createSearchFilter('10').initFilters(moduleList);
-  const filtered = [...filter.filteredModules()];
-  expect(filtered).toEqual(['BFS1001', 'CS1010S', 'GES1021']);
+test('searches by module code', () => {
+  testSearchTerm('10', ['BFS1001', 'CS1010S', 'GES1021']);
 });
 
-test('it searches by module title', () => {
-  const filter = createSearchFilter('Managerial').initFilters(moduleList);
-  const filtered = [...filter.filteredModules()];
-  expect(filtered).toEqual(['ACC2002']);
+test('searches by module title', () => {
+  testSearchTerm('Managerial', ['ACC2002']);
 });
 
-test('it searches by module description, if available', () => {
-  const filter = createSearchFilter('concepts').initFilters(moduleList);
-  const filtered = [...filter.filteredModules()];
-  expect(filtered).toEqual(['ACC2002', 'CS1010S']);
+test('searches by module description, if available', () => {
+  testSearchTerm('concepts', ['ACC2002', 'CS1010S']);
 });
 
-test('it searches multiword terms', () => {
-  const filter = createSearchFilter('coding,  testing ').initFilters(moduleList);
-  const filtered = [...filter.filteredModules()];
-  expect(filtered).toEqual(['CS1010S']);
+test('searches multiword terms', () => {
+  testSearchTerm('coding,  testing', ['CS1010S']);
 });
 
-test('its searches get more specific with more keywords', () => {
-  const filter = createSearchFilter('to by').initFilters(moduleList);
-  const filtered = [...filter.filteredModules()];
-  expect(filtered).toEqual([]);
+test('searches get more specific with more keywords', () => {
+  testSearchTerm('to by', []);
 });
 
-test('it sorts by prefering module prefix', () => {
+test('sorts by preferring module prefix', () => {
   const [first, second] = sortModules('cs', moduleList).map(m => m.ModuleCode);
   expect([first, second]).toEqual(['CS1010S', 'CS3216']);
 });
 
-test('it sorts by prefering module code', () => {
+test('sorts by preferring module code', () => {
   const [one, two, three] = sortModules('10', moduleList).map(m => m.ModuleCode);
   expect([one, two, three]).toEqual(['BFS1001', 'CS1010S', 'GES1021']);
 });
 
-test('it sorts by prefering title second', () => {
+test('sorts by preferring title second', () => {
   const [first] = sortModules('managerial', moduleList).map(m => m.ModuleCode);
   expect(first).toBe('ACC2002');
 });

--- a/v3/src/js/utils/moduleSearch.test.js
+++ b/v3/src/js/utils/moduleSearch.test.js
@@ -31,7 +31,8 @@ test('searches multiword terms', () => {
 });
 
 test('searches get more specific with more keywords', () => {
-  testSearchTerm('to by', []);
+  testSearchTerm('fund problem', ['CS1010S']);
+  testSearchTerm('prod eng', ['CS3216']);
 });
 
 test('sorts by preferring module prefix', () => {

--- a/v3/src/js/utils/moduleSearch.test.js
+++ b/v3/src/js/utils/moduleSearch.test.js
@@ -4,48 +4,55 @@ import moduleList from '__mocks__/modules';
 
 import { createSearchFilter, sortModules } from './moduleSearch';
 
-function testSearchTerm(term: string, expectedModules: ModuleCode[]) {
-  const filter = createSearchFilter(term).initFilters(moduleList);
-  expect(filter.filteredModules())
-    .toEqual(new Set(expectedModules));
-}
+describe('createSearchFilter', () => {
+  function testSearchTerm(term: string, expectedModules: ModuleCode[]) {
+    const filter = createSearchFilter(term).initFilters(moduleList);
+    expect(filter.filteredModules())
+      .toEqual(new Set(expectedModules));
+  }
 
-test('searches by module prefix', () => {
-  testSearchTerm('CS', ['CS1010S', 'CS3216']);
+  test('searches by module prefix', () => {
+    testSearchTerm('CS', ['CS1010S', 'CS3216']);
+  });
+
+  test('searches by module code', () => {
+    testSearchTerm('10', ['BFS1001', 'CS1010S', 'GES1021']);
+  });
+
+  test('searches by module title', () => {
+    testSearchTerm('Managerial', ['ACC2002']);
+  });
+
+  test('searches by module description, if available', () => {
+    testSearchTerm('concepts', ['ACC2002', 'CS1010S']);
+  });
+
+  test('searches multiword terms', () => {
+    testSearchTerm('coding,  testing', ['CS1010S']);
+  });
+
+  test('searches get more specific with more keywords', () => {
+    testSearchTerm('fund problem', ['CS1010S']);
+    testSearchTerm('prod eng', ['CS3216']);
+  });
 });
 
-test('searches by module code', () => {
-  testSearchTerm('10', ['BFS1001', 'CS1010S', 'GES1021']);
-});
+describe('sortModules', () => {
+  function testSortModule(term: string, ...results: ModuleCode[]) {
+    const sorted = sortModules(term, moduleList).map(m => m.ModuleCode);
+    expect(sorted.slice(0, results.length))
+      .toEqual(results);
+  }
 
-test('searches by module title', () => {
-  testSearchTerm('Managerial', ['ACC2002']);
-});
+  test('sorts by preferring module prefix', () => {
+    testSortModule('cs', 'CS1010S', 'CS3216');
+  });
 
-test('searches by module description, if available', () => {
-  testSearchTerm('concepts', ['ACC2002', 'CS1010S']);
-});
+  test('sorts by preferring module code', () => {
+    testSortModule('10', 'BFS1001', 'CS1010S', 'GES1021');
+  });
 
-test('searches multiword terms', () => {
-  testSearchTerm('coding,  testing', ['CS1010S']);
-});
-
-test('searches get more specific with more keywords', () => {
-  testSearchTerm('fund problem', ['CS1010S']);
-  testSearchTerm('prod eng', ['CS3216']);
-});
-
-test('sorts by preferring module prefix', () => {
-  const [first, second] = sortModules('cs', moduleList).map(m => m.ModuleCode);
-  expect([first, second]).toEqual(['CS1010S', 'CS3216']);
-});
-
-test('sorts by preferring module code', () => {
-  const [one, two, three] = sortModules('10', moduleList).map(m => m.ModuleCode);
-  expect([one, two, three]).toEqual(['BFS1001', 'CS1010S', 'GES1021']);
-});
-
-test('sorts by preferring title second', () => {
-  const [first] = sortModules('managerial', moduleList).map(m => m.ModuleCode);
-  expect(first).toBe('ACC2002');
+  test('sorts by preferring title second', () => {
+    testSortModule('managerial', 'ACC2002');
+  });
 });

--- a/v3/src/js/views/modules/ModuleFinderContainer.jsx
+++ b/v3/src/js/views/modules/ModuleFinderContainer.jsx
@@ -178,9 +178,14 @@ export class ModuleFinderContainerComponent extends Component<Props, State> {
 
   // Event handlers
   onQueryStringChange(query: string) {
-    this.setState(state => ({
-      filterGroups: updateGroups(state.filterGroups, query),
-    }));
+    const { filterGroups } = this.state;
+
+    // Trim the starting '?' character
+    if (query.replace(/^\?/, '') !== serializeGroups(filterGroups)) {
+      this.setState({
+        filterGroups: updateGroups(filterGroups, query),
+      });
+    }
   }
 
   onFilterChange = (newGroup: FilterGroup<*>, resetScroll: boolean = true) => {


### PR DESCRIPTION
Fixes two bugs 

- Searching for two words or more which return no results somehow causes the search filter to be disabled, which returns all results. This is fixed by not calling `setState` in the history change listener if the query string is not changed. Not entirely sure why this was triggering the bug in the first place 

- Only enable the search query filter if the search string is non-empty. This means the 'Clear filters' button won't show up if the search query is empty 

This PR also implements tokenized search so that eg. search queries like 'sci fi' will match 'science fiction'. 

There's still one more bug, which is that because the search box does not have state lifted, which means going back in history would not cause the search box to be cleared. This is a bit more complicated to fix, so I'll probably open up another PR for this. 