### PR TITLE
Touchscreen UI improvements for module finder 

### DIFF
--- a/v3/flow-typed/package-dep-libdefs.js
+++ b/v3/flow-typed/package-dep-libdefs.js
@@ -8,6 +8,10 @@ declare module 'downshift' {
   declare module.exports: any;
 }
 
+declare module 'json2mq' {
+  declare module.exports: any;
+}
+
 declare module 'localforage' {
   declare module.exports: any;
 }

--- a/v3/package.json
+++ b/v3/package.json
@@ -102,6 +102,7 @@
     "downshift": "^1.22.3",
     "ical-generator": "^0.2.9",
     "immutability-helper": "^2.3.1",
+    "json2mq": "^0.2.0",
     "localforage": "^1.5.5",
     "lodash": "^4.17.4",
     "no-scroll": "^2.1.0",

--- a/v3/src/js/utils/css.js
+++ b/v3/src/js/utils/css.js
@@ -4,6 +4,8 @@
 import { entries } from 'lodash';
 
 export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type QueryObject = { [string]: string | number | boolean } | QueryObject[];
+
 const breakpoints: { [Breakpoint]: number } = {
   xs: 0,
   sm: 576,
@@ -19,18 +21,18 @@ function nextBreakpoint(size: Breakpoint): ?Breakpoint {
   return breakpointEntries[nextBreakpointIndex][1];
 }
 
-export function breakpointDown(size: Breakpoint): string {
+export function breakpointDown(size: Breakpoint): QueryObject {
   const nextSize = nextBreakpoint(size);
-  if (nextSize == null) return 'all';
-  return `(max-width: ${breakpoints[nextSize] - 1}px )`;
+  if (nextSize == null) return { all: true };
+  return { maxWidth: breakpoints[nextSize] - 1 };
 }
 
-export function breakpointUp(size: Breakpoint): string {
-  return `(min-width: ${breakpoints[size]}px)`;
+export function breakpointUp(size: Breakpoint): QueryObject {
+  return { minWidth: breakpoints[size] };
 }
 
-export function touchScreenOnly(): string {
-  return '(pointer: coarse)';
+export function touchScreenOnly(): QueryObject {
+  return { pointer: 'coarse' };
 }
 
 export function supportsCSSVariables() {

--- a/v3/src/js/utils/css.js
+++ b/v3/src/js/utils/css.js
@@ -1,6 +1,7 @@
 // @flow
 
 // Define media breakpoints
+import json2mq from 'json2mq';
 import { entries } from 'lodash';
 
 export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
@@ -33,6 +34,10 @@ export function breakpointUp(size: Breakpoint): QueryObject {
 
 export function touchScreenOnly(): QueryObject {
   return { pointer: 'coarse' };
+}
+
+export function queryMatch(query: QueryObject) {
+  return window.matchMedia(json2mq(query));
 }
 
 export function supportsCSSVariables() {

--- a/v3/src/js/utils/css.js
+++ b/v3/src/js/utils/css.js
@@ -1,0 +1,39 @@
+// @flow
+
+// Define media breakpoints
+import { entries } from 'lodash';
+
+export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+const breakpoints: { [Breakpoint]: number } = {
+  xs: 0,
+  sm: 576,
+  md: 768,
+  lg: 992,
+  xl: 1200,
+};
+
+function nextBreakpoint(size: Breakpoint): ?Breakpoint {
+  const breakpointEntries = entries(breakpoints);
+  const nextBreakpointIndex = breakpointEntries.findIndex(([breakpoint]) => breakpoint === size) + 1;
+  if (nextBreakpointIndex >= breakpointEntries.length) return null;
+  return breakpointEntries[nextBreakpointIndex][1];
+}
+
+export function breakpointDown(size: Breakpoint): string {
+  const nextSize = nextBreakpoint(size);
+  if (nextSize == null) return 'all';
+  return `(max-width: ${breakpoints[nextSize] - 1}px )`;
+}
+
+export function breakpointUp(size: Breakpoint): string {
+  return `(min-width: ${breakpoints[size]}px)`;
+}
+
+export function touchScreenOnly(): string {
+  return '(pointer: coarse)';
+}
+
+export function supportsCSSVariables() {
+  // Safari does not support supports('--var', 'red')
+  return window.CSS.supports && window.CSS.supports('(--var: red)');
+}

--- a/v3/src/js/utils/react.jsx
+++ b/v3/src/js/utils/react.jsx
@@ -2,43 +2,12 @@
 
 import type { Node, ComponentType } from 'react';
 import React from 'react';
-import { escapeRegExp, castArray, entries } from 'lodash';
+import { escapeRegExp, castArray } from 'lodash';
 
 // Define some useful Unicode characters as constants
 export const NBSP = '\u00a0';
 export const BULLET = ' • ';
 
-// Define media breakpoints
-export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-const breakpoints: { [Breakpoint]: number } = {
-  xs: 0,
-  sm: 576,
-  md: 768,
-  lg: 992,
-  xl: 1200,
-};
-
-function nextBreakpoint(size: Breakpoint): ?Breakpoint {
-  const breakpointEntries = entries(breakpoints);
-  const nextBreakpointIndex = breakpointEntries.findIndex(([breakpoint]) => breakpoint === size) + 1;
-  if (nextBreakpointIndex >= breakpointEntries.length) return null;
-  return breakpointEntries[nextBreakpointIndex][1];
-}
-
-export function breakpointDown(size: Breakpoint): MediaQueryList {
-  const nextSize = nextBreakpoint(size);
-  if (nextSize == null) return window.matchMedia('all');
-  return window.matchMedia(`(max-width: ${breakpoints[nextSize] - 1}px )`);
-}
-
-export function breakpointUp(size: Breakpoint): MediaQueryList {
-  return window.matchMedia(`(min-width: ${breakpoints[size]}px)`);
-}
-
-export function supportsCSSVariables() {
-  // Safari does not support supports('--var', 'red')
-  return window.CSS.supports && window.CSS.supports('(--var: red)');
-}
 
 /**
  * Replace substring matching the provided regex with React nodes. This is

--- a/v3/src/js/views/components/ModulesSelect.jsx
+++ b/v3/src/js/views/components/ModulesSelect.jsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 
 import type { ModuleSelectList } from 'types/reducers';
 import { createSearchPredicate, sortModules } from 'utils/moduleSearch';
+import { breakpointUp } from 'utils/css';
 import makeResponsive from 'views/hocs/makeResponsive';
 import Modal from 'views/components/Modal';
 import CloseButton from 'views/components/CloseButton';
@@ -153,4 +154,4 @@ class ModulesSelect extends Component<Props, State> {
   }
 }
 
-export default makeResponsive(ModulesSelect, 'md');
+export default makeResponsive(ModulesSelect, breakpointUp('md'));

--- a/v3/src/js/views/components/SideMenu.jsx
+++ b/v3/src/js/views/components/SideMenu.jsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { Menu, Close } from 'views/components/icons';
 import makeResponsive from 'views/hocs/makeResponsive';
 import noScroll from 'utils/noScroll';
+import { breakpointUp } from 'utils/css';
 import Fab from './Fab';
 
 import styles from './SideMenu.scss';
@@ -66,4 +67,4 @@ export class SideMenuComponent extends PureComponent<Props> {
   }
 }
 
-export default makeResponsive(SideMenuComponent, 'md');
+export default makeResponsive(SideMenuComponent, breakpointUp('md'));

--- a/v3/src/js/views/components/SideMenu.scss
+++ b/v3/src/js/views/components/SideMenu.scss
@@ -14,6 +14,7 @@ $animation-duration: 0.3s;
   composes: scrollable from global;
   position: fixed;
   max-height: calc(100% - #{$navbar-height});
+  overscroll-behavior: contain; // stylelint-disable-line property-no-unknown
 }
 
 .overlay {

--- a/v3/src/js/views/components/filters/DropdownListFilters.jsx
+++ b/v3/src/js/views/components/filters/DropdownListFilters.jsx
@@ -91,7 +91,6 @@ export class DropdownListFiltersComponent extends PureComponent<Props, State> {
           <label htmlFor={htmlId}>{group.label}</label>
         </h4>
 
-        {/* Use a search-select combo dropdown on desktop */}
         {/* Use a native select for mobile devices */}
         {matchBreakpoint ?
           <select
@@ -115,7 +114,7 @@ export class DropdownListFiltersComponent extends PureComponent<Props, State> {
               </option>
             ))}
           </select>
-          :
+          : /* Use a search-select combo dropdown on desktop */
           <Downshift
             breakingChanges={{ resetInputOnSelection: true }}
             onChange={(selectedItem, { clearSelection }) => {

--- a/v3/src/js/views/components/filters/DropdownListFilters.jsx
+++ b/v3/src/js/views/components/filters/DropdownListFilters.jsx
@@ -12,6 +12,7 @@ import makeResponsive from 'views/hocs/makeResponsive';
 import FilterGroup from 'utils/filters/FilterGroup';
 import ModuleFilter from 'utils/filters/ModuleFilter';
 import { highlight } from 'utils/react';
+import { breakpointUp } from 'utils/css';
 import styles from './styles.scss';
 import Checklist from './Checklist';
 
@@ -192,4 +193,4 @@ export class DropdownListFiltersComponent extends PureComponent<Props, State> {
   }
 }
 
-export default makeResponsive(DropdownListFiltersComponent, 'md');
+export default makeResponsive(DropdownListFiltersComponent, breakpointUp('md'));

--- a/v3/src/js/views/components/filters/DropdownListFilters.jsx
+++ b/v3/src/js/views/components/filters/DropdownListFilters.jsx
@@ -12,7 +12,7 @@ import makeResponsive from 'views/hocs/makeResponsive';
 import FilterGroup from 'utils/filters/FilterGroup';
 import ModuleFilter from 'utils/filters/ModuleFilter';
 import { highlight } from 'utils/react';
-import { breakpointUp } from 'utils/css';
+import { breakpointDown, touchScreenOnly } from 'utils/css';
 import styles from './styles.scss';
 import Checklist from './Checklist';
 
@@ -92,7 +92,30 @@ export class DropdownListFiltersComponent extends PureComponent<Props, State> {
         </h4>
 
         {/* Use a search-select combo dropdown on desktop */}
+        {/* Use a native select for mobile devices */}
         {matchBreakpoint ?
+          <select
+            className="form-control"
+            id={htmlId}
+            onChange={(evt) => {
+              this.onSelectItem(evt.target.value);
+              // Reset selection to the first placeholder item so that the last selected item
+              // is not left selected in the <select>
+              evt.target.selectedIndex = 0; // eslint-disable-line no-param-reassign
+            }}
+          >
+            <option>{placeholder}</option>
+            {this.displayedFilters().map(([filter, count]) => (
+              <option key={filter.id} value={filter.id}>
+                {/* Extra layer of interpolation to workaround https://github.com/facebook/react/issues/11911 */}
+                {/* Use a unicode checkbox to indicate to the user filters that are already enabled */}
+                {filter.enabled
+                  ? `☑ ${filter.label} (${count})`
+                  : `${filter.label} (${count})`}
+              </option>
+            ))}
+          </select>
+          :
           <Downshift
             breakingChanges={{ resetInputOnSelection: true }}
             onChange={(selectedItem, { clearSelection }) => {
@@ -157,30 +180,7 @@ export class DropdownListFiltersComponent extends PureComponent<Props, State> {
                   </div>}
               </div>
             )}
-          />
-          :
-          /* Use a native select for mobile devices */
-          <select
-            className="form-control"
-            id={htmlId}
-            onChange={(evt) => {
-              this.onSelectItem(evt.target.value);
-              // Reset selection to the first placeholder item so that the last selected item
-              // is not left selected in the <select>
-              evt.target.selectedIndex = 0; // eslint-disable-line no-param-reassign
-            }}
-          >
-            <option>{placeholder}</option>
-            {this.displayedFilters().map(([filter, count]) => (
-              <option key={filter.id} value={filter.id}>
-                {/* Extra layer of interpolation to workaround https://github.com/facebook/react/issues/11911 */}
-                {/* Use a unicode checkbox to indicate to the user filters that are already enabled */}
-                {filter.enabled
-                  ? `☑ ${filter.label} (${count})`
-                  : `${filter.label} (${count})`}
-              </option>
-            ))}
-          </select>}
+          />}
 
         {/* Show all filters that have been selected at some point */}
         <Checklist
@@ -193,4 +193,4 @@ export class DropdownListFiltersComponent extends PureComponent<Props, State> {
   }
 }
 
-export default makeResponsive(DropdownListFiltersComponent, breakpointUp('md'));
+export default makeResponsive(DropdownListFiltersComponent, [breakpointDown('sm'), touchScreenOnly()]);

--- a/v3/src/js/views/components/filters/DropdownListFilters.test.jsx
+++ b/v3/src/js/views/components/filters/DropdownListFilters.test.jsx
@@ -17,7 +17,7 @@ describe('<DropdownListFilters>', () => {
   function make(
     filterGroup: FilterGroup<*>,
     groups: FilterGroup<any>[] = [filterGroup],
-    matchBreakpoint: boolean = true,
+    matchBreakpoint: boolean = false,
   ) {
     const onFilterChange = jest.fn();
 
@@ -39,7 +39,7 @@ describe('<DropdownListFilters>', () => {
   //       to ensure values in both match
   test('use native <select> element on mobile', () => {
     const group = createGroup(modules);
-    const { wrapper } = make(group, [group], false);
+    const { wrapper } = make(group, [group], true);
 
     expect(wrapper.find('select').exists()).toBe(true);
     expect(wrapper.find('option')).toHaveLength(3); // One placeholder and two options
@@ -49,7 +49,7 @@ describe('<DropdownListFilters>', () => {
 
   test('change value when <select> value changes', () => {
     const group = createGroup(modules);
-    const { wrapper, onFilterChange } = make(group, [group], false);
+    const { wrapper, onFilterChange } = make(group, [group], true);
 
     // Simulate selecting an <option> in the <select>
     wrapper.find('select').simulate('change', { target: { value: 'a' } });
@@ -69,7 +69,7 @@ describe('<DropdownListFilters>', () => {
 
   test('render a list of previously selected items outside the <select>', () => {
     const group = createGroup(modules).toggle('a');
-    const { wrapper, onFilterChange } = make(group, [group], false);
+    const { wrapper, onFilterChange } = make(group, [group], true);
 
     // Should render the item in the checklist outside
     const checklist1 = wrapper.find('ul.list-unstyled input');

--- a/v3/src/js/views/components/filters/styles.scss
+++ b/v3/src/js/views/components/filters/styles.scss
@@ -123,6 +123,10 @@ $h-padding: $grid-gutter-width / 2;
     background: var(--gray-lightest);
   }
 
+  select {
+    width: calc(100% - 3px);
+  }
+
   @include media-breakpoint-down(sm) {
     select {
       width: calc(100% - #{$grid-gutter-width});

--- a/v3/src/js/views/components/filters/styles.scss
+++ b/v3/src/js/views/components/filters/styles.scss
@@ -8,7 +8,7 @@ $h-padding: $grid-gutter-width / 2;
   font-weight: bold;
   font-size: $font-size-xs;
 
-  @include media-breakpoint-down(sm) {
+  @include touchscreen-only {
     padding: $v-padding $h-padding;
     font-size: $font-size-sm;
     border-bottom: 1px solid var(--gray-lighter);
@@ -33,7 +33,7 @@ $h-padding: $grid-gutter-width / 2;
     font-weight: normal;
   }
 
-  @include media-breakpoint-down(sm) {
+  @include touchscreen-only {
     font-size: $font-size-sm;
   }
 }
@@ -45,7 +45,7 @@ $h-padding: $grid-gutter-width / 2;
     padding-top: 0.1rem;
     padding-bottom: 0.1rem;
 
-    @include media-breakpoint-down(sm) {
+    @include touchscreen-only {
       padding: $v-padding $h-padding $v-padding ($h-padding + 20px);
       border-bottom: 1px solid var(--gray-lighter);
     }
@@ -123,9 +123,11 @@ $h-padding: $grid-gutter-width / 2;
     background: var(--gray-lightest);
   }
 
-  select {
-    width: calc(100% - #{$grid-gutter-width});
-    margin: 0.5rem ($grid-gutter-width / 2);
+  @include media-breakpoint-down(sm) {
+    select {
+      width: calc(100% - #{$grid-gutter-width});
+      margin: 0.5rem ($grid-gutter-width / 2);
+    }
   }
 }
 
@@ -149,7 +151,7 @@ $h-padding: $grid-gutter-width / 2;
     }
   }
 
-  @include media-breakpoint-down(sm) {
+  @include touchscreen-only {
     .heading {
       border-bottom: 0;
     }

--- a/v3/src/js/views/hocs/makeResponsive.jsx
+++ b/v3/src/js/views/hocs/makeResponsive.jsx
@@ -1,8 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 
-import { breakpointUp, wrapComponentName } from 'utils/react';
-import type { Breakpoint } from 'utils/react';
+import { wrapComponentName } from 'utils/react';
 
 type State = {
   matchBreakpoint: boolean,
@@ -10,7 +9,7 @@ type State = {
 
 function makeResponsive<Props: {}>(
   WrappedComponent: ComponentType<Props>,
-  breakpoint: Breakpoint,
+  mediaQuery: string,
 ): ComponentType<$Diff<Props, State>> {
   return class extends Component<Props, State> {
     mql: ?MediaQueryList;
@@ -22,8 +21,8 @@ function makeResponsive<Props: {}>(
     };
 
     componentDidMount() {
-      const mql = breakpointUp(breakpoint);
-      mql.addListener(e => this.updateMediaQuery(e));
+      const mql = window.matchMedia(mediaQuery);
+      mql.addListener(this.updateMediaQuery);
       this.updateMediaQuery(mql);
       this.mql = mql;
     }

--- a/v3/src/js/views/hocs/makeResponsive.jsx
+++ b/v3/src/js/views/hocs/makeResponsive.jsx
@@ -1,6 +1,8 @@
 // @flow
 import React, { Component } from 'react';
+import json2mq from 'json2mq';
 
+import type { QueryObject } from 'utils/css';
 import { wrapComponentName } from 'utils/react';
 
 type State = {
@@ -9,8 +11,10 @@ type State = {
 
 function makeResponsive<Props: {}>(
   WrappedComponent: ComponentType<Props>,
-  mediaQuery: string,
+  mediaQuery: string | QueryObject,
 ): ComponentType<$Diff<Props, State>> {
+  const media = typeof mediaQuery === 'string' ? mediaQuery : json2mq(mediaQuery);
+
   return class extends Component<Props, State> {
     mql: ?MediaQueryList;
 
@@ -21,7 +25,7 @@ function makeResponsive<Props: {}>(
     };
 
     componentDidMount() {
-      const mql = window.matchMedia(mediaQuery);
+      const mql = window.matchMedia(media);
       mql.addListener(this.updateMediaQuery);
       this.updateMediaQuery(mql);
       this.mql = mql;

--- a/v3/src/js/views/modules/ModuleFinderContainer.jsx
+++ b/v3/src/js/views/modules/ModuleFinderContainer.jsx
@@ -47,7 +47,7 @@ import { resetModuleFinder } from 'actions/moduleFinder';
 import FilterGroup from 'utils/filters/FilterGroup';
 import HistoryDebouncer from 'utils/HistoryDebouncer';
 import { defer } from 'utils/react';
-import { breakpointUp } from 'utils/css';
+import { breakpointUp, queryMatch } from 'utils/css';
 import styles from './ModuleFinderContainer.scss';
 
 type Props = {
@@ -148,7 +148,7 @@ export class ModuleFinderContainerComponent extends Component<Props, State> {
         } else {
           // By default, only turn on instant search for desktop and if the
           // benchmark earlier is fast enough
-          this.useInstantSearch = window.matchMedia(breakpointUp('sm')).matches && (time < INSTANT_SEARCH_THRESHOLD);
+          this.useInstantSearch = queryMatch(breakpointUp('sm')).matches && (time < INSTANT_SEARCH_THRESHOLD);
         }
 
         console.info(`${time}ms taken to init filters`); // eslint-disable-line

--- a/v3/src/js/views/modules/ModuleFinderContainer.jsx
+++ b/v3/src/js/views/modules/ModuleFinderContainer.jsx
@@ -279,7 +279,7 @@ export class ModuleFinderContainerComponent extends Component<Props, State> {
         {pageHead}
 
         <div className="row">
-          <div className="col-md-8 col-lg-9">
+          <div className="col">
             <h1 className="sr-only">Module Finder</h1>
 
             <ModuleSearchBox useInstantSearch={this.useInstantSearch} />

--- a/v3/src/js/views/modules/ModuleFinderContainer.jsx
+++ b/v3/src/js/views/modules/ModuleFinderContainer.jsx
@@ -46,7 +46,8 @@ import nusmods from 'apis/nusmods';
 import { resetModuleFinder } from 'actions/moduleFinder';
 import FilterGroup from 'utils/filters/FilterGroup';
 import HistoryDebouncer from 'utils/HistoryDebouncer';
-import { defer, breakpointUp } from 'utils/react';
+import { defer } from 'utils/react';
+import { breakpointUp } from 'utils/css';
 import styles from './ModuleFinderContainer.scss';
 
 type Props = {
@@ -147,7 +148,7 @@ export class ModuleFinderContainerComponent extends Component<Props, State> {
         } else {
           // By default, only turn on instant search for desktop and if the
           // benchmark earlier is fast enough
-          this.useInstantSearch = breakpointUp('md').matches && (time < INSTANT_SEARCH_THRESHOLD);
+          this.useInstantSearch = window.matchMedia(breakpointUp('md')).matches && (time < INSTANT_SEARCH_THRESHOLD);
         }
 
         console.info(`${time}ms taken to init filters`); // eslint-disable-line

--- a/v3/src/js/views/modules/ModuleFinderContainer.jsx
+++ b/v3/src/js/views/modules/ModuleFinderContainer.jsx
@@ -148,7 +148,7 @@ export class ModuleFinderContainerComponent extends Component<Props, State> {
         } else {
           // By default, only turn on instant search for desktop and if the
           // benchmark earlier is fast enough
-          this.useInstantSearch = window.matchMedia(breakpointUp('md')).matches && (time < INSTANT_SEARCH_THRESHOLD);
+          this.useInstantSearch = window.matchMedia(breakpointUp('sm')).matches && (time < INSTANT_SEARCH_THRESHOLD);
         }
 
         console.info(`${time}ms taken to init filters`); // eslint-disable-line

--- a/v3/src/js/views/settings/SettingsContainer.jsx
+++ b/v3/src/js/views/settings/SettingsContainer.jsx
@@ -16,7 +16,7 @@ import FacultySelect from 'views/components/FacultySelect';
 import NewStudentSelect from 'views/components/NewStudentSelect';
 import ScrollToTop from 'views/components/ScrollToTop';
 import Timetable from 'views/timetable/Timetable';
-import { supportsCSSVariables } from 'utils/react';
+import { supportsCSSVariables } from 'utils/css';
 
 import ThemeOption from './ThemeOption';
 import ModeSelect from './ModeSelect';

--- a/v3/src/styles/utils/mixins.scss
+++ b/v3/src/styles/utils/mixins.scss
@@ -8,7 +8,7 @@
   }
 }
 
-@mixin mobile-landscape() {
+@mixin mobile-landscape {
   @include media-breakpoint-down(sm) {
     @media (max-height: 15rem) {
       @content;
@@ -16,7 +16,7 @@
   }
 }
 
-@mixin scrollable() {
+@mixin scrollable {
   overflow: auto;
 
   // @supports is used here because Safari requires overflow: scroll to be used in conjunction with
@@ -25,5 +25,11 @@
   @supports (-webkit-overflow-scrolling: touch) {
     overflow: scroll;
     -webkit-overflow-scrolling: touch;
+  }
+}
+
+@mixin touchscreen-only() {
+  @media (pointer: coarse) {
+    @content;
   }
 }

--- a/v3/yarn.lock
+++ b/v3/yarn.lock
@@ -4844,6 +4844,12 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+json2mq@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
+  dependencies:
+    string-convert "^0.2.0"
+
 json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -7731,6 +7737,10 @@ stream-shift@^1.0.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #547 

This PR refactors the CSS utilities to return CSS media queries represented in object format instead of strings to allow them to be composed together, via the [json2mq](https://github.com/akiran/json2mq) library. It also makes the `makeResponsive` HOC take in a media query object / string instead of just Bootstrap breakpoints. 

Using `pointer: coarse` media query, which has [good support on Chrome and Safari](https://caniuse.com/#feat=css-media-interaction), we make the module filter UI enable touch styling (larger surfaces, use native `<select>` instead of the custom combo-box for selecting department/faculty filters) when the device is a touchscreen instead of just targeting smaller screens. 

![screenshot from 2017-12-25 19-58-44](https://user-images.githubusercontent.com/445650/34339360-0ad6ee7c-e9ae-11e7-98d6-037742b07e8d.png)

(Desktop Chrome simulating iPad) 
