### PR TITLE
Switch navtab's second breakpoint to xl from lg

### DIFF
--- a/v3/src/js/views/layout/Navtabs.scss
+++ b/v3/src/js/views/layout/Navtabs.scss
@@ -24,7 +24,7 @@
     box-shadow: none;
   }
 
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-up(xl) {
     margin-top: 1rem;
   }
 
@@ -83,7 +83,7 @@
     padding: 1rem 0.5rem;
   }
 
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-up(xl) {
     display: flex;
     align-items: center;
     padding: 0.8rem 0 0.8rem 2rem;
@@ -99,7 +99,7 @@
     display: block;
   }
 
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-up(xl) {
     margin-left: 0.4rem;
     font-size: 1rem;
   }

--- a/v3/src/styles/layout/site.scss
+++ b/v3/src/styles/layout/site.scss
@@ -51,7 +51,7 @@ a {
     }
   }
 
-  @include media-breakpoint-up(lg) {
+  @include media-breakpoint-up(xl) {
     > nav {
       width: $side-nav-width-lg;
     }


### PR DESCRIPTION
The problem with using lg as the breakpoint is that at the lower end (~992px) the horizontal timetable doesn't have enough space.  This change also makes the layout less cramped on other pages. The most popular device that uses this screen size is of course the iPad on landscape. 

Before: 

![screenshot from 2017-12-25 22-45-00](https://user-images.githubusercontent.com/445650/34340775-561268e6-e9c5-11e7-98c0-1fefde49bd11.png)

After: 

![screenshot from 2017-12-25 22-44-21](https://user-images.githubusercontent.com/445650/34340774-55e2db94-e9c5-11e7-925e-386b8ac4cda2.png)

