### PR TITLE
Fix 'cannot declare a variable twice' bug in Safari 10 

### DIFF
--- a/v3/webpack/webpack.parts.js
+++ b/v3/webpack/webpack.parts.js
@@ -186,6 +186,10 @@ exports.minifyJavascript = () => {
         sourceMap: true,
         // See: https://github.com/mishoo/UglifyJS2/tree/harmony
         uglifyOptions: {
+          mangle: {
+            // Required to avoid Safari 10 bug https://github.com/mishoo/UglifyJS2/issues/1753
+            safari10: true,
+          },
           // Don't beautify output (enable for neater output).
           beautify: false,
           // Eliminate comments.


### PR DESCRIPTION
This is a bug in Safari 10. The Uglify JS mangle option should hopefully prevent it. 