### PR TITLE
Fix URL shortener

### DIFF
--- a/v3/src/js/views/timetable/ShareTimetable.jsx
+++ b/v3/src/js/views/timetable/ShareTimetable.jsx
@@ -49,7 +49,7 @@ export default class ShareTimetable extends PureComponent<Props, State> {
   };
 
   loadShortUrl(url: string) {
-    return axios.get('https://nusmods.com/short_url.php', { data: { url }, timeout: 2000 })
+    return axios.get('https://nusmods.com/short_url.php', { params: { url }, timeout: 2000 })
       .then(({ data }) => this.setState({ shortUrl: data.shortUrl }))
       // Cannot get short URL - just use long URL instead
       .catch(() => this.setState({ shortUrl: url }));


### PR DESCRIPTION
Made a mistake in assuming axios was like jQuery - the correct config key for sending out query strings is `params`, not `data` 