### PR TITLE
Show commits differences during promote staging

### DIFF
--- a/v3/scripts/promote-staging.sh
+++ b/v3/scripts/promote-staging.sh
@@ -35,13 +35,13 @@ if [[ -d $PROD_DIR ]]; then
 fi
 
 DEPLOYMENT_COMMIT=$(cat $STAGING_DIR/app.*js | grep -Eo "20\d{6}-[0-9a-f]{7}" | cut -d '-' -f 2)
-LOG_FORMAT="%h %s by %an%n"
+LOG_FORMAT="%h %s by %an"
 
 echo
 if [[ "$PROD_COMMIT" = "$DEPLOYMENT_COMMIT" ]]; then
   echo "No changes to be deployed, both src and dst dirs are on:"
   echo
-  git --no-pager log --pretty=format:"$LOG_FORMAT" $PROD_COMMIT -1
+  git --no-pager log --pretty=format:"$LOG_FORMAT%n" $PROD_COMMIT -1
   echo
   echo "But you may continue anyway"
 elif [[ "$PROD_COMMIT" = "" ]]; then
@@ -51,6 +51,7 @@ else
   echo "The following commits will be deployed:"
   echo
   git --no-pager log --pretty=format:"$LOG_FORMAT" $PROD_COMMIT...$DEPLOYMENT_COMMIT
+  echo
 fi
 echo
 

--- a/v3/scripts/promote-staging.sh
+++ b/v3/scripts/promote-staging.sh
@@ -29,27 +29,28 @@ echo
 echo "Dry running deployment..."
 npm run rsync -- --dry-run $PROD_DIR
 
-PROD_COMMIT=''
+PROD_COMMIT=""
 if [[ -d $PROD_DIR ]]; then
   PROD_COMMIT=$(cat $PROD_DIR/app.*js | grep -Eo "20\d{6}-[0-9a-f]{7}" | cut -d '-' -f 2)
 fi
 
 DEPLOYMENT_COMMIT=$(cat $STAGING_DIR/app.*js | grep -Eo "20\d{6}-[0-9a-f]{7}" | cut -d '-' -f 2)
+LOG_FORMAT="%h %s by %an%n"
 
 echo
 if [[ "$PROD_COMMIT" = "$DEPLOYMENT_COMMIT" ]]; then
   echo "No changes to be deployed, both src and dst dirs are on:"
   echo
-  git --no-pager log --pretty=oneline $PROD_COMMIT -1
+  git --no-pager log --pretty=format:"$LOG_FORMAT" $PROD_COMMIT -1
   echo
   echo "But you may continue anyway"
-elif [[ "$PROD_COMMIT" = '' ]]; then
+elif [[ "$PROD_COMMIT" = "" ]]; then
   # Usually a case of a fresh deployment. This almost never happens.
   echo "No existing version found in production dir."
 else
   echo "The following commits will be deployed:"
   echo
-  git --no-pager log --pretty=oneline $PROD_COMMIT...$DEPLOYMENT_COMMIT
+  git --no-pager log --pretty=format:"$LOG_FORMAT" $PROD_COMMIT...$DEPLOYMENT_COMMIT
 fi
 echo
 

--- a/v3/scripts/promote-staging.sh
+++ b/v3/scripts/promote-staging.sh
@@ -29,27 +29,27 @@ echo
 echo "Dry running deployment..."
 npm run rsync -- --dry-run $PROD_DIR
 
-CURRENT_COMMIT=''
+PROD_COMMIT=''
 if [[ -d $PROD_DIR ]]; then
-  CURRENT_COMMIT=$(cat $PROD_DIR/app.*js | grep -Eo "20\d{6}-[0-9a-f]{7}" | cut -d '-' -f 2)
+  PROD_COMMIT=$(cat $PROD_DIR/app.*js | grep -Eo "20\d{6}-[0-9a-f]{7}" | cut -d '-' -f 2)
 fi
 
 DEPLOYMENT_COMMIT=$(cat $STAGING_DIR/app.*js | grep -Eo "20\d{6}-[0-9a-f]{7}" | cut -d '-' -f 2)
 
 echo
-if [[ "$CURRENT_COMMIT" = "$DEPLOYMENT_COMMIT" ]]; then
+if [[ "$PROD_COMMIT" = "$DEPLOYMENT_COMMIT" ]]; then
   echo "No changes to be deployed, both src and dst dirs are on:"
   echo
-  git --no-pager log --pretty=oneline $CURRENT_COMMIT -1
+  git --no-pager log --pretty=oneline $PROD_COMMIT -1
   echo
   echo "But you may continue anyway"
-elif [[ "$CURRENT_COMMIT" = '' ]]; then
+elif [[ "$PROD_COMMIT" = '' ]]; then
   # Usually a case of a fresh deployment. This almost never happens.
   echo "No existing version found in production dir."
 else
   echo "The following commits will be deployed:"
   echo
-  git --no-pager log --pretty=oneline $CURRENT_COMMIT...$DEPLOYMENT_COMMIT
+  git --no-pager log --pretty=oneline $PROD_COMMIT...$DEPLOYMENT_COMMIT
 fi
 echo
 


### PR DESCRIPTION
So that we know which commits will be deployed to production with `npm run promote-staging`.

```sh
...
img/
img/nusmods-logo.2e16a09b2adbddc47e8ae921c59e9639.png
deleting app.9764cf96e7da3ce0bd5b.js.map
deleting app.9764cf96e7da3ce0bd5b.js
deleting app.9764cf96e7da3ce0bd5b.css.map
deleting app.9764cf96e7da3ce0bd5b.css

sent 834 bytes  received 194 bytes  2056.00 bytes/sec
total size is 3993024  speedup is 3884.26

The following commits will be deployed:

aed0f401 Improve log formatting by Yangshun Tay
7da4b840 s/CURRENT_COMMIT/PROD_COMMIT by Yangshun Tay
9716a772 Show commits differences during promote staging by Yangshun Tay
7ac42552 Update Bootstrap alert and modal colors on night mode  (#591) by Zhang Yi Jiang

Ready to promote? [y/N] 
```