### PR TITLE
Add dismiss button and settings for CORS reminders 

### DIFF
--- a/v3/src/js/actions/settings.js
+++ b/v3/src/js/actions/settings.js
@@ -67,6 +67,14 @@ export function dismissCorsNotification(round: string): FSA {
   };
 }
 
+export const ENABLE_CORS_NOTIFICATION = 'ENABLE_CORS_NOTIFICATION';
+export function enableCorsNotification(round: string): FSA {
+  return {
+    type: ENABLE_CORS_NOTIFICATION,
+    payload: { round },
+  };
+}
+
 export const TOGGLE_CORS_NOTIFICATION_GLOBALLY = 'TOGGLE_CORS_NOTIFICATION_GLOBALLY';
 export function toggleCorsNotificationGlobally(enabled: boolean): FSA {
   return {

--- a/v3/src/js/actions/settings.js
+++ b/v3/src/js/actions/settings.js
@@ -58,3 +58,19 @@ export function showLessonInTimetable(moduleCode: ModuleCode): FSA {
     payload: moduleCode,
   };
 }
+
+export const DISMISS_CORS_NOTIFICATION = 'DISMISS_CORS_NOTIFICATION';
+export function dismissCorsNotification(round: string): FSA {
+  return {
+    type: DISMISS_CORS_NOTIFICATION,
+    payload: { round },
+  };
+}
+
+export const TOGGLE_CORS_NOTIFICATION_GLOBALLY = 'TOGGLE_CORS_NOTIFICATION_GLOBALLY';
+export function toggleCorsNotificationGlobally(enabled: boolean): FSA {
+  return {
+    type: TOGGLE_CORS_NOTIFICATION_GLOBALLY,
+    payload: { enabled },
+  };
+}

--- a/v3/src/js/config/__mocks__/config.js
+++ b/v3/src/js/config/__mocks__/config.js
@@ -4,6 +4,10 @@ const mockConfig = {
   ...config,
   academicYear: '2017/2018',
   semester: 1,
+
+  getSemesterKey: () => {
+    return '2017/2018 Semester 1';
+  },
 };
 
 export default mockConfig;

--- a/v3/src/js/config/config.test.js
+++ b/v3/src/js/config/config.test.js
@@ -1,7 +1,9 @@
 // @flow
+import _ from 'lodash';
 import { roundEnd } from 'utils/cors';
 import academicCalendar from 'data/academic-calendar.json';
 import config from './index';
+import { Semesters } from '../types/modules';
 
 function isSorted(arr: Array<*>) {
   return arr.slice(1).every((item, index) => item >= arr[index]);
@@ -15,5 +17,21 @@ test('CORS schedule is sorted', () => {
   expect(isSorted(config.corsSchedule.map(roundEnd))).toBe(true);
   config.corsSchedule.forEach((round) => {
     expect(isSorted(round.periods.map(period => period.endDate))).toBe(true);
+  });
+});
+
+test('getSemesterKey() should be unique for every acad year / semester', () => {
+  const keys = new Set();
+
+  _.range(0, 40).forEach((offset) => {
+    const year = 2010 + offset;
+    config.academicYear = `${year}/${year + 1}`;
+
+    Semesters.forEach((semester) => {
+      config.semester = semester;
+
+      expect(keys.has(config.getSemesterKey())).toBe(false);
+      keys.add(config.getSemesterKey());
+    });
   });
 });

--- a/v3/src/js/config/index.js
+++ b/v3/src/js/config/index.js
@@ -24,6 +24,7 @@ export type Config = {
   brandName: string,
   academicYear: AcadYear,
   semester: Semester,
+  getSemesterKey: () => string,
 
   apiBaseUrl: string,
   corsUrl: string,
@@ -76,6 +77,13 @@ const augmentedConfig: Config = {
   holidays: holidays.map(date => new Date(date)),
 
   corsSchedule: corsData.map(convertCorsDate),
+
+  /**
+   * Returns a unique key for every acad year + semester
+   */
+  getSemesterKey: (): string => {
+    return `${augmentedConfig.academicYear} ${augmentedConfig.semesterNames[augmentedConfig.semester]}`;
+  },
 };
 
 export default augmentedConfig;

--- a/v3/src/js/reducers/app.test.js
+++ b/v3/src/js/reducers/app.test.js
@@ -9,6 +9,7 @@ import reducer from 'reducers/app';
 import type { Lesson, Semester } from 'types/modules';
 import type { FSA } from 'types/redux';
 import type { AppState } from 'types/reducers';
+import { initAction } from 'test-utils/redux';
 import lessons from '__mocks__/lessons-array.json';
 
 const semester: Semester = 1;
@@ -24,7 +25,7 @@ const appHasSemesterTwoState: AppState = { ...appInitialState, activeSemester: a
 const appHasActiveLessonState: AppState = { ...appInitialState, activeLesson: lesson };
 
 test('app should return initial state', () => {
-  const nextState: AppState = reducer(undefined, { type: 'INIT', payload: null });
+  const nextState: AppState = reducer(undefined, initAction());
 
   expect(nextState).toEqual(appInitialState);
 });

--- a/v3/src/js/reducers/settings.js
+++ b/v3/src/js/reducers/settings.js
@@ -1,6 +1,8 @@
 // @flow
-import type { FSA } from 'types/redux';
+import { uniq } from 'lodash';
 import update from 'immutability-helper';
+
+import type { FSA } from 'types/redux';
 import type {
   SettingsState,
 } from 'types/reducers';
@@ -12,6 +14,8 @@ import {
   TOGGLE_MODE,
   HIDE_LESSON_IN_TIMETABLE,
   SHOW_LESSON_IN_TIMETABLE,
+  DISMISS_CORS_NOTIFICATION,
+  TOGGLE_CORS_NOTIFICATION_GLOBALLY,
 } from 'actions/settings';
 import { LIGHT_MODE, DARK_MODE } from 'types/settings';
 import config from 'config';
@@ -72,6 +76,21 @@ function settings(state: SettingsState = defaultSettingsState, action: FSA): Set
         ...state,
         hiddenInTimetable: hidden(state.hiddenInTimetable, action),
       };
+
+    case TOGGLE_CORS_NOTIFICATION_GLOBALLY:
+      return update(state, {
+        corsNotification: {
+          enabled: { $set: action.payload.enabled },
+        },
+      });
+
+    case DISMISS_CORS_NOTIFICATION:
+      return update(state, {
+        corsNotification: {
+          dismissed: rounds => uniq([...rounds, action.payload.round]),
+        },
+      });
+
     default:
       // Rehydrating from store - check that the key is the same, and if not,
       // return to default state since the old dismissed notification settings is stale

--- a/v3/src/js/reducers/settings.js
+++ b/v3/src/js/reducers/settings.js
@@ -91,11 +91,19 @@ function settings(state: SettingsState = defaultSettingsState, action: FSA): Set
         },
       });
 
-    default:
+    default: {
+      let nextState = state;
+
+      if (!nextState.corsNotification) {
+        nextState = update(nextState, {
+          corsNotification: { $set: defaultCorsNotificationState },
+        });
+      }
+
       // Rehydrating from store - check that the key is the same, and if not,
       // return to default state since the old dismissed notification settings is stale
-      if (state.corsNotification.semesterKey !== config.getSemesterKey()) {
-        return update(state, {
+      if (nextState.corsNotification.semesterKey !== config.getSemesterKey()) {
+        nextState = update(nextState, {
           corsNotification: {
             semesterKey: { $set: config.getSemesterKey() },
             dismissed: { $set: [] },
@@ -103,7 +111,8 @@ function settings(state: SettingsState = defaultSettingsState, action: FSA): Set
         });
       }
 
-      return state;
+      return nextState;
+    }
   }
 }
 

--- a/v3/src/js/reducers/settings.js
+++ b/v3/src/js/reducers/settings.js
@@ -1,5 +1,5 @@
 // @flow
-import { uniq } from 'lodash';
+import { uniq, without } from 'lodash';
 import update from 'immutability-helper';
 
 import type { FSA } from 'types/redux';
@@ -15,6 +15,7 @@ import {
   HIDE_LESSON_IN_TIMETABLE,
   SHOW_LESSON_IN_TIMETABLE,
   DISMISS_CORS_NOTIFICATION,
+  ENABLE_CORS_NOTIFICATION,
   TOGGLE_CORS_NOTIFICATION_GLOBALLY,
 } from 'actions/settings';
 import { LIGHT_MODE, DARK_MODE } from 'types/settings';
@@ -88,6 +89,13 @@ function settings(state: SettingsState = defaultSettingsState, action: FSA): Set
       return update(state, {
         corsNotification: {
           dismissed: rounds => uniq([...rounds, action.payload.round]),
+        },
+      });
+
+    case ENABLE_CORS_NOTIFICATION:
+      return update(state, {
+        corsNotification: {
+          dismissed: rounds => without(rounds, action.payload.round),
         },
       });
 

--- a/v3/src/js/reducers/settings.test.js
+++ b/v3/src/js/reducers/settings.test.js
@@ -6,6 +6,7 @@ import type { SettingsState } from 'types/reducers';
 import * as actions from 'actions/settings';
 import reducer from 'reducers/settings';
 import { LIGHT_MODE, DARK_MODE } from 'types/settings';
+import { initAction } from 'test-utils/redux';
 import config from 'config/__mocks__/config';
 
 const initialState: SettingsState = {
@@ -33,7 +34,7 @@ const settingsWithDismissedNotifications: SettingsState = {
 
 describe('settings', () => {
   test('settings should return initial state', () => {
-    const nextState: SettingsState = reducer(undefined, { type: 'INIT', payload: null });
+    const nextState: SettingsState = reducer(undefined, initAction());
     expect(nextState).toEqual(initialState);
   });
 
@@ -71,7 +72,7 @@ describe('settings', () => {
   test('will clear out dismissed notifications when semester changes', () => {
     config.getSemesterKey = () => '2017/2018 Semester 2';
 
-    const nextState: SettingsState = reducer(settingsWithDismissedNotifications, { type: 'INIT', payload: null });
+    const nextState: SettingsState = reducer(settingsWithDismissedNotifications, initAction());
     expect(nextState.corsNotification).toMatchObject({
       semesterKey: '2017/2018 Semester 2',
       dismissed: [],
@@ -84,7 +85,7 @@ describe('settings', () => {
     const settingsState = _.cloneDeep(settingsWithDismissedNotifications);
     settingsState.corsNotification.enabled = false;
 
-    const nextState: SettingsState = reducer(settingsState, { type: 'INIT', payload: null });
+    const nextState: SettingsState = reducer(settingsState, initAction());
     expect(nextState.corsNotification).toHaveProperty('enabled', false);
   });
 });

--- a/v3/src/js/reducers/settings.test.js
+++ b/v3/src/js/reducers/settings.test.js
@@ -68,8 +68,10 @@ describe('settings', () => {
     const nextState2: SettingsState = reducer(nextState, action);
     expect(nextState2).toEqual(initialState);
   });
+});
 
-  test('will clear out dismissed notifications when semester changes', () => {
+describe('corsNotification settings', () => {
+  test('clear out dismissed notifications when semester changes', () => {
     config.getSemesterKey = () => '2017/2018 Semester 2';
 
     const nextState: SettingsState = reducer(settingsWithDismissedNotifications, initAction());
@@ -80,12 +82,31 @@ describe('settings', () => {
     });
   });
 
-  test('will not clear disabled when semester changes', () => {
+  test('not clear disabled when semester changes', () => {
     config.getSemesterKey = () => '2017/2018 Semester 2';
     const settingsState = _.cloneDeep(settingsWithDismissedNotifications);
     settingsState.corsNotification.enabled = false;
 
     const nextState: SettingsState = reducer(settingsState, initAction());
     expect(nextState.corsNotification).toHaveProperty('enabled', false);
+  });
+
+  test('dismiss CORS notification', () => {
+    const state1 = reducer(initialState, actions.dismissCorsNotification('1A'));
+    expect(state1.corsNotification.dismissed).toEqual(['1A']);
+
+    const state2 = reducer(state1, actions.dismissCorsNotification('1B'));
+    expect(state2.corsNotification.dismissed).toEqual(['1A', '1B']);
+
+    const state3 = reducer(state2, actions.dismissCorsNotification('1B'));
+    expect(state3.corsNotification.dismissed).toEqual(['1A', '1B']);
+  });
+
+  test('toggle CORS notification globally', () => {
+    const state1 = reducer(initialState, actions.toggleCorsNotificationGlobally(true));
+    expect(state1.corsNotification.enabled).toEqual(true);
+
+    const state2 = reducer(initialState, actions.toggleCorsNotificationGlobally(false));
+    expect(state2.corsNotification.enabled).toEqual(false);
   });
 });

--- a/v3/src/js/reducers/settings.test.js
+++ b/v3/src/js/reducers/settings.test.js
@@ -1,56 +1,90 @@
 // @flow
+import _ from 'lodash';
 import type { FSA } from 'types/redux';
 import type { SettingsState } from 'types/reducers';
 
 import * as actions from 'actions/settings';
 import reducer from 'reducers/settings';
 import { LIGHT_MODE, DARK_MODE } from 'types/settings';
+import config from 'config/__mocks__/config';
 
-const settingsInitialState: SettingsState = {
+const initialState: SettingsState = {
   newStudent: false,
   faculty: '',
   mode: LIGHT_MODE,
   hiddenInTimetable: [],
+  corsNotification: {
+    enabled: true,
+    semesterKey: config.getSemesterKey(),
+    dismissed: [],
+  },
 };
-const settingsWithNewStudent: SettingsState = { ...settingsInitialState, newStudent: true };
+const settingsWithNewStudent: SettingsState = { ...initialState, newStudent: true };
 const faculty = 'School of Computing';
-const settingsWithFaculty: SettingsState = { ...settingsInitialState, faculty };
-const settingsWithDarkMode: SettingsState = { ...settingsInitialState, mode: DARK_MODE };
+const settingsWithFaculty: SettingsState = { ...initialState, faculty };
+const settingsWithDarkMode: SettingsState = { ...initialState, mode: DARK_MODE };
+const settingsWithDismissedNotifications: SettingsState = {
+  ...initialState,
+  corsNotification: {
+    ...initialState.corsNotification,
+    dismissed: ['0', '1A'],
+  },
+};
 
 describe('settings', () => {
   test('settings should return initial state', () => {
     const nextState: SettingsState = reducer(undefined, { type: 'INIT', payload: null });
-    expect(nextState).toEqual(settingsInitialState);
+    expect(nextState).toEqual(initialState);
   });
 
   test('can select new student', () => {
     const action: FSA = actions.selectNewStudent(true);
-    const nextState: SettingsState = reducer(settingsInitialState, action);
+    const nextState: SettingsState = reducer(initialState, action);
     expect(nextState).toEqual(settingsWithNewStudent);
   });
 
   test('can select faculty', () => {
     const action: FSA = actions.selectFaculty(faculty);
-    const nextState: SettingsState = reducer(settingsInitialState, action);
+    const nextState: SettingsState = reducer(initialState, action);
     expect(nextState).toEqual(settingsWithFaculty);
   });
 
   test('can select mode', () => {
     const action: FSA = actions.selectMode(DARK_MODE);
-    const nextState: SettingsState = reducer(settingsInitialState, action);
+    const nextState: SettingsState = reducer(initialState, action);
     expect(nextState).toEqual(settingsWithDarkMode);
 
     const action2: FSA = actions.selectMode(LIGHT_MODE);
     const nextState2: SettingsState = reducer(nextState, action2);
-    expect(nextState2).toEqual(settingsInitialState);
+    expect(nextState2).toEqual(initialState);
   });
 
   test('can toggle mode', () => {
     const action: FSA = actions.toggleMode();
-    const nextState: SettingsState = reducer(settingsInitialState, action);
+    const nextState: SettingsState = reducer(initialState, action);
     expect(nextState).toEqual(settingsWithDarkMode);
 
     const nextState2: SettingsState = reducer(nextState, action);
-    expect(nextState2).toEqual(settingsInitialState);
+    expect(nextState2).toEqual(initialState);
+  });
+
+  test('will clear out dismissed notifications when semester changes', () => {
+    config.getSemesterKey = () => '2017/2018 Semester 2';
+
+    const nextState: SettingsState = reducer(settingsWithDismissedNotifications, { type: 'INIT', payload: null });
+    expect(nextState.corsNotification).toMatchObject({
+      semesterKey: '2017/2018 Semester 2',
+      dismissed: [],
+      enabled: true,
+    });
+  });
+
+  test('will not clear disabled when semester changes', () => {
+    config.getSemesterKey = () => '2017/2018 Semester 2';
+    const settingsState = _.cloneDeep(settingsWithDismissedNotifications);
+    settingsState.corsNotification.enabled = false;
+
+    const nextState: SettingsState = reducer(settingsState, { type: 'INIT', payload: null });
+    expect(nextState.corsNotification).toHaveProperty('enabled', false);
   });
 });

--- a/v3/src/js/test-utils/createHistory.js
+++ b/v3/src/js/test-utils/createHistory.js
@@ -1,0 +1,36 @@
+// @flow
+
+import type { ContextRouter } from 'react-router-dom';
+import _ from 'lodash';
+
+// react-router-dom internal dependency, used here to construct the history
+// object needed for testing. This is not added as a dev dependency to avoid
+// version desync between the version depended on by react-router-dom
+import createMemoryHistory from 'history/createMemoryHistory'; // eslint-disable-line import/no-extraneous-dependencies
+
+type MatchShape = {
+  params?: { [string]: ?string },
+  isExact?: boolean
+}
+
+export default function createHistory(
+  initialEntries: string | string[] = '/',
+  matchParams: MatchShape = {},
+): ContextRouter {
+  const entries = _.castArray(initialEntries);
+  const history = createMemoryHistory({ initialEntries: entries });
+  const { params = {}, isExact = true } = matchParams;
+
+  const match = {
+    params,
+    isExact,
+    path: entries[0],
+    url: entries[0],
+  };
+
+  return {
+    history,
+    match,
+    location: history.location,
+  };
+}

--- a/v3/src/js/test-utils/redux.js
+++ b/v3/src/js/test-utils/redux.js
@@ -1,0 +1,10 @@
+// @flow
+import type { FSA } from 'types/redux';
+
+// eslint-disable-next-line import/prefer-default-export
+export function initAction(): FSA {
+  return {
+    type: 'INIT',
+    payload: null,
+  };
+}

--- a/v3/src/js/types/reducers.js
+++ b/v3/src/js/types/reducers.js
@@ -44,6 +44,12 @@ export type SettingsState = {
   faculty: ?Faculty,
   mode: Mode,
   hiddenInTimetable: ModuleCode[],
+
+  corsNotification: {
+    enabled: boolean,
+    semesterKey: string,
+    dismissed: string[],
+  },
 };
 
 /* moduleBank.js */

--- a/v3/src/js/types/reducers.js
+++ b/v3/src/js/types/reducers.js
@@ -39,17 +39,18 @@ export type ThemeState = {
 };
 
 /* settings */
+export type CorsNotificationSettings = {
+  enabled: boolean,
+  semesterKey: string,
+  dismissed: string[],
+}
+
 export type SettingsState = {
   newStudent: boolean,
   faculty: ?Faculty,
   mode: Mode,
   hiddenInTimetable: ModuleCode[],
-
-  corsNotification: {
-    enabled: boolean,
-    semesterKey: string,
-    dismissed: string[],
-  },
+  corsNotification: CorsNotificationSettings,
 };
 
 /* moduleBank.js */

--- a/v3/src/js/utils/HistoryDebouncer.test.js
+++ b/v3/src/js/utils/HistoryDebouncer.test.js
@@ -1,11 +1,11 @@
 // @flow
 
-import createHistory from 'history/createMemoryHistory'; // eslint-disable-line import/no-extraneous-dependencies
+import createHistory from 'test-utils/createHistory';
 import HistoryDebouncer from './HistoryDebouncer';
 
 describe('HistoryDebouncer', () => {
-  function createHistoryMock(initialEntries = []) {
-    const history = createHistory(initialEntries);
+  function createHistoryMock(initialEntries = ['/']) {
+    const { history } = createHistory(initialEntries);
     jest.spyOn(history, 'push');
     jest.spyOn(history, 'replace');
 

--- a/v3/src/js/utils/cors.js
+++ b/v3/src/js/utils/cors.js
@@ -1,7 +1,7 @@
 // @flow
 import { first, groupBy, head, last, map, mapValues, min, sumBy } from 'lodash';
 
-import type { CorsRound } from 'config';
+import type { CorsRound, CorsPeriod } from 'config';
 import type { BiddingStat, GroupedBiddingStat, SemesterStats, StudentType, BiddingSummary } from 'types/cors';
 import { studentTypes, NON_BIDDING, NEW_STUDENT, RETURNING_STUDENT, GENERAL_ACCOUNT } from 'types/cors';
 import config from 'config';
@@ -137,4 +137,12 @@ export function roundStart(round: CorsRound): Date {
 
 export function roundEnd(round: CorsRound): Date {
   return last(round.periods).endDate;
+}
+
+export function currentRound(now: Date = new Date()): ?CorsRound {
+  return config.corsSchedule.find(round => roundEnd(round) > now);
+}
+
+export function currentPeriod(round: CorsRound, now: Date = new Date()): ?CorsPeriod {
+  return round.periods.find(period => period.endDate > now);
 }

--- a/v3/src/js/views/Toggle.jsx
+++ b/v3/src/js/views/Toggle.jsx
@@ -1,0 +1,43 @@
+// @flow
+
+import React, { PureComponent } from 'react';
+import classnames from 'classnames';
+
+type Props = {
+  labels: [string, string],
+  isOn: ?boolean,
+
+  onChange: boolean => void,
+};
+
+export default class Toggle extends PureComponent<Props> {
+  static defaultProps = {
+    labels: ['On', 'Off'],
+  };
+
+  render() {
+    const { labels, isOn, onChange } = this.props;
+
+    return (
+      <div className="btn-group" role="group">
+        {labels.map((label, index) => {
+          const value = index === 0;
+
+          return (
+            <button
+              key={label}
+              type="button"
+              className={classnames('btn', {
+                'btn-primary': value === isOn,
+                'btn-outline-primary': value !== isOn,
+              })}
+              onClick={() => {
+                if (value !== isOn) onChange(value);
+              }}
+            >{label}</button>
+          );
+        })}
+      </div>
+    );
+  }
+}

--- a/v3/src/js/views/components/cors-info/CorsNotification.jsx
+++ b/v3/src/js/views/components/cors-info/CorsNotification.jsx
@@ -15,6 +15,9 @@ import CloseButton from 'views/components/CloseButton';
 import styles from './CorsNotification.scss';
 
 type Props = {
+  // True only in the preview in the settings page since we don't want
+  // users accidentally dismissing that
+  hideCloseButton?: boolean,
   enabled: boolean,
   dismissedRounds: string[],
 
@@ -58,7 +61,7 @@ export class CorsNotificationComponent extends PureComponent<Props> {
   }
 
   render() {
-    const { enabled, dismissedRounds } = this.props;
+    const { enabled, dismissedRounds, hideCloseButton } = this.props;
 
     // User has disabled CORS notification globally
     if (!enabled) return null;
@@ -77,10 +80,11 @@ export class CorsNotificationComponent extends PureComponent<Props> {
           <div className={styles.notification}>{corsNotificationText(true, round, this.currentTime())}</div>
         </a>
 
-        <CloseButton
-          className={styles.close}
-          onClick={() => this.props.dismissCorsNotification(round.round)}
-        />
+        {!hideCloseButton &&
+          <CloseButton
+            className={styles.close}
+            onClick={() => this.props.dismissCorsNotification(round.round)}
+          />}
       </div>
     );
   }

--- a/v3/src/js/views/components/cors-info/CorsNotification.jsx
+++ b/v3/src/js/views/components/cors-info/CorsNotification.jsx
@@ -1,16 +1,27 @@
 // @flow
 
 import React, { PureComponent } from 'react';
-import { capitalize } from 'lodash';
+import { connect } from 'react-redux';
 import { withRouter, type ContextRouter } from 'react-router-dom';
+import { capitalize } from 'lodash';
 import qs from 'query-string';
 
-import config, { type CorsRound } from 'config';
+import type { State } from 'reducers';
+import config, { type CorsRound, type CorsPeriod } from 'config';
+import { dismissCorsNotification } from 'actions/settings';
 import { roundStart, roundEnd } from 'utils/cors';
+import CloseButton from 'views/components/CloseButton';
 
 import styles from './CorsNotification.scss';
 
-type Props = ContextRouter;
+type Props = {
+  enabled: boolean,
+  dismissedRounds: string[],
+
+  dismissCorsNotification: string => void,
+
+  ...ContextRouter,
+};
 
 const NOW = new Date();
 
@@ -27,34 +38,55 @@ export class CorsNotificationComponent extends PureComponent<Props> {
     return NOW;
   }
 
-  currentCorsRound() {
+  currentCorsRound(): ?CorsRound {
     return config.corsSchedule.find(round => roundEnd(round) > this.currentTime());
   }
 
-  currentPeriod(round: CorsRound) {
+  currentPeriod(round: CorsRound): ?CorsPeriod {
     return round.periods.find(period => period.endDate > this.currentTime());
   }
 
   render() {
+    const { enabled, dismissedRounds } = this.props;
+
+    // User has disabled CORS notification globally
+    if (!enabled) return null;
+
     const round = this.currentCorsRound();
 
     // CORS bidding is over - don't show anything
     if (!round) return null;
+    // User has dismissed this round of CORS notifications
+    if (dismissedRounds.includes(round.round)) return null;
+
     const period = this.currentPeriod(round);
     if (!period) return null; // Shouldn't happen
 
     const isRoundOpen = this.currentTime() >= period.startDate;
     return (
-      <a href="https://myaces.nus.edu.sg/cors/StudentLogin" target="_blank" rel="noopener noreferrer">
-        <div className={styles.wrapper}>
-          {isRoundOpen ? 'Current' : 'Next'} CORS round: <strong>{round.round} ({capitalize(period.type)})</strong>
-          {isRoundOpen ? ' till' : ' at'} <br />
-          <strong>{isRoundOpen ? period.end : period.start}</strong>
-        </div>
-      </a>
+      <div className={styles.wrapper}>
+        <a href="https://myaces.nus.edu.sg/cors/StudentLogin" target="_blank" rel="noopener noreferrer">
+          <div className={styles.notification}>
+            {isRoundOpen ? 'Current' : 'Next'} CORS round: <strong>{round.round} ({capitalize(period.type)})</strong>
+            {isRoundOpen ? ' till' : ' at'} <br />
+            <strong>{isRoundOpen ? period.end : period.start}</strong>
+          </div>
+        </a>
+
+        <CloseButton
+          className={styles.close}
+          onClick={() => this.props.dismissCorsNotification(round.round)}
+        />
+      </div>
     );
   }
 }
 
-const CorsNotification = withRouter(CorsNotificationComponent);
+const mapStateToProps = (state: State) => ({
+  enabled: state.settings.corsNotification.enabled,
+  dismissedRounds: state.settings.corsNotification.dismissed,
+});
+
+const withStoreCorsNotification = connect(mapStateToProps, { dismissCorsNotification })(CorsNotificationComponent);
+const CorsNotification = withRouter(withStoreCorsNotification);
 export default CorsNotification;

--- a/v3/src/js/views/components/cors-info/CorsNotification.scss
+++ b/v3/src/js/views/components/cors-info/CorsNotification.scss
@@ -1,7 +1,11 @@
 @import "~styles/utils/modules-entry";
 
 .wrapper {
-  padding: 0.6rem 1rem;
+  position: relative;
+}
+
+.notification {
+  padding: 0.6rem 3rem 0.6rem 1rem;
   font-size: 0.9rem;
   color: var(--body-color);
   border: 1px solid theme-color();
@@ -15,12 +19,25 @@
       display: none;
     }
   }
+}
 
-  @include media-breakpoint-up(md) {
+.close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 3rem;
+}
+
+@include media-breakpoint-up(md) {
+  .wrapper {
     position: fixed;
     bottom: 2rem;
     left: 2rem;
     z-index: $cors-notification-z-index;
+  }
+
+  .notification {
     box-shadow: 0 3px 12px rgba(#000, 0.3);
 
     :global {

--- a/v3/src/js/views/components/cors-info/CorsNotification.scss
+++ b/v3/src/js/views/components/cors-info/CorsNotification.scss
@@ -27,6 +27,11 @@
   right: 0;
   bottom: 0;
   width: 3rem;
+
+  @include media-breakpoint-down(sm) {
+    // Visually align with alert box close buttons
+    width: 4rem;
+  }
 }
 
 @include media-breakpoint-up(md) {

--- a/v3/src/js/views/components/cors-info/CorsNotification.scss
+++ b/v3/src/js/views/components/cors-info/CorsNotification.scss
@@ -35,15 +35,15 @@
     bottom: 2rem;
     left: 2rem;
     z-index: $cors-notification-z-index;
-  }
-
-  .notification {
-    box-shadow: 0 3px 12px rgba(#000, 0.3);
 
     :global {
       // Delay the animation a bit so that the user will not be distracted
       // by the page loading
       animation: bounceInUp 1.5s 0.7s backwards;
     }
+  }
+
+  .notification {
+    box-shadow: 0 3px 12px rgba(#000, 0.3);
   }
 }

--- a/v3/src/js/views/components/cors-info/CorsNotification.test.jsx
+++ b/v3/src/js/views/components/cors-info/CorsNotification.test.jsx
@@ -1,11 +1,11 @@
 // @flow
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import moment from 'moment';
-import { MemoryRouter } from 'react-router-dom';
 
 import config, { type CorsRound, type CorsPeriod, type CorsPeriodType } from 'config';
-import CorsNotification from './CorsNotification';
+import createHistory from 'test-utils/createHistory';
+import { CorsNotificationComponent } from './CorsNotification';
 
 // Save the original CORS schedule for this test and restore it afterwards
 let originalSchedule;
@@ -38,10 +38,10 @@ function setSchedule(schedule: CorsRound[]) {
 }
 
 function make() {
-  return mount(
-    <MemoryRouter>
-      <CorsNotification />
-    </MemoryRouter>,
+  return shallow(
+    <CorsNotificationComponent
+      {...createHistory()}
+    />,
   );
 }
 

--- a/v3/src/js/views/modules/ModuleFinderContainer.test.jsx
+++ b/v3/src/js/views/modules/ModuleFinderContainer.test.jsx
@@ -7,15 +7,12 @@ import { type ShallowWrapper, shallow } from 'enzyme';
 import _ from 'lodash';
 import qs from 'query-string';
 
-// react-router-dom internal dependency, used here to construct the history
-// object needed for testing. This is not added as a dev dependency to avoid
-// version desync between the version depended on by react-router-dom
-import createHistory from 'history/createMemoryHistory'; // eslint-disable-line import/no-extraneous-dependencies
 
 import type { FilterGroupId, PageRange } from 'types/views';
 
-import { nextTick, waitFor } from 'test-utils/async';
 import mockDom from 'test-utils/mockDom';
+import createHistory from 'test-utils/createHistory';
+import { nextTick, waitFor } from 'test-utils/async';
 import FilterGroup from 'utils/filters/FilterGroup';
 import { ModuleFinderContainerComponent, mergePageRange } from './ModuleFinderContainer';
 
@@ -44,24 +41,16 @@ describe('<ModuleFinderContainer', () => {
     console.info.mockRestore(); // eslint-disable-line no-console
   });
 
-  async function createContainer(initialEntries?: Array<LocationShape | string>): Promise<Container> {
-    const history = createHistory({ initialEntries });
-    const mockMatch = {
-      path: '/',
-      url: '/',
-      isExact: true,
-      params: {},
-    };
+  async function createContainer(initialEntries?: Array<string>): Promise<Container> {
+    const router = createHistory(initialEntries);
 
     const container = {
-      history,
+      history: router.history,
       component: shallow(
         <ModuleFinderContainerComponent
-          history={history}
-          location={history.location}
-          match={mockMatch}
           resetModuleFinder={_.noop}
           searchTerm=""
+          {...router}
         />,
       ),
     };

--- a/v3/src/js/views/modules/ModulePageContainer.test.jsx
+++ b/v3/src/js/views/modules/ModulePageContainer.test.jsx
@@ -5,8 +5,7 @@ import { shallow } from 'enzyme';
 import { noop } from 'lodash';
 import { Redirect } from 'react-router-dom';
 
-import createHistory from 'history/createMemoryHistory'; // eslint-disable-line import/no-extraneous-dependencies
-
+import createHistory from 'test-utils/createHistory';
 import type { ModuleCodeMap, FetchRequest } from 'types/reducers';
 import type { Module, ModuleCode } from 'types/modules';
 
@@ -32,14 +31,6 @@ function make(
   request: ?FetchRequest = null,
   fetchModule: (ModuleCode) => void = noop,
 ) {
-  const history = createHistory();
-  const mockMatch = {
-    url,
-    path: url,
-    isExact: true,
-    params: {},
-  };
-
   return shallow(
     <ModulePageContainerComponent
       moduleCode={moduleCode}
@@ -48,9 +39,7 @@ function make(
       request={request}
       fetchModule={fetchModule}
 
-      history={history}
-      location={history.location}
-      match={mockMatch}
+      {...createHistory()}
     />,
   );
 }

--- a/v3/src/js/views/settings/SettingsContainer.jsx
+++ b/v3/src/js/views/settings/SettingsContainer.jsx
@@ -4,13 +4,21 @@ import { connect } from 'react-redux';
 import deferComponentRender from 'views/hocs/deferComponentRender';
 import classnames from 'classnames';
 import Helmet from 'react-helmet';
+import { head, last } from 'lodash';
 
 import type { Faculty } from 'types/modules';
 import type { Mode } from 'types/settings';
+import type { CorsNotificationSettings } from 'types/reducers';
+import type { State } from 'reducers';
 
-import config from 'config';
+import config, { type CorsRound } from 'config';
 import { selectTheme } from 'actions/theme';
-import { selectNewStudent, selectFaculty, selectMode } from 'actions/settings';
+import {
+  selectNewStudent,
+  selectFaculty,
+  selectMode,
+  toggleCorsNotificationGlobally,
+} from 'actions/settings';
 import availableThemes from 'data/themes.json';
 // import FacultySelect from 'views/components/FacultySelect';
 // import NewStudentSelect from 'views/components/NewStudentSelect';
@@ -28,6 +36,7 @@ type Props = {
   faculty: Faculty,
   currentThemeId: string,
   mode: Mode,
+  corsNotification: CorsNotificationSettings,
 
   selectTheme: Function,
   selectNewStudent: Function,
@@ -113,14 +122,34 @@ function SettingsContainer(props: Props) {
           />
         ))}
       </div>
+
+      <hr />
+
+      <h4>CORS Notification</h4>
+
+      <p>Tell me when CORS bidding starts with a small notification.</p>
+
+      <table className="table">
+        <tbody>
+          {config.corsSchedule.map((round: CorsRound) => (
+            <tr>
+              <th>Round {round.round}</th>
+              <td>{head(round.periods).start} - {last(round.periods).end}</td>
+              <td>{props.corsNotification.dismissed.includes(round.round)
+                ? 'Disabled' : 'Enabled'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state: State) => ({
   newStudent: state.settings.newStudent,
   faculty: state.settings.faculty,
   mode: state.settings.mode,
+  corsNotification: state.settings.corsNotification,
   currentThemeId: state.theme.id,
 });
 
@@ -131,6 +160,7 @@ const connectedSettings = connect(
     selectNewStudent,
     selectFaculty,
     selectMode,
+    toggleCorsNotificationGlobally,
   },
 )(SettingsContainer);
 export default deferComponentRender(connectedSettings);

--- a/v3/src/js/views/settings/SettingsContainer.jsx
+++ b/v3/src/js/views/settings/SettingsContainer.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import deferComponentRender from 'views/hocs/deferComponentRender';
 import classnames from 'classnames';
@@ -17,6 +17,8 @@ import {
   selectNewStudent,
   selectFaculty,
   selectMode,
+  dismissCorsNotification,
+  enableCorsNotification,
   toggleCorsNotificationGlobally,
 } from 'actions/settings';
 import availableThemes from 'data/themes.json';
@@ -30,6 +32,8 @@ import ThemeOption from './ThemeOption';
 import ModeSelect from './ModeSelect';
 import styles from './SettingsContainer.scss';
 import previewTimetable from './previewTimetable';
+import Toggle from '../Toggle';
+import CorsNotification from '../components/cors-info/CorsNotification';
 
 type Props = {
   newStudent: boolean,
@@ -42,6 +46,10 @@ type Props = {
   selectNewStudent: Function,
   selectFaculty: Function,
   selectMode: Function,
+
+  dismissCorsNotification: Function,
+  enableCorsNotification: Function,
+  toggleCorsNotificationGlobally: Function,
 };
 
 function SettingsContainer(props: Props) {
@@ -125,22 +133,47 @@ function SettingsContainer(props: Props) {
 
       <hr />
 
-      <h4>CORS Notification</h4>
+      <h4>CORS Bidding Reminder</h4>
 
-      <p>Tell me when CORS bidding starts with a small notification.</p>
+      <div className={classnames(styles.toggleRow, 'row')}>
+        <div className={classnames(styles.toggleDescription, 'col-sm-7')}>
+          <p>You can get a reminder when CORS bidding starts with a small notification.</p>
+        </div>
+        <div className={classnames('col-sm-4 offset-sm-1', styles.toggle)}>
+          <Toggle
+            isOn={props.corsNotification.enabled}
+            onChange={props.toggleCorsNotificationGlobally}
+          />
+        </div>
+      </div>
 
-      <table className="table">
-        <tbody>
-          {config.corsSchedule.map((round: CorsRound) => (
-            <tr>
-              <th>Round {round.round}</th>
-              <td>{head(round.periods).start} - {last(round.periods).end}</td>
-              <td>{props.corsNotification.dismissed.includes(round.round)
-                ? 'Disabled' : 'Enabled'}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <CorsNotification />
+
+      {props.corsNotification.enabled &&
+        <Fragment>
+          <p>You can also enable reminders about each round individually.</p>
+
+          <table className="table">
+            <tbody>
+              {config.corsSchedule.map((round: CorsRound) => (
+                <tr>
+                  <th>Round {round.round}</th>
+                  <td>{head(round.periods).start} - {last(round.periods).end}</td>
+                  <td>
+                    <Toggle
+                      onChange={isOn => (
+                        isOn
+                          ? props.enableCorsNotification(round.round)
+                          : props.dismissCorsNotification(round.round)
+                      )}
+                      isOn={!props.corsNotification.dismissed.includes(round.round)}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Fragment>}
     </div>
   );
 }
@@ -161,6 +194,8 @@ const connectedSettings = connect(
     selectFaculty,
     selectMode,
     toggleCorsNotificationGlobally,
+    dismissCorsNotification,
+    enableCorsNotification,
   },
 )(SettingsContainer);
 export default deferComponentRender(connectedSettings);

--- a/v3/src/js/views/settings/SettingsContainer.jsx
+++ b/v3/src/js/views/settings/SettingsContainer.jsx
@@ -140,7 +140,7 @@ function SettingsContainer(props: Props) {
       <h4>CORS Bidding Reminder</h4>
 
       <div className={styles.notificationPreview}>
-        <CorsNotification />
+        <CorsNotification hideCloseButton />
       </div>
 
       <div className={classnames(styles.toggleRow, 'row')}>

--- a/v3/src/js/views/settings/SettingsContainer.scss
+++ b/v3/src/js/views/settings/SettingsContainer.scss
@@ -54,3 +54,11 @@
     width: 50%;
   }
 }
+
+.notificationPreview {
+  margin-bottom: 1rem;
+
+  &:empty {
+    margin: 0;
+  }
+}

--- a/v3/src/js/views/settings/SettingsContainer.scss
+++ b/v3/src/js/views/settings/SettingsContainer.scss
@@ -8,6 +8,11 @@
     animation-name: $page-entering-animation;
   }
 
+  hr {
+    clear: both;
+    margin-bottom: 2rem;
+  }
+
   // Styles nested for specificity
   @include media-breakpoint-down(xs) {
     .toggleRow {

--- a/v3/src/js/views/timetable/TimetableContainer.test.jsx
+++ b/v3/src/js/views/timetable/TimetableContainer.test.jsx
@@ -6,10 +6,7 @@ import { shallow } from 'enzyme';
 import type { SemTimetableConfig } from 'types/timetables';
 import type { ModulesMap } from 'reducers/moduleBank';
 
-// react-router-dom internal dependency, used here to construct the history
-// object needed for testing. This is not added as a dev dependency to avoid
-// version desync between the version depended on by react-router-dom
-import createHistory from 'history/createMemoryHistory'; // eslint-disable-line import/no-extraneous-dependencies
+import createHistory from 'test-utils/createHistory';
 
 import { timetablePage, semesterForTimetablePage, timetableShare } from 'views/routes/paths';
 import NotFoundPage from 'views/errors/NotFoundPage';
@@ -29,30 +26,21 @@ function create(
   timetable: SemTimetableConfig = {},
   modules: ModulesMap = { CS1010S, CS3216 },
 ) {
-  const history = createHistory({ initialEntries: [path] });
-  const match = {
-    path,
-    params,
-    url: path,
-    isExact: true,
-  };
+  const router = createHistory(path);
+  router.match.params = params;
 
   const selectSemester = jest.fn();
   const setTimetable = jest.fn();
   const fetchTimetableModules = jest.fn();
 
   return {
-    history,
     selectSemester,
     setTimetable,
     fetchTimetableModules,
+    history: router.history,
 
     wrapper: shallow(
       <TimetableContainerComponent
-        history={history}
-        location={history.location}
-        match={match}
-
         activeSemester={1}
         semester={semesterForTimetablePage(params.semester)}
         timetable={timetable}
@@ -63,6 +51,8 @@ function create(
         selectSemester={selectSemester}
         setTimetable={setTimetable}
         fetchTimetableModules={fetchTimetableModules}
+
+        {...router}
       />,
     ),
   };

--- a/v3/src/js/views/venues/VenuesContainer.test.jsx
+++ b/v3/src/js/views/venues/VenuesContainer.test.jsx
@@ -1,28 +1,18 @@
 // @flow
 import React from 'react';
 import { shallow } from 'enzyme';
-import createHistory from 'history/createMemoryHistory'; // eslint-disable-line import/no-extraneous-dependencies
 
 import type { Venue } from 'types/venues';
 
+import createHistory from 'test-utils/createHistory';
 import { VenuesContainerComponent, mapStateToProps } from './VenuesContainer';
 
 function createComponent(urlVenue: ?Venue) {
-  const history = createHistory();
-  const mockMatch = {
-    path: '/',
-    url: '/',
-    isExact: true,
-    params: {},
-  };
-
   return shallow(
     <VenuesContainerComponent
-      history={history}
-      location={history.location}
-      match={mockMatch}
       urlVenue={urlVenue}
       activeSemester={1}
+      {...createHistory()}
     />,
   );
 }

--- a/v3/yarn.lock
+++ b/v3/yarn.lock
@@ -4095,8 +4095,8 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
 
 immutability-helper@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.3.1.tgz#8ccfce92157208c120b2afad7ed05c11114c086e"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.6.2.tgz#0df76cd906518cf81f79caecb4e55d2850a11e2d"
   dependencies:
     invariant "^2.2.0"
 
@@ -4797,8 +4797,8 @@ js-combinatorics@^0.5.2:
   resolved "https://registry.yarnpkg.com/js-combinatorics/-/js-combinatorics-0.5.2.tgz#f060749232ea1b770076ff97aed6cfa9ab41b8f4"
 
 js-tokens@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 js-yaml@3.6.1:
   version "3.6.1"


### PR DESCRIPTION
Fixes #580 

This PR adds a dismiss button to the CORS reminder popup. This info is linked to the `settings.corsNotification` branch in the Redux store. It contains a flag to turn off all reminders globally, or just the current round (which is what happens when you dismiss the reminder). 

The settings page has options to toggle reminders off globally, or to snooze until the end of the current round (which is exactly the same as closing it using the close button). 