### PR TITLE
Fix Disqus comments not updating on page navigation

### DIFF
--- a/v3/src/js/views/components/DisqusComments.jsx
+++ b/v3/src/js/views/components/DisqusComments.jsx
@@ -13,6 +13,14 @@ const SCRIPT_ID = 'dsq-embed-scr';
 
 export default class DisqusComments extends PureComponent<Props> {
   componentDidMount() {
+    this.loadInstance();
+  }
+
+  componentDidUpdate() {
+    this.loadInstance();
+  }
+
+  loadInstance() {
     if (window.DISQUS) {
       // See https://help.disqus.com/customer/portal/articles/472107
       window.DISQUS.reset({


### PR DESCRIPTION
Fixes #601 

This is somewhat embarrassing - the component only updated itself on mount, so of course it didn't display the new comments. 