### PR TITLE
Improve short url tooling and tests 

### DIFF
--- a/www/scripts/start.js
+++ b/www/scripts/start.js
@@ -46,6 +46,14 @@ function runDevServer(host, port, protocol) {
     https: protocol === 'https',
     host,
     port,
+
+    // Proxy the short_url.php endpoint because it does not support CORS
+    proxy: {
+      '/short_url.php': {
+        target: 'https://nusmods.com',
+        changeOrigin: true,
+      },
+    },
   });
 
   // Launch WebpackDevServer.

--- a/www/src/js/views/timetable/ShareTimetable.jsx
+++ b/www/src/js/views/timetable/ShareTimetable.jsx
@@ -53,9 +53,9 @@ export default class ShareTimetable extends PureComponent<Props, State> {
 
     return (
       axios
-        .get('https://nusmods.com/short_url.php', { params: { url }, timeout: 2000 })
+        .get('/short_url.php', { params: { url }, timeout: 2000 })
         .then(({ data }) => {
-          if (data.shortUrl) {
+          if (data.shorturl) {
             this.setState({ shortUrl: data.shorturl });
           } else {
             showFullUrl();

--- a/www/src/js/views/timetable/ShareTimetable.jsx
+++ b/www/src/js/views/timetable/ShareTimetable.jsx
@@ -38,6 +38,9 @@ function shareUrl(semester: Semester, timetable: SemTimetableConfig): string {
   return absolutePath(timetableShare(semester, timetable));
 }
 
+// So that I don't keep typing 'shortUrl' instead
+export const SHORT_URL_KEY = 'shorturl';
+
 export default class ShareTimetable extends PureComponent<Props, State> {
   urlInput: ?HTMLInputElement;
   url: ?string;
@@ -55,8 +58,8 @@ export default class ShareTimetable extends PureComponent<Props, State> {
       axios
         .get('/short_url.php', { params: { url }, timeout: 2000 })
         .then(({ data }) => {
-          if (data.shorturl) {
-            this.setState({ shortUrl: data.shorturl });
+          if (data[SHORT_URL_KEY]) {
+            this.setState({ shortUrl: data[SHORT_URL_KEY] });
           } else {
             showFullUrl();
           }

--- a/www/src/js/views/timetable/ShareTimetable.jsx
+++ b/www/src/js/views/timetable/ShareTimetable.jsx
@@ -49,12 +49,20 @@ export default class ShareTimetable extends PureComponent<Props, State> {
   };
 
   loadShortUrl(url: string) {
+    const showFullUrl = () => this.setState({ shortUrl: url });
+
     return (
       axios
         .get('https://nusmods.com/short_url.php', { params: { url }, timeout: 2000 })
-        .then(({ data }) => this.setState({ shortUrl: data.shorturl }))
+        .then(({ data }) => {
+          if (data.shortUrl) {
+            this.setState({ shortUrl: data.shorturl });
+          } else {
+            showFullUrl();
+          }
+        })
         // Cannot get short URL - just use long URL instead
-        .catch(() => this.setState({ shortUrl: url }))
+        .catch(showFullUrl)
     );
   }
 

--- a/www/src/js/views/timetable/ShareTimetable.test.jsx
+++ b/www/src/js/views/timetable/ShareTimetable.test.jsx
@@ -4,14 +4,19 @@ import React from 'react';
 import axios from 'axios';
 import { shallow } from 'enzyme';
 
+import { waitFor } from 'test-utils/async';
 import Modal from 'views/components/Modal';
 import LoadingSpinner from 'views/components/LoadingSpinner';
-import ShareTimetable from './ShareTimetable';
+import ShareTimetable, { SHORT_URL_KEY } from './ShareTimetable';
 
 describe('ShareTimetable', () => {
+  const MOCK_SHORTURL = 'http://mod.us/short';
+
   // Mock axios to stop it from firing API requests
   beforeEach(() => {
-    jest.spyOn(axios, 'get').mockReturnValue(Promise.resolve({ data: { shortUrl: '' } }));
+    jest
+      .spyOn(axios, 'get')
+      .mockImplementation(() => Promise.resolve({ data: { [SHORT_URL_KEY]: MOCK_SHORTURL } }));
   });
 
   afterEach(() => {
@@ -31,6 +36,15 @@ describe('ShareTimetable', () => {
       .first()
       .props()
       .onRequestClose();
+
+  const openAndWait = async (wrapper) => {
+    openModal(wrapper);
+
+    await waitFor(() => {
+      wrapper.update();
+      return wrapper.find('input').exists();
+    });
+  };
 
   test('should load short URL when the modal is opened', () => {
     const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
@@ -72,5 +86,31 @@ describe('ShareTimetable', () => {
 
     openModal(wrapper);
     expect(wrapper.find(LoadingSpinner).exists()).toBe(true);
+  });
+
+  test('should display shortUrl if available', async () => {
+    const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
+
+    await openAndWait(wrapper);
+
+    expect(wrapper.find('input').prop('value')).toEqual(MOCK_SHORTURL);
+  });
+
+  test('should display long URL if data is corrupted', async () => {
+    axios.get.mockReturnValue(Promise.resolve({})); // No short URL
+    const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
+
+    await openAndWait(wrapper);
+
+    expect(wrapper.find('input').prop('value')).toBeTruthy();
+  });
+
+  test('should display long URL if the endpoint returns an error', async () => {
+    axios.get.mockReturnValue(Promise.reject());
+    const wrapper = shallow(<ShareTimetable semester={1} timetable={timetable} />);
+
+    await openAndWait(wrapper);
+
+    expect(wrapper.find('input').prop('value')).toBeTruthy();
   });
 });

--- a/www/webpack/webpack.config.dev.js
+++ b/www/webpack/webpack.config.dev.js
@@ -39,7 +39,7 @@ const developmentConfig = merge([
         entry: parts.DLL.ENTRIES,
       }),
       // Copy files from static folder over (in-memory)
-      new CopyWebpackPlugin([{ from: 'static', context: parts.PATHS.root }]),
+      new CopyWebpackPlugin([{ from: 'static', context: parts.PATHS.root, ignore: ['short_url.php'] }]),
       // Ignore node_modules so CPU usage with poll watching drops significantly.
       new webpack.WatchIgnorePlugin([parts.PATHS.node, parts.PATHS.build]),
       // Enable multi-pass compilation for enhanced performance

--- a/www/webpack/webpack.config.dev.js
+++ b/www/webpack/webpack.config.dev.js
@@ -39,7 +39,9 @@ const developmentConfig = merge([
         entry: parts.DLL.ENTRIES,
       }),
       // Copy files from static folder over (in-memory)
-      new CopyWebpackPlugin([{ from: 'static', context: parts.PATHS.root, ignore: ['short_url.php'] }]),
+      new CopyWebpackPlugin([
+        { from: 'static', context: parts.PATHS.root, ignore: ['short_url.php'] },
+      ]),
       // Ignore node_modules so CPU usage with poll watching drops significantly.
       new webpack.WatchIgnorePlugin([parts.PATHS.node, parts.PATHS.build]),
       // Enable multi-pass compilation for enhanced performance


### PR DESCRIPTION
This makes the URL shortener related code more defensive and improve the tooling around it 

- Add proxy option so the service can be tested locally 
- Add more tests to ensure correct behavior 
- Fall back to long URL when the key is not present in the data 