### PR TITLE
Fix global search dropdown appearing under module finder search

### DIFF
--- a/www/src/styles/components/search-panel.scss
+++ b/www/src/styles/components/search-panel.scss
@@ -1,7 +1,7 @@
 .search-panel {
   position: sticky;
   top: $navbar-height;
-  z-index: $module-finder-search-z-index;
+  z-index: $module-finder-search-z-index-md;
   padding: 0 0 1rem;
   background:
     linear-gradient(
@@ -11,6 +11,7 @@
     );
 
   @include media-breakpoint-down(sm) {
+    z-index: $module-finder-search-z-index-sm;
     padding: 0 0 $navtab-shadow-height;
     margin: -1rem (-$grid-gutter-width / 2) 0;
     border-top: 1px solid var(--gray-lighter);

--- a/www/src/styles/constants.scss
+++ b/www/src/styles/constants.scss
@@ -161,14 +161,15 @@ $nusmods-theme-colors: (
 // Z-index
 $sentry-z-index: 2000;
 $modal-z-index: 1500;
-$module-finder-search-z-index: 950;
+$module-select-z-index: 960;
+$module-finder-search-z-index-sm: 950;
 $navtabs-z-index: 900;
 $navbar-z-index: 890;
+$module-finder-search-z-index-md: 850;
 $fab-z-index: 800;
 $side-menu-z-index: 700;
 $side-menu-overlay-z-index: 690;
 $cors-notification-z-index: 500;
-$module-select-z-index: 101;
 $timetable-timing-z-index: 95;
 $timetable-day-z-index: 90;
 $timetable-selected-cell-z-index: 75;


### PR DESCRIPTION
This fixes a small bug where global search dropdown will appear under the module finder's searchbar. Adjusting the global search z-index is insufficient, because it is a child of navbar which itself has a lower z-index. The solution is to only use the high z-index on sm and below, since the only reason their z-index was so high was the need to occlude the navtab shadows. 

Do note that this may still be a problem if we introduce global search on mobile, but it is good enough for now. 