### PR TITLE
Fix layout shifting because of last updated timestamp 

### DIFF
--- a/www/src/js/views/layout/Footer.jsx
+++ b/www/src/js/views/layout/Footer.jsx
@@ -20,9 +20,6 @@ export function FooterComponent(props: Props) {
   const versionStr = process.env.versionStr;
 
   const lastUpdatedDate = props.lastUpdatedDate;
-  const apiUpdateSpan = lastUpdatedDate && (
-    <span>Data correct as at {lastUpdatedDate.toLocaleString()}.</span>
-  );
 
   const versionSpan = commitHash &&
     versionStr && (
@@ -91,7 +88,9 @@ export function FooterComponent(props: Props) {
             </button>
           </li>
         </ul>
-        <p>{apiUpdateSpan}</p>
+        <p>
+          Data correct as at {lastUpdatedDate ? lastUpdatedDate.toLocaleString() : 'Loading...'}.
+        </p>
         <p>
           Designed and built with all the love in the world by{' '}
           <a href={config.contact.githubOrg} target="_blank" rel="noopener noreferrer">

--- a/www/src/js/views/layout/Footer.scss
+++ b/www/src/js/views/layout/Footer.scss
@@ -19,7 +19,8 @@
   }
 
   p {
-    margin-bottom: 0;
+    margin-bottom: 0.4rem;
+    line-height: 1.3;
   }
 
   @include media-breakpoint-up(sm) {


### PR DESCRIPTION
When the last updated timestamp loads, on some screen sizes the layout of the entire footer would shift upwards because of the new element. This is minor, but it is kind of distracting. I'm fixing this by adding some placeholder text instead. 

Also add some margins between footer paragraphs to better separate them - this is more apparent on smaller screens when there are multiple lines per paragraph. Previously without margin it is difficult to tell where each paragraph began. 