### PR TITLE
Fix scrolling on horizontal timetable

### DIFF
--- a/www/src/js/views/components/module-info/LessonTimetable.scss
+++ b/www/src/js/views/components/module-info/LessonTimetable.scss
@@ -1,6 +1,11 @@
 @import "~styles/utils/modules-entry.scss";
 
 .lessonTimetable {
-  composes: scrollable from global;
   margin-top: 0.5rem;
+  overflow: auto;
+
+  @supports (-webkit-overflow-scrolling: touch) {
+    overflow: scroll;
+    -webkit-overflow-scrolling: touch;
+  }
 }


### PR DESCRIPTION
I accidentally broke horizontal timetable scrolling in the last commit in #613 - this fixes that. 