### PR TITLE
Hotfix timetable scrolling

### DIFF
--- a/www/src/js/views/components/Modal.scss
+++ b/www/src/js/views/components/Modal.scss
@@ -14,7 +14,7 @@
 .modal {
   $spacing: 1rem;
 
-  composes: scrollable from global;
+  composes: scrollable-y from global;
   position: absolute;
   top: $spacing;
   right: $spacing;

--- a/www/src/js/views/components/SideMenu.scss
+++ b/www/src/js/views/components/SideMenu.scss
@@ -11,7 +11,7 @@ $animation-duration: 0.3s;
 }
 
 .sideMenu {
-  composes: scrollable from global;
+  composes: scrollable-y from global;
   position: fixed;
   max-height: calc(100% - #{$navbar-height});
   overscroll-behavior: contain; // stylelint-disable-line property-no-unknown

--- a/www/src/js/views/components/module-info/LessonTimetable.scss
+++ b/www/src/js/views/components/module-info/LessonTimetable.scss
@@ -1,11 +1,6 @@
 @import "~styles/utils/modules-entry.scss";
 
 .lessonTimetable {
+  composes: scrollable from global;
   margin-top: 0.5rem;
-  overflow: auto;
-
-  @supports (-webkit-overflow-scrolling: touch) {
-    overflow: scroll;
-    -webkit-overflow-scrolling: touch;
-  }
 }

--- a/www/src/js/views/components/module-info/LessonTimetable.scss
+++ b/www/src/js/views/components/module-info/LessonTimetable.scss
@@ -1,6 +1,11 @@
 @import "~styles/utils/modules-entry.scss";
 
 .lessonTimetable {
-  composes: scrollable from global;
   margin-top: 0.5rem;
+  overflow: auto;
+
+  @supports (-webkit-overflow-scrolling: touch) {
+    overflow: scroll;
+    -webkit-overflow-scrolling: touch;
+  }
 }

--- a/www/src/js/views/layout/GlobalSearch.scss
+++ b/www/src/js/views/layout/GlobalSearch.scss
@@ -74,7 +74,7 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
 }
 
 .selectList {
-  composes: list-unstyled scrollable from global;
+  composes: list-unstyled scrollable-y from global;
   position: absolute;
   top: $navbar-height - 0.5rem;
   right: 0;

--- a/www/src/js/views/timetable/ModulesSelect.scss
+++ b/www/src/js/views/timetable/ModulesSelect.scss
@@ -53,7 +53,7 @@ div > .modal {
 }
 
 .selectList {
-  composes: scrollable from global;
+  composes: scrollable-y from global;
   max-height: calc(100% - #{$input-height});
   padding: 0;
   margin: 0;

--- a/www/src/styles/bootstrap/style-override.scss
+++ b/www/src/styles/bootstrap/style-override.scss
@@ -30,7 +30,7 @@ mark {
   background: var(--body-bg);
   box-shadow: 0 2px 6px rgba(#000, 0.25);
 
-  @include scrollable;
+  @include scrollable-y;
 }
 
 .dropdown-item {

--- a/www/src/styles/utils/mixins.scss
+++ b/www/src/styles/utils/mixins.scss
@@ -17,6 +17,18 @@
 }
 
 @mixin scrollable {
+  overflow: auto;
+
+  // @supports is used here because Safari requires overflow: scroll to be used in conjunction with
+  // -webkit-overflow-scrolling: touch to ensure smooth scrolling on iOS, but this causes ugly
+  // scrollbars to appear in other browsers
+  @supports (-webkit-overflow-scrolling: touch) {
+    overflow: scroll;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+@mixin scrollable-y {
   overflow-x: hidden;
   overflow-y: auto;
 

--- a/www/src/styles/utils/scrollable.scss
+++ b/www/src/styles/utils/scrollable.scss
@@ -1,3 +1,7 @@
 .scrollable {
   @include scrollable;
 }
+
+.scrollable-y {
+  @include scrollable-y;
+}


### PR DESCRIPTION
The last fix (#626) wasn't enough. This, I swear, fixes the issue completely. 

The mistake was assuming all scrolling in the UI is done vertically. This is mostly true, except for the timetable, which I somehow forgot. 🤦‍♂️ The fix is to properly split the `scrollable` and `scrollable-y` mixins and classes.

I'm not entirely sure why I thought the previous PR was sufficient. It looked fine on local testing, but I realized that may have just been code that was cached from another branch that didn't have master merged in. 