### PR TITLE
Change UI of exam timetable clash

### DIFF
--- a/www/src/js/views/timetable/TimetableContent.jsx
+++ b/www/src/js/views/timetable/TimetableContent.jsx
@@ -176,17 +176,21 @@ class TimetableContent extends Component<Props, State> {
     return (
       <div>
         {!_.isEmpty(clashes) && (
-          <div className="alert alert-danger" role="alert">
-            <h4>Exam Clashes</h4>
-            <p>These modules have clashing exams.</p>
+          <div>
+            <div className="alert alert-danger">
+              Warning! There are clashes in your exam timetable.
+            </div>
             {Object.keys(clashes)
               .sort()
               .map((clashDate) => (
                 <div key={clashDate}>
-                  <h5>Clash on {formatExamDate(clashDate)}</h5>
+                  <p>
+                    Clash on <strong>{formatExamDate(clashDate)}</strong>
+                  </p>
                   {renderModuleTable(clashes[clashDate])}
                 </div>
               ))}
+            <hr />
           </div>
         )}
         {renderModuleTable(nonClashingMods)}


### PR DESCRIPTION
Putting the modules with clashes inside the alert doesn't look very nice IMO. Did some simply shifting around of DOM elements.

You can test with this [URL](https://deploy-preview-630--nusmods.netlify.com/timetable/sem-2/share?ACC1002=LEC:V02,TUT:A02&ACC1002X=LEC:X1,TUT:X15&ACC1701=LEC:V01,TUT:A03&ACC1701X=LEC:X1,TUT:X11&CS1010=SEC:1,TUT:1&CS1010S=LEC:1,REC:5,TUT:14).

![screen shot 2017-12-30 at 11 16 42 pm](https://user-images.githubusercontent.com/1315101/34460049-e232ba06-edb7-11e7-8625-6c51b7dcb970.png)

![screen shot 2017-12-30 at 11 20 56 pm](https://user-images.githubusercontent.com/1315101/34460058-1c594556-edb8-11e7-9dcb-888f8d4a72af.png)
