### PR TITLE
v2 bookmark data export

### DIFF
--- a/www/src/js/views/routes/paths.js
+++ b/www/src/js/views/routes/paths.js
@@ -38,7 +38,7 @@ export function isV2TimetablePageUrl(params: { [string]: ?string }): boolean {
 }
 
 // Module Code, Module Title -> Module page path
-export function modulePage(moduleCode: ModuleCode, moduleTitle: ModuleTitle): string {
+export function modulePage(moduleCode: ModuleCode, moduleTitle: ModuleTitle = ''): string {
   return `/modules/${moduleCode}/${kebabCase(moduleTitle)}`;
 }
 

--- a/www/src/js/views/routes/paths.js
+++ b/www/src/js/views/routes/paths.js
@@ -38,7 +38,7 @@ export function isV2TimetablePageUrl(params: { [string]: ?string }): boolean {
 }
 
 // Module Code, Module Title -> Module page path
-export function modulePage(moduleCode: ModuleCode, moduleTitle: ModuleTitle = ''): string {
+export function modulePage(moduleCode: ModuleCode, moduleTitle: ModuleTitle): string {
   return `/modules/${moduleCode}/${kebabCase(moduleTitle)}`;
 }
 

--- a/www/src/js/views/settings/SettingsContainer.jsx
+++ b/www/src/js/views/settings/SettingsContainer.jsx
@@ -217,27 +217,30 @@ class SettingsContainer extends Component<Props, State> {
 
         <hr />
 
-        {this.state.bookmarks && (
-          <div>
-            <h4>Bookmarks from previous version of NUSMods</h4>
-            <p>
-              Bookmarks are no longer supported in NUSMods R, but you can still view your previously
-              saved bookmarks here.
-            </p>
+        {this.state.bookmarks &&
+          this.state.bookmarks.length > 0 && (
+            <div>
+              <h4>Bookmarks from previous version of NUSMods</h4>
+              <p>
+                Bookmarks are no longer supported in NUSMods R, but you can still view your
+                previously saved bookmarks here.
+              </p>
 
-            <ul>
-              {this.state.bookmarks.map((moduleCode) => (
-                <li>
-                  <LinkModuleCodes>{moduleCode}</LinkModuleCodes>
-                </li>
-              ))}
-            </ul>
+              <ul>
+                {this.state.bookmarks.map((moduleCode) => (
+                  <li>
+                    <LinkModuleCodes>{moduleCode}</LinkModuleCodes>
+                  </li>
+                ))}
+              </ul>
 
-            <div className="alert alert-danger">
-              <strong>Please save these elsewhere as this will be removed by next semester.</strong>
+              <div className="alert alert-danger">
+                <strong>
+                  Please save these elsewhere as this will be removed by next semester.
+                </strong>
+              </div>
             </div>
-          </div>
-        )}
+          )}
       </div>
     );
   }

--- a/www/src/js/views/settings/SettingsContainer.jsx
+++ b/www/src/js/views/settings/SettingsContainer.jsx
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import deferComponentRender from 'views/hocs/deferComponentRender';
 import classnames from 'classnames';
 import Helmet from 'react-helmet';
@@ -23,11 +22,11 @@ import {
   enableCorsNotification,
   toggleCorsNotificationGlobally,
 } from 'actions/settings';
-import { modulePage } from 'views/routes/paths';
 // import FacultySelect from 'views/components/FacultySelect';
 // import NewStudentSelect from 'views/components/NewStudentSelect';
 import ScrollToTop from 'views/components/ScrollToTop';
 import Timetable from 'views/timetable/Timetable';
+import LinkModuleCodes from 'views/components/LinkModuleCodes';
 import CorsNotification, {
   corsNotificationText,
 } from 'views/components/cors-info/CorsNotification';
@@ -220,23 +219,23 @@ class SettingsContainer extends Component<Props, State> {
 
         {this.state.bookmarks && (
           <div>
-            <h4>Bookmarks from v2</h4>
+            <h4>Bookmarks from previous version of NUSMods</h4>
             <p>
-              You have bookmarked the following modules in v2. Bookmarks are no longer supported in
-              NUSMods R, but you can still view your previously saved bookmarks here.
+              Bookmarks are no longer supported in NUSMods R, but you can still view your previously
+              saved bookmarks here.
             </p>
-
-            <div className="alert alert-danger">
-              <strong>Please save these elsewhere as this will be removed by next semester.</strong>
-            </div>
 
             <ul>
               {this.state.bookmarks.map((moduleCode) => (
                 <li>
-                  <Link to={modulePage(moduleCode)}>{moduleCode}</Link>
+                  <LinkModuleCodes>{moduleCode}</LinkModuleCodes>
                 </li>
               ))}
             </ul>
+
+            <div className="alert alert-danger">
+              <strong>Please save these elsewhere as this will be removed by next semester.</strong>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Adds a simple bookmark export view on the settings page. This allows users to get their data from v2 out if they had any. Since we already have localforage from the migration, this is pretty much free. 