### PR TITLE
Fix CI tests 

### DIFF
--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -19,6 +19,9 @@ module.exports = {
       env: {
         jest: true,
       },
+      globals: {
+        jasmine: false,
+      },
       rules: {
         // Much more lenient linting for tests
         'max-len': ['error', 120, {

--- a/api/gulp-tasks/remote/examTimetable.test.js
+++ b/api/gulp-tasks/remote/examTimetable.test.js
@@ -12,6 +12,17 @@ import {
 jest.unmock('fs-extra');
 
 describe('parseExamPdf', () => {
+  let originalTimeout;
+
+  beforeEach(() => {
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000; // Default of 5 seconds times out on Travis
+  });
+
+  afterEach(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
+
   const sublog = { warn: jest.fn() };
   function matchPdfOutput(filePath) {
     return fs


### PR DESCRIPTION
Since Travis has only one core, it should be better to use `maxWorkers=1`. ~~~Let's see if this fixes the broken tests on API.~~~ Didn't work. Let's try raising the max timeout then. 