### PR TITLE
Semester in results and "no result" message for global search 

### DIFF
--- a/www/src/js/views/components/filters/styles.scss
+++ b/www/src/js/views/components/filters/styles.scss
@@ -113,11 +113,6 @@ $h-padding: $grid-gutter-width / 2;
     }
   }
 
-  mark {
-    padding: 0;
-    border-bottom: 1px solid var(--yellow);
-  }
-
   .selected {
     color: theme-color();
     background: var(--gray-lightest);

--- a/www/src/js/views/components/icons/index.js
+++ b/www/src/js/views/components/icons/index.js
@@ -17,6 +17,7 @@ import FileText from 'react-feather/dist/icons/file-text';
 import Filter from 'react-feather/dist/icons/filter';
 import GitHub from 'react-feather/dist/icons/github';
 import Heart from 'react-feather/dist/icons/heart';
+import Help from 'react-feather/dist/icons/help-circle';
 import Image from 'react-feather/dist/icons/image';
 import LinkedIn from 'react-feather/dist/icons/linkedin';
 import Map from 'react-feather/dist/icons/map';
@@ -49,6 +50,7 @@ export {
   FileText,
   GitHub,
   Heart,
+  Help,
   Image,
   Map,
   Menu,

--- a/www/src/js/views/layout/GlobalSearch.jsx
+++ b/www/src/js/views/layout/GlobalSearch.jsx
@@ -6,10 +6,11 @@ import classnames from 'classnames';
 
 import { highlight } from 'utils/react';
 import { Search, ChevronRight } from 'views/components/icons';
-import type { Module } from 'types/modules';
+import type { ModuleCondensed } from 'types/modules';
 import type { Venue } from 'types/venues';
 import type { ResultType, SearchResult } from 'types/views';
 
+import config from 'config';
 import { MODULE_RESULT, SEARCH_RESULT, VENUE_RESULT } from 'types/views';
 import styles from './GlobalSearch.scss';
 
@@ -17,7 +18,7 @@ type Props = {
   getResults: string => SearchResult,
 
   onSelectVenue: Venue => void,
-  onSelectModule: Module => void,
+  onSelectModule: ModuleCondensed => void,
   onSearch: (ResultType, string) => void,
 };
 
@@ -26,6 +27,15 @@ type State = {
 };
 
 const PLACEHOLDER = 'Search modules & venues. Try "GER" or "LT".';
+
+/* eslint-disable no-useless-computed-key */
+const BADGE_COLOR = {
+  [1]: 'badge-primary',
+  [2]: 'badge-danger',
+  [3]: 'badge-info',
+  [4]: 'badge-success',
+};
+/* eslint-enable */
 
 class GlobalSearch extends Component<Props, State> {
   input: ?HTMLInputElement;
@@ -124,7 +134,18 @@ class GlobalSearch extends Component<Props, State> {
                       [styles.selected]: highlightedIndex === index + 1,
                     })}
                   >
-                    {highlight(`${module.ModuleCode} ${module.ModuleTitle}`, tokens)}
+                    <span>{highlight(`${module.ModuleCode} ${module.ModuleTitle}`, tokens)}</span>
+
+                    <span className={styles.semesters}>
+                      {module.Semesters.sort().map((semester) => (
+                        <span
+                          className={classnames('badge', BADGE_COLOR[semester])}
+                          title={config.semesterNames[semester]}
+                        >
+                          {config.shortSemesterNames[semester]}
+                        </span>
+                      ))}
+                    </span>
                   </div>
                 ))}
               </Fragment>

--- a/www/src/js/views/layout/GlobalSearch.jsx
+++ b/www/src/js/views/layout/GlobalSearch.jsx
@@ -5,7 +5,7 @@ import Downshift from 'downshift';
 import classnames from 'classnames';
 
 import { highlight } from 'utils/react';
-import { Search, ChevronRight } from 'views/components/icons';
+import { ChevronRight, Help, Search } from 'views/components/icons';
 import type { ModuleCondensed } from 'types/modules';
 import type { Venue } from 'types/venues';
 import type { ResultType, SearchResult } from 'types/views';
@@ -15,7 +15,7 @@ import { MODULE_RESULT, SEARCH_RESULT, VENUE_RESULT } from 'types/views';
 import styles from './GlobalSearch.scss';
 
 type Props = {
-  getResults: string => SearchResult,
+  getResults: string => ?SearchResult,
 
   onSelectVenue: Venue => void,
   onSelectModule: ModuleCondensed => void,
@@ -84,15 +84,10 @@ class GlobalSearch extends Component<Props, State> {
     inputValue,
     highlightedIndex,
   }: any) => {
-    const { modules, venues, tokens } = this.props.getResults(inputValue);
-    const hasModules = modules.length > 0;
-    const hasVenues = venues.length > 0;
-
-    const venueHeaderIndex = hasModules ? modules.length + 1 : 0;
-    const venueItemOffset = venueHeaderIndex + 1;
-
-    return (
-      <div className={styles.container}>
+    // key to ensure the input element does not change during rerender, which would cause
+    // selection to be lost
+    const searchForm = (
+      <Fragment key="search">
         <Search className={classnames(styles.icon, { [styles.iconOpen]: isOpen })} />
         <label className="sr-only" {...getLabelProps()}>
           {PLACEHOLDER}
@@ -105,84 +100,147 @@ class GlobalSearch extends Component<Props, State> {
           {...getInputProps({ placeholder: PLACEHOLDER })}
           onFocus={this.onOpen}
         />
+      </Fragment>
+    );
 
-        {(hasModules || hasVenues) && (
+    const searchResults = this.props.getResults(inputValue);
+
+    // 1. Search is not active - just show the search form
+    if (!searchResults) {
+      return <div className={styles.container}>{searchForm}</div>;
+    }
+
+    const { modules, venues, tokens } = searchResults;
+    const hasModules = modules.length > 0;
+    const hasVenues = venues.length > 0;
+
+    // 2. No results - show a message and ask if the user wants to view all
+    //    results instead
+    if (!hasModules && !hasVenues) {
+      return (
+        <div className={styles.container}>
+          {searchForm}
+
           <div className={styles.selectList}>
-            {hasModules && (
-              <Fragment>
-                <div
+            <div className={styles.noResults}>
+              <Help />
+              <p>
+                No results found for{' '}
+                <strong className={styles.searchTerm}>&quot;{inputValue}&quot;</strong>
+              </p>
+              <p>
+                Try searching all{' '}
+                <button
                   {...getItemProps({
                     item: [SEARCH_RESULT, [MODULE_RESULT, inputValue]],
                   })}
-                  className={classnames(styles.selectHeader, {
+                  className={classnames('btn btn-inline', {
                     [styles.selected]: highlightedIndex === 0,
                   })}
                 >
-                  <span className={styles.headerName}>Modules</span>
-                  <span className={styles.viewAll}>
-                    View All <ChevronRight />
-                  </span>
-                </div>
-
-                {modules.map((module, index) => (
-                  <div
-                    {...getItemProps({
-                      key: module.ModuleCode,
-                      item: [MODULE_RESULT, module],
-                    })}
-                    className={classnames(styles.option, {
-                      [styles.selected]: highlightedIndex === index + 1,
-                    })}
-                  >
-                    <span>{highlight(`${module.ModuleCode} ${module.ModuleTitle}`, tokens)}</span>
-
-                    <span className={styles.semesters}>
-                      {module.Semesters.sort().map((semester) => (
-                        <span
-                          className={classnames('badge', BADGE_COLOR[semester])}
-                          title={config.semesterNames[semester]}
-                        >
-                          {config.shortSemesterNames[semester]}
-                        </span>
-                      ))}
-                    </span>
-                  </div>
-                ))}
-              </Fragment>
-            )}
-            {hasVenues && (
-              <Fragment>
-                <div
+                  modules
+                </button>{' '}
+                or{' '}
+                <button
                   {...getItemProps({
                     item: [SEARCH_RESULT, [VENUE_RESULT, inputValue]],
                   })}
-                  className={classnames(styles.selectHeader, {
-                    [styles.selected]: highlightedIndex === venueHeaderIndex,
+                  className={classnames('btn btn-inline', {
+                    [styles.selected]: highlightedIndex === 1,
                   })}
                 >
-                  <span className={styles.headerName}>Venues</span>
-                  <span className={styles.viewAll}>
-                    View All <ChevronRight />
+                  venues
+                </button>
+              </p>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    const venueHeaderIndex = hasModules ? modules.length + 1 : 0;
+    const venueItemOffset = venueHeaderIndex + 1;
+
+    // 3. We have results - so show them to the user
+    return (
+      <div className={styles.container}>
+        {searchForm}
+
+        <div className={styles.selectList}>
+          {hasModules && (
+            <Fragment>
+              <div
+                {...getItemProps({
+                  item: [SEARCH_RESULT, [MODULE_RESULT, inputValue]],
+                })}
+                className={classnames(styles.selectHeader, {
+                  [styles.selected]: highlightedIndex === 0,
+                })}
+              >
+                <span className={styles.headerName}>Modules</span>
+                <span className={styles.viewAll}>
+                  View All <ChevronRight />
+                </span>
+              </div>
+
+              {modules.map((module, index) => (
+                <div
+                  {...getItemProps({
+                    key: module.ModuleCode,
+                    item: [MODULE_RESULT, module],
+                  })}
+                  className={classnames(styles.option, {
+                    [styles.selected]: highlightedIndex === index + 1,
+                  })}
+                >
+                  <span>{highlight(`${module.ModuleCode} ${module.ModuleTitle}`, tokens)}</span>
+
+                  <span className={styles.semesters}>
+                    {module.Semesters.sort().map((semester) => (
+                      <span
+                        className={classnames('badge', BADGE_COLOR[semester])}
+                        title={config.semesterNames[semester]}
+                      >
+                        {config.shortSemesterNames[semester]}
+                      </span>
+                    ))}
                   </span>
                 </div>
+              ))}
+            </Fragment>
+          )}
+          {hasVenues && (
+            <Fragment>
+              <div
+                {...getItemProps({
+                  item: [SEARCH_RESULT, [VENUE_RESULT, inputValue]],
+                })}
+                className={classnames(styles.selectHeader, {
+                  [styles.selected]: highlightedIndex === venueHeaderIndex,
+                })}
+              >
+                <span className={styles.headerName}>Venues</span>
+                <span className={styles.viewAll}>
+                  View All <ChevronRight />
+                </span>
+              </div>
 
-                {venues.map((venue, index) => (
-                  <div
-                    {...getItemProps({
-                      key: venue,
-                      item: [VENUE_RESULT, venue],
-                    })}
-                    className={classnames(styles.option, {
-                      [styles.selected]: highlightedIndex === venueItemOffset + index,
-                    })}
-                  >
-                    {highlight(venue, tokens)}
-                  </div>
-                ))}
-              </Fragment>
-            )}
-          </div>
-        )}
+              {venues.map((venue, index) => (
+                <div
+                  {...getItemProps({
+                    key: venue,
+                    item: [VENUE_RESULT, venue],
+                  })}
+                  className={classnames(styles.option, {
+                    [styles.selected]: highlightedIndex === venueItemOffset + index,
+                  })}
+                >
+                  {highlight(venue, tokens)}
+                </div>
+              ))}
+            </Fragment>
+          )}
+        </div>
       </div>
     );
   };

--- a/www/src/js/views/layout/GlobalSearch.jsx
+++ b/www/src/js/views/layout/GlobalSearch.jsx
@@ -30,10 +30,10 @@ const PLACEHOLDER = 'Search modules & venues. Try "GER" or "LT".';
 
 /* eslint-disable no-useless-computed-key */
 const BADGE_COLOR = {
-  [1]: 'badge-primary',
-  [2]: 'badge-danger',
-  [3]: 'badge-info',
-  [4]: 'badge-success',
+  [1]: styles.sem1,
+  [2]: styles.sem2,
+  [3]: styles.sem3,
+  [4]: styles.sem4,
 };
 /* eslint-enable */
 
@@ -125,8 +125,7 @@ class GlobalSearch extends Component<Props, State> {
             <div className={styles.noResults}>
               <Help />
               <p>
-                No results found for{' '}
-                <strong className={styles.searchTerm}>&quot;{inputValue}&quot;</strong>
+                No results found for <strong className="h4">&quot;{inputValue}&quot;</strong>
               </p>
               <p>
                 Try searching all{' '}
@@ -178,8 +177,8 @@ class GlobalSearch extends Component<Props, State> {
                 })}
               >
                 <span className={styles.headerName}>Modules</span>
-                <span className={styles.viewAll}>
-                  View All <ChevronRight />
+                <span className="btn-svg">
+                  View All <ChevronRight className={styles.svg} />
                 </span>
               </div>
 
@@ -220,8 +219,8 @@ class GlobalSearch extends Component<Props, State> {
                 })}
               >
                 <span className={styles.headerName}>Venues</span>
-                <span className={styles.viewAll}>
-                  View All <ChevronRight />
+                <span className="btn-svg">
+                  View All <ChevronRight className={styles.svg} />
                 </span>
               </div>
 
@@ -235,7 +234,7 @@ class GlobalSearch extends Component<Props, State> {
                     [styles.selected]: highlightedIndex === venueItemOffset + index,
                   })}
                 >
-                  {highlight(venue, tokens)}
+                  <span>{highlight(venue, tokens)}</span>
                 </div>
               ))}
             </Fragment>

--- a/www/src/js/views/layout/GlobalSearch.jsx
+++ b/www/src/js/views/layout/GlobalSearch.jsx
@@ -125,7 +125,8 @@ class GlobalSearch extends Component<Props, State> {
             <div className={styles.noResults}>
               <Help />
               <p>
-                No results found for <strong className="h4">&quot;{inputValue}&quot;</strong>
+                No results found for{' '}
+                <strong className={styles.searchTerm}>&quot;{inputValue}&quot;</strong>
               </p>
               <p>
                 Try searching all{' '}

--- a/www/src/js/views/layout/GlobalSearch.scss
+++ b/www/src/js/views/layout/GlobalSearch.scss
@@ -166,6 +166,12 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
   }
 }
 
+.searchTerm {
+  composes: h4 from global;
+  display: block;
+  white-space: normal;
+}
+
 .sem1,
 .sem2,
 .sem3,

--- a/www/src/js/views/layout/GlobalSearch.scss
+++ b/www/src/js/views/layout/GlobalSearch.scss
@@ -154,3 +154,27 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
   }
 }
 
+.noResults {
+  composes: openWidth;
+  text-align: center;
+
+  p {
+    margin-bottom: 0.4rem;
+  }
+
+  svg {
+    opacity: 0.35;
+    width: 4rem;
+    height: 4rem;
+    margin-top: 1rem;
+  }
+
+  :global(.btn).selected {
+    text-decoration: underline;
+  }
+
+  .searchTerm {
+    display: block;
+    font-size: 1.4rem;
+  }
+}

--- a/www/src/js/views/layout/GlobalSearch.scss
+++ b/www/src/js/views/layout/GlobalSearch.scss
@@ -93,13 +93,14 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
 
 .item {
   composes: openWidth;
+  display: flex;
+  justify-content: space-between;
   padding: 0.6rem $container-padding;
   cursor: pointer;
 }
 
 .selectHeader {
   composes: item;
-  display: flex;
   justify-content: space-between;
   padding: 0.3rem $container-padding;
   color: var(--body-bg);
@@ -112,12 +113,12 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
 
   .viewAll {
     position: relative;
-    padding-right: 1.4rem;
+    padding-right: 1.6rem;
 
     svg {
       position: absolute;
       top: 0;
-      right: 0;
+      right: 0.2rem;
       height: 1.2rem;
       transition: $transition-base;
     }
@@ -128,7 +129,7 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
       color: theme-color();
 
       svg {
-        right: -0.2rem;
+        right: 0;
       }
     }
   }
@@ -140,6 +141,15 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
   &.selected {
     color: theme-color();
     background: var(--gray-lightest);
+  }
+
+  .semesters {
+    margin-right: 0.4rem;
+  }
+
+  :global(.badge) {
+    margin-right: 0.2rem;
+    border-radius: 1px;
   }
 }
 

--- a/www/src/js/views/layout/GlobalSearch.scss
+++ b/www/src/js/views/layout/GlobalSearch.scss
@@ -102,37 +102,29 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
 .selectHeader {
   composes: item;
   justify-content: space-between;
-  padding: 0.3rem $container-padding;
-  color: var(--body-bg);
-  background: var(--gray-light);
-
-  .headerName {
-    text-transform: uppercase;
-    letter-spacing: 1px;
-  }
-
-  .viewAll {
-    position: relative;
-    padding-right: 1.6rem;
-
-    svg {
-      position: absolute;
-      top: 0;
-      right: 0.2rem;
-      height: 1.2rem;
-      transition: $transition-base;
-    }
-  }
+  font-size: 0.95rem;
+  border-bottom: 1px solid var(--gray-lighter);
 
   &.selected {
-    .viewAll {
+    > :global(.btn-svg) {
       color: theme-color();
+    }
 
-      svg {
-        right: 0;
-      }
+    .svg {
+      transform: translateX(0.2rem);
     }
   }
+}
+
+.headerName {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  transition: $entering-duration transform $material-standard-curve;
 }
 
 .option {
@@ -172,9 +164,28 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
   :global(.btn).selected {
     text-decoration: underline;
   }
+}
 
-  .searchTerm {
-    display: block;
-    font-size: 1.4rem;
-  }
+.sem {
+  color: $body-color;
+}
+
+.sem1 {
+  composes: sem;
+  background: darken($gray-lightest, 1%);
+}
+
+.sem2 {
+  composes: sem;
+  background: darken($gray-lightest, 4%);
+}
+
+.sem3 {
+  composes: sem;
+  background: darken($gray-lightest, 7%);
+}
+
+.sem4 {
+  composes: sem;
+  background: darken($gray-lightest, 10%);
 }

--- a/www/src/js/views/layout/GlobalSearch.scss
+++ b/www/src/js/views/layout/GlobalSearch.scss
@@ -166,26 +166,45 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
   }
 }
 
-.sem {
-  color: $body-color;
+.sem1,
+.sem2,
+.sem3,
+.sem4 {
+  color: var(--body-color);
 }
 
 .sem1 {
-  composes: sem;
-  background: darken($gray-lightest, 1%);
+  background: darken($gray-lightest, 5%);
 }
 
 .sem2 {
-  composes: sem;
-  background: darken($gray-lightest, 4%);
+  background: darken($gray-lightest, 10%);
 }
 
 .sem3 {
-  composes: sem;
-  background: darken($gray-lightest, 7%);
+  background: darken($gray-lightest, 15%);
 }
 
 .sem4 {
-  composes: sem;
-  background: darken($gray-lightest, 10%);
+  background: darken($gray-lightest, 20%);
+}
+
+@include night-mode-only {
+  $dark-bg: #2c2c2c;
+
+  .sem1 {
+    background: lighten($dark-bg, 5%);
+  }
+
+  .sem2 {
+    background: lighten($dark-bg, 10%);
+  }
+
+  .sem3 {
+    background: lighten($dark-bg, 15%);
+  }
+
+  .sem4 {
+    background: lighten($dark-bg, 20%);
+  }
 }

--- a/www/src/js/views/layout/GlobalSearch.scss
+++ b/www/src/js/views/layout/GlobalSearch.scss
@@ -144,6 +144,7 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
   }
 
   .semesters {
+    flex: 0 0 auto;
     margin-right: 0.4rem;
   }
 

--- a/www/src/js/views/layout/GlobalSearchContainer.jsx
+++ b/www/src/js/views/layout/GlobalSearchContainer.jsx
@@ -1,6 +1,6 @@
 // @flow
 import type { State } from 'reducers';
-import type { Module } from 'types/modules';
+import type { ModuleCondensed } from 'types/modules';
 import type { Venue, VenueList } from 'types/venues';
 import type { ModuleList } from 'types/reducers';
 import { type ResultType, type SearchResult, VENUE_RESULT } from 'types/views';
@@ -44,7 +44,7 @@ export class SearchContainerComponent extends Component<Props> {
     );
   }
 
-  onSelectModule = (module: Module) => {
+  onSelectModule = (module: ModuleCondensed) => {
     this.props.history.push(modulePage(module.ModuleCode, module.ModuleTitle));
   };
 
@@ -58,9 +58,9 @@ export class SearchContainerComponent extends Component<Props> {
     this.props.history.push(`${path}?q=${encodeURIComponent(query)}`);
   };
 
-  getResults = (inputValue: string): SearchResult => {
+  getResults = (inputValue: string): ?SearchResult => {
     if (!inputValue || inputValue.length < MIN_INPUT_LENGTH) {
-      return { modules: [], venues: [], tokens: [] };
+      return null;
     }
 
     const { moduleList, venueList } = this.props;

--- a/www/src/js/views/layout/GlobalSearchContainer.test.jsx
+++ b/www/src/js/views/layout/GlobalSearchContainer.test.jsx
@@ -45,12 +45,9 @@ test('fetches venue list', () => {
   expect(mock).toHaveBeenCalled();
 });
 
-test('shows at no choices when search is too short', () => {
+test('shows no choices when search is too short', () => {
   const instance = make().instance();
-  const { modules, venues, tokens } = instance.getResults('1');
-  expect(modules).toHaveLength(0);
-  expect(venues).toHaveLength(0);
-  expect(tokens).toHaveLength(0);
+  expect(instance.getResults('1')).toBeNull();
 });
 
 test('passes down search tokens', () => {

--- a/www/src/styles/bootstrap/style-override.scss
+++ b/www/src/styles/bootstrap/style-override.scss
@@ -9,7 +9,6 @@ mark {
   padding: 0;
   font-weight: bold;
   color: currentColor;
-  background: transparent;
 }
 
 // Forms

--- a/www/src/styles/bootstrap/style-override.scss
+++ b/www/src/styles/bootstrap/style-override.scss
@@ -6,10 +6,10 @@ body {
 }
 
 mark {
-  padding: 0.2em 0;
-  color: inherit;
-  border-bottom: 1px solid var(--yellow);
-  background: var(--yellow-light);
+  padding: 0;
+  font-weight: bold;
+  color: currentColor;
+  background: transparent;
 }
 
 // Forms

--- a/www/src/styles/bootstrap/variable-overrides.scss
+++ b/www/src/styles/bootstrap/variable-overrides.scss
@@ -41,6 +41,7 @@ $state-danger-text:         #fff;
 $state-danger-bg:           theme-color('danger');
 
 // Element styles
+$mark-bg: transparent;
 $hr-border-color: var(--gray-lighter);
 
 // Close button line color

--- a/www/src/styles/pages/module-finder.scss
+++ b/www/src/styles/pages/module-finder.scss
@@ -17,6 +17,10 @@
     margin-top: 0.15rem; // align baseline with semester switcher
     font-size: $font-size-lg;
   }
+
+  mark {
+    border-bottom: 1px solid;
+  }
 }
 
 .module-page-divider {

--- a/www/src/styles/utils/css-variables.scss
+++ b/www/src/styles/utils/css-variables.scss
@@ -28,10 +28,6 @@
   --gray-lightest: $gray-lightest;
   --gray-dark: $gray-dark;
 
-  // Yellow
-  --yellow: $yellow;
-  --yellow-light: $mark-bg;
-
   // Alert colors
   @each $color in $alert-override-themes {
     @include alert-variables($color);
@@ -58,10 +54,6 @@ body.mode-dark {
   --gray-lighter: #474747;
   --gray-lightest: #333;
   --gray-dark: invert($gray-dark);
-
-  // Yellow
-  --yellow: darken($yellow, 20);
-  --yellow-light: darken($mark-bg, 75);
 
   // Alert colors
   @each $color in $alert-override-themes {


### PR DESCRIPTION
This adds two features - 

## Semester in global search results 

Pretty self explanatory. The result is a bit ugly, to be honest. Maybe adjusting the colors would help. Performance seems fine, at least on desktop. We may need to virtualize the list on mobile. 

![screenshot from 2018-01-01 23-48-14](https://user-images.githubusercontent.com/445650/34468929-6d8d1b18-ef4e-11e7-9f76-41de5d797777.png)


## "No result" message 

Inform the user that their search returned no result, and show links to the full modules and venue search. 

![screenshot from 2018-01-01 23-48-29](https://user-images.githubusercontent.com/445650/34468930-712478fc-ef4e-11e7-9d87-840f9744ff4d.png)

The code is a bit longer than I'd like, but I'm not sure how I can shorten it. 
