### PR TITLE
Fix yarn lint script

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -10,7 +10,7 @@
     "rsync:export": "rsync -avu --delete-after dist-timetable/",
     "promote-staging": "bash scripts/promote-staging.sh",
     "postinstall": "flow-scripts stub",
-    "lint": "npm run flow && npm run lint:code && npm run lint:styles",
+    "lint": "yarn flow && yarn lint:code && yarn lint:styles",
     "lint:code": "eslint src/js webpack scripts",
     "lint:styles": "stylelint \"src/**/*.scss\" --syntax scss",
     "test": "jest --coverage",


### PR DESCRIPTION
'npm run flow' results in the error `missing script: flow`, breaking the lint script. Replaced with `yarn flow` to run flow directly.