### PR TITLE
Remove duplicate colors from 'Google' theme

### DIFF
--- a/www/src/styles/constants.scss
+++ b/www/src/styles/constants.scss
@@ -72,9 +72,9 @@ $nusmods-theme-colors: (
     #fba922,
     #198844,
     #3971ed,
-    #3971ed,
+    #79a4f9,
     #a36ac7,
-    #3971ed
+    #ec9998
   ),
   mocha: (
     #cb6077,


### PR DESCRIPTION
The Google theme somehow has two duplicate colors. This fixes that. 

![screenshot from 2018-01-02 23-42-47](https://user-images.githubusercontent.com/445650/34489349-018db052-f017-11e7-9cc3-657ac097ee61.png)
