### PR TITLE
Split export related code into their own bundle

### DIFF
--- a/www/src/js/actions/export.js
+++ b/www/src/js/actions/export.js
@@ -1,10 +1,7 @@
 // @flow
-import ical from 'ical-generator';
-
 import type { Module, Semester } from 'types/modules';
 import type { State } from 'reducers';
 
-import iCalForTimetable from 'utils/ical';
 import { hydrateSemTimetableWithLessons } from 'utils/timetables';
 import type { ExportData } from 'types/export';
 import type { FSA } from 'types/redux';
@@ -26,19 +23,25 @@ export const SUPPORTS_DOWNLOAD = 'download' in document.createElement('a');
 
 export function downloadAsIcal(semester: Semester) {
   return (dispatch: Function, getState: () => State) => {
-    const modules = getState().moduleBank.modules;
-    const timetable = getState().timetables[semester] || {};
-    const timetableWithLessons = hydrateSemTimetableWithLessons(timetable, modules, semester);
+    Promise.all([
+      import(/* webpackChunkName: "export" */ 'ical-generator'),
+      import(/* webpackChunkName: "export" */ 'utils/ical'),
+    ]).then(([ical, icalUtils]) => {
+      const modules = getState().moduleBank.modules;
+      const timetable = getState().timetables[semester] || {};
+      const timetableWithLessons = hydrateSemTimetableWithLessons(timetable, modules, semester);
 
-    const events = iCalForTimetable(semester, timetableWithLessons, modules);
-    const cal = ical({
-      domain: 'nusmods.com',
-      prodId: '//NUSMods//NUSMods//EN',
-      events,
+      const events = icalUtils.default(semester, timetableWithLessons, modules);
+      // $FlowFixMe Flow doesn't seem to like import() for CJS modules
+      const cal = ical({
+        domain: 'nusmods.com',
+        prodId: '//NUSMods//NUSMods//EN',
+        events,
+      });
+
+      const blob = new Blob([cal.toString()], { type: 'text/plain' });
+      downloadUrl(blob, 'nusmods_calendar.ics');
     });
-
-    const blob = new Blob([cal.toString()], { type: 'text/plain' });
-    downloadUrl(blob, 'nusmods_calendar.ics');
   };
 }
 

--- a/www/src/js/actions/export.js
+++ b/www/src/js/actions/export.js
@@ -4,7 +4,7 @@ import ical from 'ical-generator';
 import type { Module, Semester } from 'types/modules';
 import type { State } from 'reducers';
 
-import { iCalForTimetable } from 'utils/ical';
+import iCalForTimetable from 'utils/ical';
 import { hydrateSemTimetableWithLessons } from 'utils/timetables';
 import type { ExportData } from 'types/export';
 import type { FSA } from 'types/redux';

--- a/www/src/js/utils/ical.js
+++ b/www/src/js/utils/ical.js
@@ -173,7 +173,7 @@ export function iCalEventForLesson(
   };
 }
 
-export function iCalForTimetable(
+export default function iCalForTimetable(
   semester: Semester,
   timetable: SemTimetableConfigWithLessons,
   moduleData: { [ModuleCode]: Module },

--- a/www/src/js/utils/ical.test.js
+++ b/www/src/js/utils/ical.test.js
@@ -1,10 +1,9 @@
 // @flow
 import type { EventOption } from 'ical-generator';
 import config from 'config';
-import {
+import iCalForTimetable, {
   RECESS_WEEK,
   iCalEventForLesson,
-  iCalForTimetable,
   datesForAcademicWeeks,
   daysAfter,
   iCalEventForExam,

--- a/www/src/js/views/timetable/ShareTimetable.jsx
+++ b/www/src/js/views/timetable/ShareTimetable.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { PureComponent, Fragment } from 'react';
-import { QRCode } from 'react-qr-svg';
 import classnames from 'classnames';
 import qs from 'query-string';
 import axios from 'axios';
@@ -44,6 +43,7 @@ export const SHORT_URL_KEY = 'shorturl';
 export default class ShareTimetable extends PureComponent<Props, State> {
   urlInput: ?HTMLInputElement;
   url: ?string;
+  QRCode: ?Object;
 
   state: State = {
     isOpen: false,
@@ -54,19 +54,21 @@ export default class ShareTimetable extends PureComponent<Props, State> {
   loadShortUrl(url: string) {
     const showFullUrl = () => this.setState({ shortUrl: url });
 
-    return (
-      axios
-        .get('/short_url.php', { params: { url }, timeout: 2000 })
-        .then(({ data }) => {
-          if (data[SHORT_URL_KEY]) {
-            this.setState({ shortUrl: data[SHORT_URL_KEY] });
-          } else {
-            showFullUrl();
-          }
-        })
-        // Cannot get short URL - just use long URL instead
-        .catch(showFullUrl)
-    );
+    import(/* webpackChunkName: "export" */ 'react-qr-svg').then((module) => {
+      this.QRCode = module.QRCode;
+    });
+
+    axios
+      .get('/short_url.php', { params: { url }, timeout: 2000 })
+      .then(({ data }) => {
+        if (data[SHORT_URL_KEY]) {
+          this.setState({ shortUrl: data[SHORT_URL_KEY] });
+        } else {
+          showFullUrl();
+        }
+      })
+      // Cannot get short URL - just use long URL instead
+      .catch(showFullUrl);
   }
 
   openModal = () => {
@@ -112,6 +114,7 @@ export default class ShareTimetable extends PureComponent<Props, State> {
 
   renderSharing(url: string) {
     const { semester } = this.props;
+    const QRCode = this.QRCode;
 
     return (
       <div>
@@ -147,9 +150,7 @@ export default class ShareTimetable extends PureComponent<Props, State> {
           <div className="col-sm-4">
             <h3 className={styles.shareHeading}>QR Code</h3>
 
-            <div className={styles.qrCode}>
-              <QRCode value={url} />
-            </div>
+            <div className={styles.qrCode}>{QRCode && <QRCode value={url} />}</div>
           </div>
           <div className="col-sm-4">
             <h3 className={styles.shareHeading}>Via email</h3>


### PR DESCRIPTION
This shaves ~11kb off the two main bundles gziped by bundling `ical-generator` and `react-qr-svg` together into a lazy loaded bundle. Since both of these are async already, the perceived performance impact should be negligible.   

```
File sizes after gzip:

  114.33 KB (+5.8 KB)  build/vendor.91f9be154916caa4e35a.js
  58.72 KB (+5.81 KB)  build/app.6e114a37a62538adf0cb.js
  21.62 KB             build/app.6e114a37a62538adf0cb.css
  15.97 KB             build/a71072d948948dc0bfcd.js
  3.32 KB              build/4f24304e46dc5f28dea3.js
```
