### PR TITLE
Fix module removal bug on iOS Safari

### DIFF
--- a/www/src/js/views/layout/__snapshots__/Navtabs.test.jsx.snap
+++ b/www/src/js/views/layout/__snapshots__/Navtabs.test.jsx.snap
@@ -68,6 +68,9 @@ exports[`renders into nav element 1`] = `
       Settings
     </span>
   </NavLink>
+  <div
+    className="divider"
+  />
   <a
     className="link hiddenOnMobile"
     href="https://nuswhispers.com"

--- a/www/src/js/views/timetable/TimetableModulesTable.jsx
+++ b/www/src/js/views/timetable/TimetableModulesTable.jsx
@@ -42,7 +42,8 @@ class TimetableModulesTable extends Component<Props> {
             title={removeBtnLabel}
             aria-label={removeBtnLabel}
             onClick={() => {
-              if (window.confirm(`Are you sure you want to remove ${module.ModuleCode}?`)) {
+              const confirmMessage = `Are you sure you want to remove ${module.ModuleCode}?`;
+              if (window.confirm(confirmMessage)) {
                 this.props.onRemoveModule(module.ModuleCode);
               }
             }}


### PR DESCRIPTION
Friend found a bug preventing modules from being removed on iOS Safari. Not sure why this fix works, but it works.

### Steps to reproduce:

1. Have a module added to the timetable.
2. Open `/modules`.
3. Go back to `/timetable`
4. Click the trashcan to remove the module. The button doesn't do anything.

---

Also corrects the failing test that got ignored by CircleCI and subsequently merged.