### PR TITLE
Add "No Exam" message to module info page

### DIFF
--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -70,11 +70,7 @@ export class ModulePageContentComponent extends Component<Props, State> {
     if (exams.length === 0) {
       return (
         <div key="no-exam" className={styles.exam}>
-          <h3 className={styles.descriptionHeading}>No Exam Info</h3>
-          <p className={styles.noExamWarning}>
-            <strong>Caution</strong> Either {ModuleCode} has no exams or {ModuleCode}&#8217;s exam
-            data has not been released.
-          </p>
+          <h3 className={styles.descriptionHeading}>No Exam</h3>
         </div>
       );
     }

--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -69,7 +69,7 @@ export class ModulePageContentComponent extends Component<Props, State> {
 
     if (exams.length === 0) {
       return (
-        <div key="no-exam" className={styles.exam}>
+        <div className={styles.exam}>
           <h3 className={styles.descriptionHeading}>No Exam</h3>
         </div>
       );

--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -63,6 +63,32 @@ export class ModulePageContentComponent extends Component<Props, State> {
 
   toggleMenu = (isMenuOpen: boolean) => this.setState({ isMenuOpen });
 
+  renderExams() {
+    const { ModuleCode } = this.props.module;
+    const exams = this.examinations();
+
+    if (exams.length === 0) {
+      return (
+        <div key="no-exam" className={styles.exam}>
+          <h3 className={styles.descriptionHeading}>No Exam Info</h3>
+          <p className={styles.noExamWarning}>
+            <strong>Caution</strong> Either {ModuleCode} has no exams or {ModuleCode}&#8217;s exam
+            data has not been released.
+          </p>
+        </div>
+      );
+    }
+
+    return exams.map((exam) => (
+      <div key={exam.semester} className={styles.exam}>
+        <h3 className={styles.descriptionHeading}>{config.semesterNames[exam.semester]} Exam</h3>
+        <p>{formatExamDate(exam.date)}</p>
+
+        <ModuleExamClash semester={exam.semester} examDate={exam.date} moduleCode={ModuleCode} />
+      </div>
+    ));
+  }
+
   render() {
     const { module } = this.props;
     const { ModuleCode, ModuleTitle } = module;
@@ -158,20 +184,7 @@ export class ModulePageContentComponent extends Component<Props, State> {
                 </div>
 
                 <div className="col-sm-4">
-                  {this.examinations().map((exam) => (
-                    <div key={exam.semester} className={styles.exam}>
-                      <h3 className={styles.descriptionHeading}>
-                        {config.semesterNames[exam.semester]} Exam
-                      </h3>
-                      <p>{formatExamDate(exam.date)}</p>
-
-                      <ModuleExamClash
-                        semester={exam.semester}
-                        examDate={exam.date}
-                        moduleCode={ModuleCode}
-                      />
-                    </div>
-                  ))}
+                  {this.renderExams()}
 
                   <div className={styles.addToTimetable}>
                     <AddToTimetableDropdown module={module} className="btn-group-sm" block />

--- a/www/src/js/views/modules/ModulePageContent.scss
+++ b/www/src/js/views/modules/ModulePageContent.scss
@@ -1,4 +1,4 @@
-@import "~styles/utils/modules-entry";
+@import '~styles/utils/modules-entry';
 
 $header-margin-top: 1rem;
 $sticky-top: $navbar-height;
@@ -87,6 +87,11 @@ $sticky-top: $navbar-height;
 
   p {
     margin-bottom: 0;
+  }
+
+  .noExamWarning {
+    margin-top: 0.1rem;
+    font-size: $font-size-sm * $sm-font-size-ratio;
   }
 }
 

--- a/www/src/js/views/modules/ModulePageContent.scss
+++ b/www/src/js/views/modules/ModulePageContent.scss
@@ -88,11 +88,6 @@ $sticky-top: $navbar-height;
   p {
     margin-bottom: 0;
   }
-
-  .noExamWarning {
-    margin-top: 0.1rem;
-    font-size: $font-size-sm * $sm-font-size-ratio;
-  }
 }
 
 .addToTimetable {


### PR DESCRIPTION
Resolves #660.

Display "No Exam" in the module page when a module has no exams.

![localhost_8080_modules_cs5218_principles-of-program-analysis 1](https://user-images.githubusercontent.com/12784593/34560705-e02a5e12-f181-11e7-94b8-2e3927c8d4fe.png)


  