### PR TITLE
Fix scraper timestamp output tz

### DIFF
--- a/www/scripts/cors-crawler.js
+++ b/www/scripts/cors-crawler.js
@@ -12,8 +12,8 @@ const TIME_FORMAT = 'dddd Do MMMM, ha'; // eg. Friday 27th October, 12pm
 const OUT_DIR = 'src/js/data';
 
 function formatDateTime(date, time) {
-  const dateTime = moment(`${date} ${time}`, 'DD/MM/YYYY HH:mm', true);
-  assert(dateTime.isValid(), `${date} ${time} is not a valid date`);
+  const dateTime = moment(`${date} ${time} +08:00`, 'DD/MM/YYYY HH:mm ZZ', true);
+  assert(dateTime.isValid(), `"${date} ${time} +08:00" is not a valid date`);
   return dateTime;
 }
 

--- a/www/src/js/data/cors-schedule-ay1718-sem2.json
+++ b/www/src/js/data/cors-schedule-ay1718-sem2.json
@@ -5,9 +5,9 @@
       {
         "type": "open",
         "start": "Thursday 4th January, 9am",
-        "startTs": "2018-01-04T17:00:00.000Z",
+        "startTs": "2018-01-04T01:00:00.000Z",
         "end": "Thursday 4th January, 5pm",
-        "endTs": "2018-01-05T01:00:00.000Z"
+        "endTs": "2018-01-04T09:00:00.000Z"
       }
     ]
   },
@@ -17,23 +17,23 @@
       {
         "type": "open",
         "start": "Friday 5th January, 9am",
-        "startTs": "2018-01-05T17:00:00.000Z",
+        "startTs": "2018-01-05T01:00:00.000Z",
         "end": "Saturday 6th January, 8am",
-        "endTs": "2018-01-06T16:59:00.000Z"
+        "endTs": "2018-01-06T00:59:00.000Z"
       },
       {
         "type": "open",
         "start": "Monday 8th January, 9am",
-        "startTs": "2018-01-08T17:00:00.000Z",
+        "startTs": "2018-01-08T01:00:00.000Z",
         "end": "Monday 8th January, 1pm",
-        "endTs": "2018-01-08T21:00:00.000Z"
+        "endTs": "2018-01-08T05:00:00.000Z"
       },
       {
         "type": "closed",
         "start": "Monday 8th January, 1pm",
-        "startTs": "2018-01-08T21:00:00.000Z",
+        "startTs": "2018-01-08T05:00:00.000Z",
         "end": "Monday 8th January, 5pm",
-        "endTs": "2018-01-09T01:00:00.000Z"
+        "endTs": "2018-01-08T09:00:00.000Z"
       }
     ]
   },
@@ -43,16 +43,16 @@
       {
         "type": "open",
         "start": "Tuesday 9th January, 9am",
-        "startTs": "2018-01-09T17:00:00.000Z",
+        "startTs": "2018-01-09T01:00:00.000Z",
         "end": "Tuesday 9th January, 3pm",
-        "endTs": "2018-01-09T23:00:00.000Z"
+        "endTs": "2018-01-09T07:00:00.000Z"
       },
       {
         "type": "closed",
         "start": "Tuesday 9th January, 3pm",
-        "startTs": "2018-01-09T23:00:00.000Z",
+        "startTs": "2018-01-09T07:00:00.000Z",
         "end": "Tuesday 9th January, 5pm",
-        "endTs": "2018-01-10T01:00:00.000Z"
+        "endTs": "2018-01-09T09:00:00.000Z"
       }
     ]
   },
@@ -62,16 +62,16 @@
       {
         "type": "open",
         "start": "Wednesday 10th January, 9am",
-        "startTs": "2018-01-10T17:00:00.000Z",
+        "startTs": "2018-01-10T01:00:00.000Z",
         "end": "Thursday 11th January, 1pm",
-        "endTs": "2018-01-11T21:00:00.000Z"
+        "endTs": "2018-01-11T05:00:00.000Z"
       },
       {
         "type": "closed",
         "start": "Thursday 11th January, 1pm",
-        "startTs": "2018-01-11T21:00:00.000Z",
+        "startTs": "2018-01-11T05:00:00.000Z",
         "end": "Thursday 11th January, 5pm",
-        "endTs": "2018-01-12T01:00:00.000Z"
+        "endTs": "2018-01-11T09:00:00.000Z"
       }
     ]
   },
@@ -81,16 +81,16 @@
       {
         "type": "open",
         "start": "Friday 12th January, 9am",
-        "startTs": "2018-01-12T17:00:00.000Z",
+        "startTs": "2018-01-12T01:00:00.000Z",
         "end": "Friday 12th January, 3pm",
-        "endTs": "2018-01-12T23:00:00.000Z"
+        "endTs": "2018-01-12T07:00:00.000Z"
       },
       {
         "type": "closed",
         "start": "Friday 12th January, 3pm",
-        "startTs": "2018-01-12T23:00:00.000Z",
+        "startTs": "2018-01-12T07:00:00.000Z",
         "end": "Friday 12th January, 5pm",
-        "endTs": "2018-01-13T01:00:00.000Z"
+        "endTs": "2018-01-12T09:00:00.000Z"
       }
     ]
   },
@@ -100,16 +100,16 @@
       {
         "type": "open",
         "start": "Monday 15th January, 9am",
-        "startTs": "2018-01-15T17:00:00.000Z",
+        "startTs": "2018-01-15T01:00:00.000Z",
         "end": "Monday 15th January, 3pm",
-        "endTs": "2018-01-15T23:00:00.000Z"
+        "endTs": "2018-01-15T07:00:00.000Z"
       },
       {
         "type": "closed",
         "start": "Monday 15th January, 3pm",
-        "startTs": "2018-01-15T23:00:00.000Z",
+        "startTs": "2018-01-15T07:00:00.000Z",
         "end": "Monday 15th January, 5pm",
-        "endTs": "2018-01-16T01:00:00.000Z"
+        "endTs": "2018-01-15T09:00:00.000Z"
       }
     ]
   },
@@ -119,16 +119,16 @@
       {
         "type": "open",
         "start": "Tuesday 16th January, 9am",
-        "startTs": "2018-01-16T17:00:00.000Z",
+        "startTs": "2018-01-16T01:00:00.000Z",
         "end": "Tuesday 16th January, 3pm",
-        "endTs": "2018-01-16T23:00:00.000Z"
+        "endTs": "2018-01-16T07:00:00.000Z"
       },
       {
         "type": "closed",
         "start": "Tuesday 16th January, 3pm",
-        "startTs": "2018-01-16T23:00:00.000Z",
+        "startTs": "2018-01-16T07:00:00.000Z",
         "end": "Tuesday 16th January, 5pm",
-        "endTs": "2018-01-17T01:00:00.000Z"
+        "endTs": "2018-01-16T09:00:00.000Z"
       }
     ]
   }


### PR DESCRIPTION
Fixes #663 

This is a rather embarrassingly error - the human readable time string (which is what I checked) was correct, but the machine readable ISO8601 timestamp used to determine which round to actually show to the user is in the wrong TZ. 
  