### PR TITLE
Retry ModulePageContent import on online chunk loading failure

### DIFF
--- a/www/src/js/utils/promise.js
+++ b/www/src/js/utils/promise.js
@@ -1,0 +1,17 @@
+// @flow
+
+// Recursively retry fn until success, maxRetries has been reached, or shouldRetry returns false.
+// Based on https://stackoverflow.com/a/30471209/5281021
+// TODO: Remove eslint-disable-line comment when other functions have been added to this file
+export function retry( // eslint-disable-line import/prefer-default-export
+  retries: number,
+  fn: () => Promise<any>,
+  shouldRetry: Error => boolean = () => true,
+) {
+  return fn().catch((err) => {
+    if (retries <= 0 || !shouldRetry(err)) {
+      throw err;
+    }
+    return retry(retries - 1, fn, shouldRetry);
+  });
+}

--- a/www/src/js/utils/promise.js
+++ b/www/src/js/utils/promise.js
@@ -1,6 +1,6 @@
 // @flow
 
-// Recursively retry fn until success, maxRetries has been reached, or shouldRetry returns false.
+// Recursively retry fn until success, retries has been reached, or shouldRetry returns false.
 // Based on https://stackoverflow.com/a/30471209/5281021
 // TODO: Remove eslint-disable-line comment when other functions have been added to this file
 export function retry( // eslint-disable-line import/prefer-default-export

--- a/www/src/js/utils/promise.test.js
+++ b/www/src/js/utils/promise.test.js
@@ -5,7 +5,7 @@ describe('#retry()', () => {
   test('should retry failing fn up till limit if shouldRetry returns true', async () => {
     const mockFailingFn = jest.fn().mockReturnValue(Promise.reject('error'));
     await expect(retry(3, mockFailingFn, () => true)).rejects.toThrow('error');
-    expect(mockFailingFn.mock.calls).toHaveLength(4);
+    expect(mockFailingFn).toHaveBeenCalledTimes(4);
   });
 
   test('should stop retrying if shouldRetry returns false', async () => {
@@ -18,7 +18,7 @@ describe('#retry()', () => {
       .mockReturnValue(false);
 
     await expect(retry(3, mockFailingFn, shouldRetry)).rejects.toThrow('error');
-    expect(mockFailingFn.mock.calls).toHaveLength(2);
+    expect(mockFailingFn).toHaveBeenCalledTimes(2);
   });
 
   test('should stop retrying if promise resolves', async () => {
@@ -29,12 +29,12 @@ describe('#retry()', () => {
       .mockReturnValue(Promise.resolve());
 
     await expect(retry(3, mockFailingFn, () => true)).resolves;
-    expect(mockFailingFn.mock.calls).toHaveLength(2);
+    expect(mockFailingFn).toHaveBeenCalledTimes(2);
   });
 
   test('should not retry successful promises', async () => {
     const mockSucceedingFn = jest.fn().mockReturnValue(Promise.resolve());
     await expect(retry(3, mockSucceedingFn, () => true)).resolves;
-    expect(mockSucceedingFn.mock.calls).toHaveLength(1);
+    expect(mockSucceedingFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/www/src/js/utils/promise.test.js
+++ b/www/src/js/utils/promise.test.js
@@ -1,0 +1,50 @@
+// @flow
+import { retry } from './promise';
+
+describe('#retry()', () => {
+  test('should retry up till limit if shouldRetry returns true', () => {
+    expect.assertions(2);
+    const mockFailingFn = jest.fn().mockReturnValue(Promise.reject('error'));
+    return retry(3, mockFailingFn, () => true).catch((error) => {
+      expect(error).toBe('error');
+      expect(mockFailingFn.mock.calls).toHaveLength(4);
+    });
+  });
+
+  test('should not retry if shouldRetry returns false', () => {
+    expect.assertions(2);
+    const mockFailingFn = jest.fn().mockReturnValue(Promise.reject('error'));
+
+    // Retry once
+    const shouldRetry = jest
+      .fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false);
+
+    return retry(3, mockFailingFn, shouldRetry).catch((error) => {
+      expect(error).toBe('error');
+      expect(mockFailingFn.mock.calls).toHaveLength(2);
+    });
+  });
+
+  test('should not retry if promise returns true', () => {
+    expect.assertions(1);
+    // Fail only once
+    const mockFailingFn = jest
+      .fn()
+      .mockReturnValueOnce(Promise.reject('error'))
+      .mockReturnValue(Promise.resolve());
+
+    return retry(3, mockFailingFn, () => true).then(() => {
+      expect(mockFailingFn.mock.calls).toHaveLength(2);
+    });
+  });
+
+  test('should not retry successful promises', () => {
+    expect.assertions(1);
+    const mockSucceedingFn = jest.fn().mockReturnValue(Promise.resolve());
+    return retry(3, mockSucceedingFn, () => true).then(() => {
+      expect(mockSucceedingFn.mock.calls).toHaveLength(1);
+    });
+  });
+});

--- a/www/src/js/utils/promise.test.js
+++ b/www/src/js/utils/promise.test.js
@@ -2,17 +2,13 @@
 import { retry } from './promise';
 
 describe('#retry()', () => {
-  test('should retry up till limit if shouldRetry returns true', () => {
-    expect.assertions(2);
+  test('should retry failing fn up till limit if shouldRetry returns true', async () => {
     const mockFailingFn = jest.fn().mockReturnValue(Promise.reject('error'));
-    return retry(3, mockFailingFn, () => true).catch((error) => {
-      expect(error).toBe('error');
-      expect(mockFailingFn.mock.calls).toHaveLength(4);
-    });
+    await expect(retry(3, mockFailingFn, () => true)).rejects.toThrow('error');
+    expect(mockFailingFn.mock.calls).toHaveLength(4);
   });
 
-  test('should not retry if shouldRetry returns false', () => {
-    expect.assertions(2);
+  test('should stop retrying if shouldRetry returns false', async () => {
     const mockFailingFn = jest.fn().mockReturnValue(Promise.reject('error'));
 
     // Retry once
@@ -21,30 +17,24 @@ describe('#retry()', () => {
       .mockReturnValueOnce(true)
       .mockReturnValue(false);
 
-    return retry(3, mockFailingFn, shouldRetry).catch((error) => {
-      expect(error).toBe('error');
-      expect(mockFailingFn.mock.calls).toHaveLength(2);
-    });
+    await expect(retry(3, mockFailingFn, shouldRetry)).rejects.toThrow('error');
+    expect(mockFailingFn.mock.calls).toHaveLength(2);
   });
 
-  test('should not retry if promise returns true', () => {
-    expect.assertions(1);
+  test('should stop retrying if promise resolves', async () => {
     // Fail only once
     const mockFailingFn = jest
       .fn()
       .mockReturnValueOnce(Promise.reject('error'))
       .mockReturnValue(Promise.resolve());
 
-    return retry(3, mockFailingFn, () => true).then(() => {
-      expect(mockFailingFn.mock.calls).toHaveLength(2);
-    });
+    await expect(retry(3, mockFailingFn, () => true)).resolves;
+    expect(mockFailingFn.mock.calls).toHaveLength(2);
   });
 
-  test('should not retry successful promises', () => {
-    expect.assertions(1);
+  test('should not retry successful promises', async () => {
     const mockSucceedingFn = jest.fn().mockReturnValue(Promise.resolve());
-    return retry(3, mockSucceedingFn, () => true).then(() => {
-      expect(mockSucceedingFn.mock.calls).toHaveLength(1);
-    });
+    await expect(retry(3, mockSucceedingFn, () => true)).resolves;
+    expect(mockSucceedingFn.mock.calls).toHaveLength(1);
   });
 });

--- a/www/src/js/views/modules/ModulePageContainer.jsx
+++ b/www/src/js/views/modules/ModulePageContainer.jsx
@@ -11,6 +11,7 @@ import type { ModuleCodeMap } from 'types/reducers';
 import type { Module, ModuleCode } from 'types/modules';
 
 import { fetchModule } from 'actions/moduleBank';
+import { retry } from 'utils/promise';
 import NotFoundPage from 'views/errors/NotFoundPage';
 import ErrorPage from 'views/errors/ErrorPage';
 import LoadingSpinner from 'views/components/LoadingSpinner';
@@ -29,21 +30,6 @@ type State = {
   ModulePageContent: ?ComponentType<*>,
   error?: any,
 };
-
-// Recursively retry fn until success, maxRetries has been reached, or shouldRetry returns false.
-// Based on https://stackoverflow.com/a/30471209/5281021
-function retry(
-  maxRetries: number,
-  fn: () => Promise<any>,
-  shouldRetry: Error => boolean = () => true,
-) {
-  return fn().catch((err) => {
-    if (maxRetries <= 0 || !shouldRetry(err)) {
-      throw err;
-    }
-    return retry(maxRetries - 1, fn, shouldRetry);
-  });
-}
 
 /**
  * Wrapper component that loads both module data and the module page component

--- a/www/src/js/views/modules/ModulePageContainer.jsx
+++ b/www/src/js/views/modules/ModulePageContainer.jsx
@@ -59,7 +59,7 @@ export class ModulePageContainerComponent extends PureComponent<Props, State> {
     retry(
       3,
       () => import('views/modules/ModulePageContent'),
-      (error) => error.message.indexOf('Loading chunk ') === 0 && window.navigator.onLine,
+      (error) => error.message.includes('Loading chunk ') && window.navigator.onLine,
     )
       .then((module) => this.setState({ ModulePageContent: module.default }))
       .catch((error) => {


### PR DESCRIPTION
Attempted fix for #658 by implementing point 2 in https://github.com/nusmodifications/nusmods/issues/658#issuecomment-355544612: Retry the `import()` promise instead of just running it once.

The promise is now called three times if we're online and encountering the chunk loading error.
  