### PR TITLE
Fix scroll to hash on settings and module info page 

### DIFF
--- a/www/src/js/utils/react.jsx
+++ b/www/src/js/utils/react.jsx
@@ -70,6 +70,14 @@ export function wrapComponentName(Component: ComponentType, wrapper: string): st
   return `${wrapper}(${Component.displayName || Component.name || 'Component'})`;
 }
 
+/**
+ * Small utility function to scroll to an element with ID matching the URL hash if
+ * both are present.
+ *
+ * This mimics traditional webpage behavior and should be used in componentDidMount() when
+ * the component is not loaded on initial page load (ie. the element is not in the DOM when
+ * the page is initially loaded), but has content that can be linked to via hashes.
+ */
 export function scrollToHash() {
   const hash = window.location.hash;
   if (hash) {

--- a/www/src/js/utils/react.jsx
+++ b/www/src/js/utils/react.jsx
@@ -70,6 +70,16 @@ export function wrapComponentName(Component: ComponentType, wrapper: string): st
   return `${wrapper}(${Component.displayName || Component.name || 'Component'})`;
 }
 
+export function scrollToHash() {
+  const hash = window.location.hash;
+  if (hash) {
+    const ele = document.getElementById(hash.slice(1)); // Hash string contains the '#' character
+    if (ele) {
+      ele.scrollIntoView(true);
+    }
+  }
+}
+
 /**
  * Utility class that encapsulates an auto-incrementing counter. Useful for
  * keeping track of Downshift item indices

--- a/www/src/js/views/components/ScrollToTop.jsx
+++ b/www/src/js/views/components/ScrollToTop.jsx
@@ -1,12 +1,12 @@
 // @flow
-import type { ContextRouter, Location } from 'react-router-dom';
+import type { ContextRouter } from 'react-router-dom';
 
 import { Component } from 'react';
 import { withRouter } from 'react-router-dom';
+import { scrollToHash } from 'utils/react';
 
 type Props = {
   ...ContextRouter,
-  location: Location,
   onComponentWillMount: boolean,
   onPathChange: boolean,
 };
@@ -26,6 +26,10 @@ export class ScrollToTopComponent extends Component<Props> {
     if (this.props.onComponentWillMount) {
       scrollToTop();
     }
+  }
+
+  componentDidMount() {
+    scrollToHash();
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/www/src/js/views/components/ScrollToTop.jsx
+++ b/www/src/js/views/components/ScrollToTop.jsx
@@ -3,7 +3,6 @@ import type { ContextRouter } from 'react-router-dom';
 
 import { Component } from 'react';
 import { withRouter } from 'react-router-dom';
-import { scrollToHash } from 'utils/react';
 
 type Props = {
   ...ContextRouter,
@@ -23,17 +22,19 @@ export class ScrollToTopComponent extends Component<Props> {
   };
 
   componentWillMount() {
-    if (this.props.onComponentWillMount) {
+    if (this.props.onComponentWillMount && !window.location.hash) {
       scrollToTop();
     }
   }
 
-  componentDidMount() {
-    scrollToHash();
-  }
-
   componentDidUpdate(prevProps: Props) {
-    if (this.props.onPathChange && this.props.location.pathname !== prevProps.location.pathname) {
+    const { onPathChange, location: { pathname, hash } } = this.props;
+
+    if (
+      onPathChange &&
+      pathname !== prevProps.location.pathname &&
+      hash === prevProps.location.hash
+    ) {
       scrollToTop();
     }
   }

--- a/www/src/js/views/components/ScrollToTop.jsx
+++ b/www/src/js/views/components/ScrollToTop.jsx
@@ -3,11 +3,13 @@ import type { ContextRouter } from 'react-router-dom';
 
 import { Component } from 'react';
 import { withRouter } from 'react-router-dom';
+import { scrollToHash } from 'utils/react';
 
 type Props = {
   ...ContextRouter,
   onComponentWillMount: boolean,
   onPathChange: boolean,
+  scrollToHash: boolean,
 };
 
 function scrollToTop() {
@@ -19,11 +21,18 @@ export class ScrollToTopComponent extends Component<Props> {
   static defaultProps = {
     onComponentWillMount: false,
     onPathChange: false,
+    scrollToHash: true,
   };
 
   componentWillMount() {
     if (this.props.onComponentWillMount && !window.location.hash) {
       scrollToTop();
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.scrollToHash) {
+      scrollToHash();
     }
   }
 

--- a/www/src/js/views/components/ScrollToTop.test.jsx
+++ b/www/src/js/views/components/ScrollToTop.test.jsx
@@ -1,49 +1,68 @@
 // @flow
 import React from 'react';
-import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import { mount, type ReactWrapper } from 'enzyme';
 import mockDom from 'test-utils/mockDom';
 
-import { ScrollToTopComponent } from './ScrollToTop';
+import ScrollToTop, { ScrollToTopComponent } from './ScrollToTop';
+
+type Props = {
+  onComponentWillMount?: boolean,
+  onPathChange?: boolean,
+};
 
 describe('ScrollToTopComponent', () => {
   beforeEach(() => {
     mockDom();
   });
 
+  function make({ onComponentWillMount, onPathChange }: Props = {}) {
+    return mount(
+      <MemoryRouter>
+        <ScrollToTop onComponentWillMount={onComponentWillMount} onPathChange={onPathChange} />
+      </MemoryRouter>,
+    );
+  }
+
+  function getHistory(wrapper: ReactWrapper) {
+    return wrapper.find(ScrollToTopComponent).prop('history');
+  }
+
   test('default behavior does not to anything', () => {
-    mount(<ScrollToTopComponent />);
+    make();
     expect(window.scrollTo).not.toHaveBeenCalled();
   });
 
   test('onComponentWillMount attribute behaves correctly', () => {
-    mount(<ScrollToTopComponent onComponentWillMount />);
+    make({ onComponentWillMount: true });
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 
   test('onPathChange attribute behaves correctly', () => {
-    const wrapper = mount(<ScrollToTopComponent onPathChange location={{ pathname: '/' }} />);
+    const wrapper = make({ onPathChange: true });
+    const history = getHistory(wrapper);
     expect(window.scrollTo).not.toHaveBeenCalled();
-    wrapper.setProps({ location: { pathname: '/foo' } });
+    history.push('/foo');
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 
   test('onComponentWillMount attribute behaves correctly', () => {
-    mount(<ScrollToTopComponent onComponentWillMount />);
+    make({ onComponentWillMount: true });
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 
   test('integration test', () => {
-    const wrapper = mount(
-      <ScrollToTopComponent onPathChange onComponentWillMount location={{ pathname: '/' }} />,
-    );
+    const wrapper = make({ onComponentWillMount: true, onPathChange: true });
+    const history = getHistory(wrapper);
+
     expect(window.scrollTo).toHaveBeenCalledTimes(1);
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
-    wrapper.setProps({ location: { pathname: '/foo' } });
+    history.push('/foo');
     expect(window.scrollTo).toHaveBeenCalledTimes(2);
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
-    wrapper.setProps({ location: { pathname: '/foo' } });
+    history.push('/foo');
     expect(window.scrollTo).toHaveBeenCalledTimes(2);
-    wrapper.setProps({ location: { pathname: '/bar' } });
+    history.push('/bar');
     expect(window.scrollTo).toHaveBeenCalledTimes(3);
   });
 });

--- a/www/src/js/views/modules/ModulePageContainer.jsx
+++ b/www/src/js/views/modules/ModulePageContainer.jsx
@@ -91,7 +91,7 @@ export class ModulePageContainerComponent extends PureComponent<Props, State> {
 
   render() {
     const { ModulePageContent, error } = this.state;
-    const { module, moduleCode, match } = this.props;
+    const { module, moduleCode, match, location } = this.props;
 
     if (!this.doesModuleExist(moduleCode)) {
       return <NotFoundPage />;
@@ -102,7 +102,14 @@ export class ModulePageContainerComponent extends PureComponent<Props, State> {
     }
 
     if (module && match.url !== this.canonicalUrl()) {
-      return <Redirect to={this.canonicalUrl()} />;
+      return (
+        <Redirect
+          to={{
+            ...location,
+            pathname: this.canonicalUrl(),
+          }}
+        />
+      );
     }
 
     if (module && ModulePageContent) {

--- a/www/src/js/views/modules/ModulePageContainer.test.jsx
+++ b/www/src/js/views/modules/ModulePageContainer.test.jsx
@@ -45,7 +45,7 @@ function make(
 
 function assertRedirect(component, redirectTo = CANONICAL) {
   expect(component.type()).toEqual(Redirect);
-  expect(component.props()).toMatchObject({ to: redirectTo });
+  expect(component.props()).toMatchObject({ to: { pathname: redirectTo } });
 }
 
 test('should show 404 page when the module code does not exist', () => {

--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -11,7 +11,7 @@ import type { Module } from 'types/modules';
 import config from 'config';
 import { formatExamDate, getSemestersOffered } from 'utils/modules';
 import { intersperse } from 'utils/array';
-import { BULLET } from 'utils/react';
+import { BULLET, scrollToHash } from 'utils/react';
 import { NAVTAB_HEIGHT } from 'views/layout/Navtabs';
 import ModuleTree from 'views/modules/ModuleTree';
 import LinkModuleCodes from 'views/components/LinkModuleCodes';
@@ -51,6 +51,10 @@ export class ModulePageContentComponent extends Component<Props, State> {
   state: State = {
     isMenuOpen: false,
   };
+
+  componentDidMount() {
+    scrollToHash();
+  }
 
   toggleMenu = (isMenuOpen: boolean) => this.setState({ isMenuOpen });
 

--- a/www/src/js/views/settings/SettingsContainer.jsx
+++ b/www/src/js/views/settings/SettingsContainer.jsx
@@ -121,8 +121,8 @@ class SettingsContainer extends Component<Props, State> {
       <hr />
       */}
         {supportsCSSVariables() && (
-          <div id="night-mode">
-            <h4>Night Mode</h4>
+          <div>
+            <h4 id="night-mode">Night Mode</h4>
             <div className={classnames(styles.toggleRow, 'row')}>
               <div className={classnames(styles.toggleDescription, 'col-sm-7')}>
                 <p>

--- a/www/src/js/views/settings/SettingsContainer.scss
+++ b/www/src/js/views/settings/SettingsContainer.scss
@@ -10,7 +10,10 @@
 
   hr {
     clear: both;
-    margin-bottom: 2rem;
+  }
+
+  h4 {
+    padding-top: $navbar-height;
   }
 
   // Styles nested for specificity
@@ -31,7 +34,7 @@
 }
 
 .title {
-  margin: 1rem 0 4rem;
+  margin: 1rem 0 0;
   font-size: $font-size-xlg;
 }
 


### PR DESCRIPTION
Adds a small util function to handle scrolling to the correct section of the page when there's a hash fragment in the URL. 

This is broken on `<ModulePageContent>` because the content is loaded asynchronously, so the element with the ID is not present at initial page load. We fix this by doing an additional check during `componentDidMount`. 

It is also broken on `<SettngsContainer>` - not entirely sure why, but adding the same function to `<ScrollToTop>` works.