### PR TITLE
Delay UrlChangeTracker.handleUrlChange invocation

### DIFF
--- a/www/src/js/bootstrapping/google-analytics.js
+++ b/www/src/js/bootstrapping/google-analytics.js
@@ -15,6 +15,7 @@ export default function initializeGA() {
       // delays the GA invocation sufficiently long enough for React to do its stuff.
       // 100ms is an arbitary value which works well enough for most cases.
       const HANDLE_URL_CHANGE_TIMEOUT = 100;
+      // eslint-disable-next-line
       window.gaplugins.UrlChangeTracker.prototype.handleUrlChange = function(historyDidUpdate) {
         setTimeout(() => {
           origHandleUrlChange.call(this, historyDidUpdate);

--- a/www/src/js/bootstrapping/google-analytics.js
+++ b/www/src/js/bootstrapping/google-analytics.js
@@ -9,6 +9,7 @@ export default function initializeGA() {
       import(/* webpackChunkName: "autotrack" */ 'autotrack/lib/plugins/url-change-tracker'),
     ]).then(() => {
       const origHandleUrlChange = window.gaplugins.UrlChangeTracker.prototype.handleUrlChange;
+      // The following is a mega hack for using react-helmet together with autotrack...
       // This timeout is needed because React (and consequently React Helmet's) render
       // update is not synchronous. In fact, UrlChangeTracker.handleUrlChange is already
       // made async via setTimeout(..., 0) but it's still insufficient. A timeout of 100ms

--- a/www/src/js/bootstrapping/google-analytics.js
+++ b/www/src/js/bootstrapping/google-analytics.js
@@ -8,6 +8,19 @@ export default function initializeGA() {
       import(/* webpackChunkName: "autotrack" */ 'autotrack/lib/plugins/outbound-link-tracker'),
       import(/* webpackChunkName: "autotrack" */ 'autotrack/lib/plugins/url-change-tracker'),
     ]).then(() => {
+      const origHandleUrlChange = window.gaplugins.UrlChangeTracker.prototype.handleUrlChange;
+      // This timeout is needed because React (and consequently React Helmet's) render
+      // update is not synchronous. In fact, UrlChangeTracker.handleUrlChange is already
+      // made async via setTimeout(..., 0) but it's still insufficient. A timeout of 100ms
+      // delays the GA invocation sufficiently long enough for React to do its stuff.
+      // 100ms is an arbitary value which works well enough for most cases.
+      const HANDLE_URL_CHANGE_TIMEOUT = 100;
+      window.gaplugins.UrlChangeTracker.prototype.handleUrlChange = function(historyDidUpdate) {
+        setTimeout(() => {
+          origHandleUrlChange.call(this, historyDidUpdate);
+        }, HANDLE_URL_CHANGE_TIMEOUT);
+      };
+
       window.ga('create', config.googleAnalyticsId, 'auto');
 
       window.ga('require', 'eventTracker');

--- a/www/src/js/views/errors/ErrorPage.jsx
+++ b/www/src/js/views/errors/ErrorPage.jsx
@@ -33,7 +33,7 @@ export default class NotFoundPage extends PureComponent<Props> {
 
     return (
       <div>
-        <Helmet>
+        <Helmet defer={false}>
           <title>Uh oh... - {config.brandName}</title>
         </Helmet>
 

--- a/www/src/js/views/errors/NotFoundPage.jsx
+++ b/www/src/js/views/errors/NotFoundPage.jsx
@@ -13,7 +13,7 @@ export default function NotFoundPage() {
 
   return (
     <div>
-      <Helmet>
+      <Helmet defer={false}>
         <title>Page Not Found - {config.brandName}</title>
       </Helmet>
 

--- a/www/src/js/views/modules/ModuleFinderContainer.jsx
+++ b/www/src/js/views/modules/ModuleFinderContainer.jsx
@@ -71,7 +71,7 @@ type State = {
 const INSTANT_SEARCH_THRESHOLD = 300;
 
 const pageHead = (
-  <Helmet>
+  <Helmet defer={false}>
     <title>Modules - {config.brandName}</title>
   </Helmet>
 );

--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -67,7 +67,7 @@ export class ModulePageContentComponent extends Component<Props, State> {
 
     return (
       <div className={classnames('page-container', styles.moduleInfoPage)}>
-        <Helmet>
+        <Helmet defer={false}>
           <title>
             {pageTitle} - {config.brandName}
           </title>

--- a/www/src/js/views/settings/SettingsContainer.jsx
+++ b/www/src/js/views/settings/SettingsContainer.jsx
@@ -83,7 +83,7 @@ class SettingsContainer extends Component<Props, State> {
     return (
       <div className={classnames(styles.settingsPage, 'page-container')}>
         <ScrollToTop onComponentWillMount />
-        <Helmet>
+        <Helmet defer={false}>
           <title>Settings - {config.brandName}</title>
         </Helmet>
 

--- a/www/src/js/views/static/StaticPage.jsx
+++ b/www/src/js/views/static/StaticPage.jsx
@@ -16,7 +16,7 @@ function StaticPage(props: Props) {
   return (
     <div className="page-container">
       <ScrollToTop onComponentWillMount />
-      <Helmet>
+      <Helmet defer={false}>
         <title>
           {props.title} - {config.brandName}
         </title>

--- a/www/src/js/views/timetable/TimetableContent.jsx
+++ b/www/src/js/views/timetable/TimetableContent.jsx
@@ -289,7 +289,7 @@ class TimetableContent extends Component<Props, State> {
         })}
         onClick={this.cancelModifyLesson}
       >
-        <Helmet>
+        <Helmet defer={false}>
           <title>Timetable - {config.brandName}</title>
         </Helmet>
 

--- a/www/src/js/views/venues/VenuesContainer.jsx
+++ b/www/src/js/views/venues/VenuesContainer.jsx
@@ -54,7 +54,7 @@ type State = {
 };
 
 const pageHead = (
-  <Helmet>
+  <Helmet defer={false}>
     <title>Venues - {config.brandName}</title>
   </Helmet>
 );


### PR DESCRIPTION
Added a timeout to `UrlChangeTracker.handleUrlChange` because React 16 (and consequently React Helmet's) render update is not synchronous. 

In fact, `UrlChangeTracker.handleUrlChange()` is already made async via `setTimeout(..., 0)` but it's still insufficient. A timeout of 100ms delays the GA invocation sufficiently long enough for React to do its stuff. 

Why 100ms? It's an arbitary value actually. It's short enough for us not to miss any page change event, but long enough for React to complete its rendering. This works well enough for most cases.

**Before**

<img width="312" alt="screen shot 2018-01-09 at 9 15 01 pm" src="https://user-images.githubusercontent.com/1315101/34756814-35743128-f582-11e7-94d2-b0b2a0f2280e.png">

**After**

<img width="336" alt="screen shot 2018-01-09 at 9 11 36 pm" src="https://user-images.githubusercontent.com/1315101/34756784-065c2562-f582-11e7-9a99-18f17ce7d8fd.png">
