### PR TITLE
Temporarily disable ivle api

### DIFF
--- a/api/gulpfile.babel.js
+++ b/api/gulpfile.babel.js
@@ -30,7 +30,7 @@ gulp.task('bulletinModules', () => {
   const subtasks = iterateSems({
     from: yearStart,
     to: yearEnd,
-    semesters: [0, 1, 2, 3, 4],
+    semesters: [0, 3, 4],
     config: config.bulletinModules,
   });
 


### PR DESCRIPTION
Since bulletinModules under ivle api hasn't been responding for a good few days now, we're going to disable scraping for them for now.