### PR TITLE
Improve data layer engineering

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -163,7 +163,7 @@ $ yarn promote-staging # Promote ./dist to production
 │   │       ├── timetable    - Timetable builder related components
 │   │       └── venues       - Venues page related components
 │   └── styles
-│       ├── bootstrap        - Bootstraping, uh, Bootstrap
+│       ├── bootstrap        - Bootstrapping, uh, Bootstrap
 │       ├── material         - Material components 
 │       ├── components       - Legacy component styles
 │       │                      (new components should colocate their styles)

--- a/www/README.md
+++ b/www/README.md
@@ -133,43 +133,46 @@ $ yarn promote-staging # Promote ./dist to production
 ## Project Structure
 
 ```
-├── scripts                 - Command line scripts to help with development
+├── scripts                  - Command line scripts to help with development
 ├── src
 │   ├── img
 │   ├── js
-│   │   ├── actions         - Redux actions
-│   │   ├── apis            - Code to interface with external APIs
-│   │   ├── config          - App configuration
-│   │   ├── data            - Static data such as theme colors
-│   │   ├── middlewares     - Redux middlewares
-│   │   ├── reducers        - Redux reducers
-│   │   ├── storage         - Persistance layer for Redux
-│   │   ├── stores          - Redux store config
-│   │   ├── test-utils      - Utilities for testing - this directory is not counted
-│   │   │                     for test coverage
-│   │   ├── types           - Flow type definitions
-│   │   ├── utils           - Utility functions and classes
+│   │   ├── actions          - Redux actions
+│   │   ├── apis             - Code to interface with external APIs
+│   │   ├── bootstrapping    - Code that runs once only on app initialization 
+│   │   ├── config           - App configuration
+│   │   ├── data             - Static data such as theme colors
+│   │   ├── middlewares      - Redux middlewares
+│   │   ├── reducers         - Redux reducers
+│   │   ├── storage          - Persistance layer for Redux
+│   │   ├── test-utils       - Utilities for testing - this directory is not counted
+│   │   │                      for test coverage
+│   │   ├── timetable-export - Entry point for timetable only build for exports
+│   │   ├── types            - Flow type definitions
+│   │   ├── utils            - Utility functions and classes
 │   │   └── views
-│   │       ├── browse      - Module info and module finder related components
-│   │       ├── components  - Reusable components
-│   │       ├── errors      - Error pages
-│   │       ├── hocs        - Higher order components
-│   │       ├── layout      - Global layout components
-│   │       ├── modules     - Module finder and module info components
-│   │       ├── routes      - Routing related components
-│   │       ├── settings    - Settings page component
-│   │       ├── static      - Static pages like /team and /developers
-│   │       └── timetable   - Timetable builder related components
+│   │       ├── browse       - Module info and module finder related components
+│   │       ├── components   - Reusable components
+│   │       ├── errors       - Error pages
+│   │       ├── hocs         - Higher order components
+│   │       ├── layout       - Global layout components
+│   │       ├── modules      - Module finder and module info components
+│   │       ├── routes       - Routing related components
+│   │       ├── settings     - Settings page component
+│   │       ├── static       - Static pages like /team and /developers
+│   │       ├── timetable    - Timetable builder related components
+│   │       └── venues       - Venues page related components
 │   └── styles
-│       ├── bootstrap       - Bootstraping, uh, Bootstrap
-│       ├── components      - Legacy component styles
-│       │                     (new components should colocate their styles)
-│       ├── layout          - Site-wide layout styles
-│       ├── pages           - Page specific styles
-│       └── utils           - Utility classes, mixins, functions
-├── static                  - Static assets, eg. favicons
-|                             These will be copied directly into /dist
-└── webpack                 - Webpack config
+│       ├── bootstrap        - Bootstraping, uh, Bootstrap
+│       ├── material         - Material components 
+│       ├── components       - Legacy component styles
+│       │                      (new components should colocate their styles)
+│       ├── layout           - Site-wide layout styles
+│       ├── pages            - Page specific styles
+│       └── utils            - Utility classes, mixins, functions
+├── static                   - Static assets, eg. favicons
+│                              These will be copied directly into /dist
+└── webpack                  - Webpack config
 ```
 
 ### Colocation

--- a/www/src/js/actions/export.js
+++ b/www/src/js/actions/export.js
@@ -1,10 +1,9 @@
 // @flow
 import type { Module, Semester } from 'types/modules';
-import type { State } from 'reducers';
 
 import { hydrateSemTimetableWithLessons } from 'utils/timetables';
 import type { ExportData } from 'types/export';
-import type { FSA } from 'types/redux';
+import type { FSA, GetState } from 'types/redux';
 
 function downloadUrl(blob: Blob, filename: string) {
   const link = document.createElement('a');
@@ -22,7 +21,7 @@ function downloadUrl(blob: Blob, filename: string) {
 export const SUPPORTS_DOWNLOAD = 'download' in document.createElement('a');
 
 export function downloadAsIcal(semester: Semester) {
-  return (dispatch: Function, getState: () => State) => {
+  return (dispatch: Function, getState: GetState) => {
     Promise.all([
       import(/* webpackChunkName: "export" */ 'ical-generator'),
       import(/* webpackChunkName: "export" */ 'utils/ical'),

--- a/www/src/js/actions/timetables.js
+++ b/www/src/js/actions/timetables.js
@@ -16,7 +16,7 @@ import { MIGRATION_KEYS, parseQueryString } from 'storage/migrateTimetable';
 
 export const ADD_MODULE: string = 'ADD_MODULE';
 export function addModule(semester: Semester, moduleCode: ModuleCode) {
-  return (dispatch: Function, getState: Function) =>
+  return (dispatch: Function, getState: GetState) =>
     dispatch(fetchModule(moduleCode)).then(() => {
       const module: Module = getState().moduleBank.modules[moduleCode];
       const lessons = getModuleTimetable(module, semester);
@@ -90,7 +90,7 @@ export function setTimetable(
   timetable?: SemTimetableConfig,
   colors?: ColorMapping,
 ) {
-  return (dispatch: Function, getState: Function) => {
+  return (dispatch: Function, getState: GetState) => {
     let validatedTimetable = timetable;
     if (timetable) {
       const moduleCodes = getState().moduleBank.moduleCodes;

--- a/www/src/js/middlewares/raven-middleware.js
+++ b/www/src/js/middlewares/raven-middleware.js
@@ -5,18 +5,14 @@ import createRavenMiddleware from 'raven-for-redux';
 
 import type { State } from 'reducers/index';
 import type { ModuleBank } from 'reducers/moduleBank';
-
-function stringifyModuleBank(moduleBank: ModuleBank): string {
-  return `${moduleBank.moduleList.length} modules`;
-}
+import type { VenueBank } from 'reducers/venueBank';
 
 export default createRavenMiddleware(Raven, {
   stateTransformer(state: State) {
     return {
       ...state,
-      entities: {
-        moduleBank: stringifyModuleBank(state.moduleBank),
-      },
+      moduleBank: (moduleBank: ModuleBank): string => `${moduleBank.moduleList.length} modules`,
+      venueBank: (venueBank: VenueBank): string => `${venueBank.venueList.length} venues`,
     };
   },
 });

--- a/www/src/js/middlewares/raven-middleware.js
+++ b/www/src/js/middlewares/raven-middleware.js
@@ -4,15 +4,13 @@ import Raven from 'raven-js';
 import createRavenMiddleware from 'raven-for-redux';
 
 import type { State } from 'reducers/index';
-import type { ModuleBank } from 'reducers/moduleBank';
-import type { VenueBank } from 'reducers/venueBank';
 
 export default createRavenMiddleware(Raven, {
   stateTransformer(state: State) {
     return {
       ...state,
-      moduleBank: (moduleBank: ModuleBank): string => `${moduleBank.moduleList.length} modules`,
-      venueBank: (venueBank: VenueBank): string => `${venueBank.venueList.length} venues`,
+      moduleBank: `${state.moduleBank.moduleList.length} modules`,
+      venueBank: `${state.venueBank.venueList.length} venues`,
     };
   },
 });

--- a/www/src/js/middlewares/requests-middleware.js
+++ b/www/src/js/middlewares/requests-middleware.js
@@ -1,17 +1,12 @@
 import axios from 'axios';
-import _ from 'lodash';
 
-function makeRequest(request, accessToken) {
-  const req = _.cloneDeep(request);
-  req.headers = {
-    'Content-Type': 'application/json',
-  };
-
-  if (accessToken) {
-    req.headers.Authorization = accessToken;
-  }
-
-  return axios(req);
+function makeRequest(request) {
+  return axios({
+    ...request,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
 }
 
 export const API_REQUEST = Symbol('API_REQUEST');
@@ -19,7 +14,7 @@ export const REQUEST = '_REQUEST';
 export const SUCCESS = '_SUCCESS';
 export const FAILURE = '_FAILURE';
 
-export default (store) => (next) => (action) => {
+export default () => (next) => (action) => {
   if (!action.meta || !action.meta[API_REQUEST]) {
     // Non-api request action
     return next(action);
@@ -48,14 +43,8 @@ export default (store) => (next) => (action) => {
     }),
   );
 
-  // Get the access token from store.
-  let accessToken = '';
-  if (_.get(store.getState(), 'user.accessToken')) {
-    accessToken = store.getState().user.accessToken;
-  }
-
   // Propagate the response of the request.
-  return makeRequest(payload, accessToken).then(
+  return makeRequest(payload).then(
     (response) =>
       next(
         constructActionWith({

--- a/www/src/js/middlewares/requests-middleware.js
+++ b/www/src/js/middlewares/requests-middleware.js
@@ -12,7 +12,7 @@ function makeRequest(request) {
   });
 }
 
-export const API_REQUEST = Symbol('API_REQUEST');
+export const API_REQUEST: any = Symbol('API_REQUEST');
 export const REQUEST = '_REQUEST';
 export const SUCCESS = '_SUCCESS';
 export const FAILURE = '_FAILURE';

--- a/www/src/js/middlewares/requests-middleware.js
+++ b/www/src/js/middlewares/requests-middleware.js
@@ -1,3 +1,6 @@
+// @flow
+import type { Middleware } from 'redux';
+import type { State } from 'reducers';
 import axios from 'axios';
 
 function makeRequest(request) {
@@ -14,7 +17,7 @@ export const REQUEST = '_REQUEST';
 export const SUCCESS = '_SUCCESS';
 export const FAILURE = '_FAILURE';
 
-export default () => (next) => (action) => {
+const requestMiddleware: Middleware<State, *, *> = () => (next) => (action) => {
   if (!action.meta || !action.meta[API_REQUEST]) {
     // Non-api request action
     return next(action);
@@ -26,7 +29,7 @@ export default () => (next) => (action) => {
 
   // Swap the action content and structured api results
   function constructActionWith(data) {
-    const finalAction = Object.assign({}, action, data);
+    const finalAction = { ...action, ...data };
     delete finalAction[API_REQUEST];
     return finalAction;
   }
@@ -72,3 +75,5 @@ export default () => (next) => (action) => {
       ),
   );
 };
+
+export default requestMiddleware;

--- a/www/src/js/reducers/index.test.js
+++ b/www/src/js/reducers/index.test.js
@@ -1,0 +1,82 @@
+// @flow
+import type { ExportData } from 'types/export';
+import { VERTICAL } from 'types/reducers';
+import reducers from 'reducers';
+import { setExportedData } from 'actions/export';
+import modules from '__mocks__/modules/index';
+
+/* eslint-disable no-useless-computed-key */
+
+const exportData: ExportData = {
+  semester: 1,
+  timetable: {
+    CS3216: {
+      Lecture: '1',
+    },
+    CS1010S: {
+      Lecture: '1',
+      Tutorial: '3',
+      Recitation: '2',
+    },
+    PC1222: {
+      Lecture: '1',
+      Tutorial: '3',
+    },
+  },
+  colors: {
+    CS3216: 1,
+    CS1010S: 0,
+    PC1222: 2,
+  },
+  hidden: ['PC1222'],
+  theme: {
+    id: 'google',
+    timetableOrientation: VERTICAL,
+  },
+  settings: {
+    mode: 'DARK',
+  },
+};
+
+jest.mock('storage/persistReducer', () => (key, reducer) => reducer);
+
+test('reducers should set export data state', () => {
+  const state = reducers(({}: any), setExportedData(modules, exportData));
+
+  expect(state.timetables).toEqual({
+    lessons: {
+      [1]: {
+        CS3216: {
+          Lecture: '1',
+        },
+        CS1010S: {
+          Lecture: '1',
+          Tutorial: '3',
+          Recitation: '2',
+        },
+        PC1222: {
+          Lecture: '1',
+          Tutorial: '3',
+        },
+      },
+    },
+    colors: {
+      [1]: {
+        CS3216: 1,
+        CS1010S: 0,
+        PC1222: 2,
+      },
+    },
+    hidden: { [1]: ['PC1222'] },
+    academicYear: expect.any(String),
+  });
+
+  expect(state.settings).toMatchObject({
+    mode: 'DARK',
+  });
+
+  expect(state.theme).toEqual({
+    id: 'google',
+    timetableOrientation: VERTICAL,
+  });
+});

--- a/www/src/js/reducers/settings.test.js
+++ b/www/src/js/reducers/settings.test.js
@@ -1,5 +1,4 @@
 // @flow
-import _ from 'lodash';
 import type { FSA } from 'types/redux';
 import type { SettingsState } from 'types/reducers';
 
@@ -84,8 +83,13 @@ describe('corsNotification settings', () => {
 
   test('not clear disabled when semester changes', () => {
     config.getSemesterKey = () => '2017/2018 Semester 2';
-    const settingsState = _.cloneDeep(settingsWithDismissedNotifications);
-    settingsState.corsNotification.enabled = false;
+    const settingsState: SettingsState = {
+      ...initialState,
+      corsNotification: {
+        ...initialState.corsNotification,
+        enabled: false,
+      },
+    };
 
     const nextState: SettingsState = reducer(settingsState, rehydrateAction());
     expect(nextState.corsNotification).toHaveProperty('enabled', false);

--- a/www/src/js/reducers/timetables.js
+++ b/www/src/js/reducers/timetables.js
@@ -104,7 +104,7 @@ function semColors(state: ColorMapping = defaultSemColorMap, action: FSA): Color
 
 // Map of semester to list of hidden modules
 const defaultHiddenState = [];
-function hidden(state = defaultHiddenState, action: FSA) {
+function semHiddenModules(state = defaultHiddenState, action: FSA) {
   if (!action.payload) {
     return state;
   }
@@ -162,18 +162,19 @@ function timetables(state: TimetablesState = defaultTimetableState, action: FSA)
           [semester]: { $set: semColors(state.colors[semester], action) },
         },
         hidden: {
-          [semester]: { $set: hidden(state.hidden[semester], action) },
+          [semester]: { $set: semHiddenModules(state.hidden[semester], action) },
         },
       });
     }
 
     case SET_EXPORTED_DATA: {
-      const { semester, timetable, colors } = action.payload;
+      const { semester, timetable, colors, hidden } = action.payload;
 
       return {
         ...state,
         lessons: { [semester]: timetable },
         colors: { [semester]: colors },
+        hidden: { [semester]: hidden },
       };
     }
     default:

--- a/www/src/js/types/export.js
+++ b/www/src/js/types/export.js
@@ -8,9 +8,9 @@ export type ExportData = {
   semester: Semester,
   timetable: SemTimetableConfig,
   colors: ColorMapping,
+  hidden: ModuleCode[],
   theme: ThemeState,
   settings: {
-    hiddenInTimetable: ModuleCode[],
     mode: Mode,
   },
 };

--- a/www/src/js/types/reducers.js
+++ b/www/src/js/types/reducers.js
@@ -11,47 +11,46 @@ import type { Mode } from 'types/settings';
 import type { TimetableConfig } from 'types/timetables';
 
 /* app.js */
-
 export type NotificationOptions = {
   // Amount of time in ms for the notification to be shown, not including opening
   // and closing animation
   // Default: a non-zero, non-infinity value - currently 2750ms.
-  timeout?: number,
+  +timeout?: number,
 
   // By default any notification that comes in when there is already a notification
   // shown will be queued behind the current one. If the notification is not too important,
   // or we expect a large number to be generated in a short period of time, we allow the
   // current notification to be overwritten by the new one.
   // Default behavior: false
-  overwritable?: boolean,
+  +overwritable?: boolean,
 
   // If `priority` is true, the new notification pushes aside the queue and the currently displayed
   // notification, and is displayed immediately. Like this: https://youtu.be/Iimj0j4NYME
   // `overwritable` behavior is prioritized over `priority`; an overwritable priority notification
   // will be discarded if a non-overwritable notification is opened.
   // Default behavior: false
-  priority?: boolean,
+  +priority?: boolean,
 
-  action?: {
-    text: string,
-    handler: () => ?boolean, // Return false to disable notification auto-close
+  +action?: {
+    +text: string,
+    +handler: () => ?boolean, // Return false to disable notification auto-close
   },
 
   // This function will be called when the notification is about to be closed,
   // just before animation starts (i.e. just before state transitions to Closing).
   // `discarded`: if false, notification will be displayed again.
   // `actionClicked`: whether the action button was clicked while the notification was displayed
-  willClose?: (discarded: boolean, actionClicked: boolean) => void,
+  +willClose?: (discarded: boolean, actionClicked: boolean) => void,
 };
 
-export type NotificationData = { message: string } & NotificationOptions;
+export type NotificationData = { +message: string } & NotificationOptions;
 
 export type AppState = {
-  activeSemester: Semester,
-  activeLesson: ?Lesson,
-  isOnline: boolean,
-  isFeedbackModalOpen: boolean,
-  notifications: NotificationData[],
+  +activeSemester: Semester,
+  +activeLesson: ?Lesson,
+  +isOnline: boolean,
+  +isFeedbackModalOpen: boolean,
+  +notifications: NotificationData[],
 };
 
 /* requests.js */
@@ -72,23 +71,23 @@ export const VERTICAL: TimetableOrientation = 'VERTICAL';
 export const HORIZONTAL: TimetableOrientation = 'HORIZONTAL';
 
 export type ThemeState = {
-  id: string,
-  timetableOrientation: TimetableOrientation,
+  +id: string,
+  +timetableOrientation: TimetableOrientation,
 };
 
 /* settings */
 export type CorsNotificationSettings = {
-  enabled: boolean,
-  semesterKey: string,
-  dismissed: string[],
+  +enabled: boolean,
+  +semesterKey: string,
+  +dismissed: string[],
 };
 
 export type SettingsState = {
-  newStudent: boolean,
-  faculty: ?Faculty,
-  mode: Mode,
-  hiddenInTimetable: ModuleCode[],
-  corsNotification: CorsNotificationSettings,
+  +newStudent: boolean,
+  +faculty: ?Faculty,
+  +mode: Mode,
+  +hiddenInTimetable: ModuleCode[],
+  +corsNotification: CorsNotificationSettings,
 };
 
 /* timetables.js */
@@ -100,15 +99,15 @@ export type SemesterColorMap = { [Semester]: ColorMapping };
 export type HiddenModulesMap = { [Semester]: ModuleCode[] };
 
 export type TimetablesState = {
-  lessons: TimetableConfig,
-  colors: SemesterColorMap,
-  hidden: HiddenModulesMap,
-  academicYear: string,
+  +lessons: TimetableConfig,
+  +colors: SemesterColorMap,
+  +hidden: HiddenModulesMap,
+  +academicYear: string,
 };
 
 /* moduleBank.js */
 export type ModuleSelectListItem = SearchableModule & {
-  isAdded: boolean,
+  +isAdded: boolean,
 };
 export type ModuleList = ModuleCondensed[];
 export type ModuleSelectList = ModuleSelectListItem[];
@@ -119,10 +118,10 @@ export type ModuleCodeMap = { [ModuleCode]: ModuleCondensed };
 
 /* moduleFinder.js */
 export type ModuleSearch = {
-  term: string,
-  tokens: string[],
+  +term: string,
+  +tokens: string[],
 };
 
 export type ModuleFinderState = {
-  search: ModuleSearch,
+  +search: ModuleSearch,
 };

--- a/www/src/js/types/redux.js
+++ b/www/src/js/types/redux.js
@@ -3,11 +3,11 @@
 import type { State } from 'reducers';
 
 // Flux Standard Action: https://github.com/acdlite/flux-standard-action
-export type FSA = {
+export type FSA = {|
   type: string,
   payload: any,
   meta?: any,
   error?: boolean,
-};
+|};
 
 export type GetState = () => State;

--- a/www/src/js/utils/export.js
+++ b/www/src/js/utils/export.js
@@ -7,14 +7,15 @@ import { getSemesterTimetable } from 'reducers/timetables';
 
 export function extractStateForExport(semester: Semester, state: State): ExportData {
   const { colors, timetable } = getSemesterTimetable(semester, state.timetables);
+  const hidden = state.timetables.hidden[semester] || [];
 
   return {
     semester,
     timetable,
     colors,
+    hidden,
     theme: state.theme,
     settings: {
-      hiddenInTimetable: state.settings.hiddenInTimetable,
       mode: state.settings.mode,
     },
   };

--- a/www/src/js/views/components/ModuleFinderItem.jsx
+++ b/www/src/js/views/components/ModuleFinderItem.jsx
@@ -5,6 +5,7 @@ import { connect, type MapStateToProps } from 'react-redux';
 
 import type { Module } from 'types/modules';
 import type { ModuleSearch } from 'types/reducers';
+import type { State } from 'reducers';
 
 import { modulePage } from 'views/routes/paths';
 import { highlight } from 'utils/react';
@@ -81,7 +82,7 @@ export class ModuleFinderItemComponent extends PureComponent<Props> {
   }
 }
 
-const mapStateToProps: MapStateToProps<*, *, *> = (state) => ({
+const mapStateToProps: MapStateToProps<State, *, *> = (state: State) => ({
   search: state.moduleFinder.search,
 });
 

--- a/www/src/js/views/components/module-info/AddModuleDropdown.jsx
+++ b/www/src/js/views/components/module-info/AddModuleDropdown.jsx
@@ -8,6 +8,7 @@ import { get } from 'lodash';
 
 import type { Module, ModuleCode, Semester } from 'types/modules';
 import type { TimetableConfig } from 'types/timetables';
+import type { State as StoreState } from 'reducers';
 
 import { addModule, removeModule } from 'actions/timetables';
 import { getFirstAvailableSemester, getSemestersOffered } from 'utils/modules';
@@ -157,7 +158,7 @@ export class AddModuleDropdownComponent extends PureComponent<Props, State> {
 }
 
 const AddModuleDropdownConnected = connect(
-  (state) => ({
+  (state: StoreState) => ({
     timetables: state.timetables.lessons,
   }),
   { addModule, removeModule },

--- a/www/src/js/views/layout/Footer.test.jsx
+++ b/www/src/js/views/layout/Footer.test.jsx
@@ -1,9 +1,11 @@
+// @flow
+
 import React from 'react';
 import { shallow } from 'enzyme';
 
 import { FooterComponent } from 'views/layout/Footer';
 
 test('is a footer element', () => {
-  const actual = shallow(<FooterComponent />);
+  const actual = shallow(<FooterComponent toggleFeedback={jest.fn} lastUpdatedDate={null} />);
   expect(actual.type()).toBe('footer');
 });

--- a/www/src/js/views/layout/Footer.test.jsx
+++ b/www/src/js/views/layout/Footer.test.jsx
@@ -6,6 +6,6 @@ import { shallow } from 'enzyme';
 import { FooterComponent } from 'views/layout/Footer';
 
 test('is a footer element', () => {
-  const actual = shallow(<FooterComponent toggleFeedback={jest.fn} lastUpdatedDate={null} />);
+  const actual = shallow(<FooterComponent toggleFeedback={jest.fn()} lastUpdatedDate={null} />);
   expect(actual.type()).toBe('footer');
 });

--- a/www/src/js/views/layout/Navtabs.test.jsx
+++ b/www/src/js/views/layout/Navtabs.test.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 import { shallow } from 'enzyme';
 

--- a/www/src/js/views/modules/ModuleFinderContainer.jsx
+++ b/www/src/js/views/modules/ModuleFinderContainer.jsx
@@ -13,6 +13,7 @@ import { clone, each, mapValues, values } from 'lodash';
 
 import type { Module } from 'types/modules';
 import type { PageRange, PageRangeDiff, FilterGroupId } from 'types/views';
+import type { State as StoreState } from 'reducers';
 
 import { Semesters } from 'types/modules';
 import ModuleFinderList from 'views/modules/ModuleFinderList';
@@ -350,7 +351,7 @@ export class ModuleFinderContainerComponent extends Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state: StoreState) => ({
   searchTerm: state.moduleFinder.search.term,
 });
 

--- a/www/src/js/views/timetable/ExportMenu.jsx
+++ b/www/src/js/views/timetable/ExportMenu.jsx
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 
 import type { State } from 'reducers';
 import type { Semester } from 'types/modules';
+
 import exportApi from 'apis/export';
 import { downloadAsIcal, SUPPORTS_DOWNLOAD } from 'actions/export';
 import { Image, Calendar, FileText, Download, ChevronDown } from 'views/components/icons';
@@ -99,4 +100,4 @@ export class ExportMenuComponent extends PureComponent<Props> {
   }
 }
 
-export default connect((state) => ({ state }), { downloadAsIcal })(ExportMenuComponent);
+export default connect((state: State) => ({ state }), { downloadAsIcal })(ExportMenuComponent);


### PR DESCRIPTION
A lot of very minor changes that were holdover from the previous PR 

- Fix the Raven middleware `stateTransformer` option 
- Fix hidden modules in timetable export 
- Tightened Redux related typedefs, including making the state read-only, typing thunk's `getState` parameter, and the state parameter in `mapStateToProps` 
- Remove auth tokens from request middleware, since it is not used by, well, anything 
- Add Flow typing to a bunch of places 
- Update README 