### PR TITLE
Stop deleting old dist files

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -6,7 +6,7 @@
     "start": "cross-env NODE_ENV=development node scripts/start",
     "start:export": "cross-env NODE_ENV=development CONFIG=timetable-only PORT=8081 node scripts/start",
     "build": "cross-env NODE_ENV=production node scripts/build",
-    "rsync": "rsync -avu --delete-after dist/",
+    "rsync": "rsync -avu dist/",
     "rsync:export": "rsync -avu --delete-after dist-timetable/",
     "promote-staging": "bash scripts/promote-staging.sh",
     "postinstall": "flow-scripts stub",


### PR DESCRIPTION
Related to #658 

This should hopefully prevent some of the `SyntaxError`s observed due to old dist files being missing. 