### PR TITLE
Remove all transition and animations from exported timetable 

### DIFF
--- a/www/src/js/timetable-export/main.scss
+++ b/www/src/js/timetable-export/main.scss
@@ -1,3 +1,10 @@
+// Disables all animations and transitions, since we don't want the screenshot
+// to be taken while there's transition happening
+* {
+  transition: none !important;
+  animation: none !important;
+}
+
 html,
 body,
 #app,
@@ -7,9 +14,9 @@ body,
 
 body {
   padding-top: 0.2rem !important;
-  transition: none !important;
 }
 
+// Hide all non-exportable UI elements
 :global(.no-export) {
   display: none !important;
 }


### PR DESCRIPTION
Sometimes exported timetable images have weird colors 

![my timetable-3](https://user-images.githubusercontent.com/445650/34862561-0b73c93a-f7a6-11e7-8324-800ef5b1210e.png)

I suspect this is due to the screenshot being taken while CSS transitions are happening. It's a little hard to repro reliably, but hopefully this will fix it. 