### PR TITLE
Fix moduleBank rehydration

### DIFF
--- a/www/src/js/reducers/moduleBank.js
+++ b/www/src/js/reducers/moduleBank.js
@@ -5,7 +5,7 @@ import type { SemTimetableConfig } from 'types/timetables';
 import type { ModuleList, ModuleSelectListItem, ModuleCodeMap } from 'types/reducers';
 
 import { REHYDRATE } from 'redux-persist';
-import { keyBy, zipObject } from 'lodash';
+import { size, keyBy, zipObject } from 'lodash';
 
 import { FETCH_MODULE_LIST, FETCH_MODULE } from 'actions/moduleBank';
 import { SET_EXPORTED_DATA } from 'actions/export';
@@ -61,7 +61,7 @@ function moduleBank(state: ModuleBank = defaultModuleBankState, action: FSA): Mo
       };
 
     case REHYDRATE:
-      if (!state.moduleCodes && state.moduleList) {
+      if (!size(state.moduleCodes) && state.moduleList) {
         return {
           ...state,
           ...precomputeFromModuleList(state.moduleList),


### PR DESCRIPTION
A bug in the REHYDRATE reducer for moduleBank is causing the module codes to fail to be loaded, causing strange 404 errors on module info pages 