### PR TITLE
Shim localStorage

### DIFF
--- a/www/src/js/storage/index.js
+++ b/www/src/js/storage/index.js
@@ -21,10 +21,12 @@ function getLocalStorage() {
     // Resolves https://sentry.io/share/issue/d65da46a7e19406aaee298fb89a635d6/
     if (!storage) throw new Error();
 
-    // Ensure that localStorage can be written to
-    // Next line throws on iOS 10 private browsing
-    storage.setItem('____writetest', 1);
-    storage.removeItem('____writetest');
+    // Ensure that if setItem throws, it's not because of private browsing
+    // If storage is empty AND setItem throws, we're probably in iOS <=10 private browsing
+    if (storage.length === 0) {
+      storage.setItem('____writetest', 1);
+      storage.removeItem('____writetest');
+    }
 
     // Only set storage AFTER we know it can be used
     usableLocalStorage = storage;

--- a/www/src/js/storage/index.js
+++ b/www/src/js/storage/index.js
@@ -14,13 +14,15 @@ function getLocalStorage() {
 
   try {
     // Ensure that accessing localStorage doesn't throw
+    // Next line throws on Chrome with cookies disabled
     const storage = window.localStorage;
 
-    // Ensure that localStorage isn't null to fix
-    // https://sentry.io/share/issue/d65da46a7e19406aaee298fb89a635d6/
+    // Ensure that localStorage isn't null
+    // Resolves https://sentry.io/share/issue/d65da46a7e19406aaee298fb89a635d6/
     if (!storage) throw new Error();
 
     // Ensure that localStorage can be written to
+    // Next line throws on iOS 10 private browsing
     storage.setItem('____writetest', 1);
     storage.removeItem('____writetest');
 

--- a/www/src/js/storage/index.js
+++ b/www/src/js/storage/index.js
@@ -15,13 +15,13 @@ function getLocalStorage() {
       usableLocalStorage = {
         privData: {},
         clear: () => {
-          window.localStorage.m_data = {};
+          usableLocalStorage.privData = {};
         },
         setItem: (id, val) => {
-          window.localStorage.privData[id] = val;
+          usableLocalStorage.privData[id] = val;
         },
-        getItem: (id) => window.localStorage.privData[id],
-        removeItem: (id) => delete window.localStorage.privData[id],
+        getItem: (id) => usableLocalStorage.privData[id],
+        removeItem: (id) => delete usableLocalStorage.privData[id],
       };
     }
     return usableLocalStorage;

--- a/www/src/js/storage/index.js
+++ b/www/src/js/storage/index.js
@@ -39,11 +39,11 @@ function getLocalStorage() {
         clear: () => {
           usableLocalStorage.privData = {};
         },
-        setItem: (id, val) => {
-          usableLocalStorage.privData[id] = val;
+        setItem: (key, val) => {
+          usableLocalStorage.privData[String(key)] = JSON.stringify(val);
         },
-        getItem: (id) => usableLocalStorage.privData[id],
-        removeItem: (id) => delete usableLocalStorage.privData[id],
+        getItem: (key) => JSON.parse(usableLocalStorage.privData[String(key)]),
+        removeItem: (key) => delete usableLocalStorage.privData[String(key)],
       };
     }
   }


### PR DESCRIPTION
Fixes #480 and hopefully all the localStorage issues once and for all. Adapted from [the best localStorage polyfill in the world](https://gist.github.com/juliocesar/926500).

Tested on iOS 10 private browsing and Chrome on macOS with cookies disabled.

As this PR only resolves the cases where localStorage doesn't exist, the try/catch blocks in the exported functions are left there to catch all other cases - such as if the localStorage is actually full.