### PR TITLE
Add fallback for when window.performance is not supported 

### DIFF
--- a/www/src/js/views/modules/ModuleFinderContainer.jsx
+++ b/www/src/js/views/modules/ModuleFinderContainer.jsx
@@ -132,9 +132,12 @@ export class ModuleFinderContainerComponent extends Component<Props, State> {
 
         // Benchmark the amount of time taken to run the filters to determine if we can
         // use instant search
-        const start = performance.now();
+        const start = performance && performance.now();
         each(filterGroups, (group) => group.initFilters(modules));
-        const time = performance.now() - start;
+        const time = performance
+          ? performance.now() - start
+          : // If the user's browser doesn't support performance.now, we don't use instant search
+            Number.MAX_VALUE;
 
         if ('instant' in params) {
           // Manual override - use 'instant=1' to force instant search, and


### PR DESCRIPTION
Resolves https://sentry.io/nusmods/v3/issues/432850464/ (Safari 9.1) 