### PR TITLE
Fix "e.split is not a function" bug

### DIFF
--- a/www/src/js/utils/timetables.js
+++ b/www/src/js/utils/timetables.js
@@ -253,8 +253,9 @@ function serializeModuleConfig(config: ModuleLessonConfig): string {
   ).join(LESSON_SEP);
 }
 
-function parseModuleConfig(serialized: string): ModuleLessonConfig {
+function parseModuleConfig(serialized: ?string): ModuleLessonConfig {
   const config = {};
+  if (!serialized) return config;
 
   serialized.split(LESSON_SEP).forEach((lesson) => {
     const [lessonTypeAbbr, classNo] = lesson.split(LESSON_TYPE_SEP);


### PR DESCRIPTION
Sentry report: https://sentry.io/nusmods/v3/issues/432989397/

Basically, the libdef for query-string is really loose - `qs.parse` produces an object with maybe strings, but the libdef just types it as `Object`. I wonder if I should go fix it. 

```
> qs.parse('abcd=')
{ abcd: '' }
> qs.parse('abcd')
{ abcd: null }
``` 
