### PR TITLE
Fix iPhone 5 and iOS 10 /timetable UI issues

### DIFF
--- a/www/src/js/views/timetable/ExportMenu.jsx
+++ b/www/src/js/views/timetable/ExportMenu.jsx
@@ -46,10 +46,7 @@ export class ExportMenuComponent extends PureComponent<Props> {
           type="button"
           onClick={toggleMenu}
         >
-          <Download className="svg svg-small" /> Download<span className={styles.longLabel}>
-            {' '}
-            As
-          </span>
+          <Download className="svg svg-small" />Download
           <ChevronDown className={classnames(styles.chevron, 'svg-small')} />
         </button>
 

--- a/www/src/js/views/timetable/ExportMenu.scss
+++ b/www/src/js/views/timetable/ExportMenu.scss
@@ -35,13 +35,3 @@
     }
   }
 }
-
-.longLabel {
-  white-space: pre;
-
-  @include media-breakpoint-only(md) {
-    @include vertical-mode {
-      display: none;
-    }
-  }
-}

--- a/www/src/js/views/timetable/ShareTimetable.jsx
+++ b/www/src/js/views/timetable/ShareTimetable.jsx
@@ -149,7 +149,6 @@ export default class ShareTimetable extends PureComponent<Props, State> {
         <div className="row">
           <div className="col-sm-4">
             <h3 className={styles.shareHeading}>QR Code</h3>
-
             <div className={styles.qrCode}>{QRCode && <QRCode value={url} />}</div>
           </div>
           <div className="col-sm-4">

--- a/www/src/js/views/timetable/ShareTimetable.scss
+++ b/www/src/js/views/timetable/ShareTimetable.scss
@@ -6,7 +6,7 @@
   svg {
     width: 5rem;
     height: 5rem;
-    color: theme-color("success");
+    color: theme-color(success);
   }
 
   h3 {
@@ -39,7 +39,7 @@
   left: 0;
   margin: 0;
   text-align: center;
-  color: theme-color("success");
+  color: theme-color(success);
 
   :global {
     animation: fadeIn 0.2s forwards;

--- a/www/src/js/views/timetable/ShareTimetable.scss
+++ b/www/src/js/views/timetable/ShareTimetable.scss
@@ -6,7 +6,7 @@
   svg {
     width: 5rem;
     height: 5rem;
-    color: theme-color('success');
+    color: theme-color("success");
   }
 
   h3 {
@@ -39,7 +39,7 @@
   left: 0;
   margin: 0;
   text-align: center;
-  color: theme-color('success');
+  color: theme-color("success");
 
   :global {
     animation: fadeIn 0.2s forwards;
@@ -61,6 +61,9 @@
 
   svg {
     display: block;
+
+    // Setting max-width again for iOS 10
+    max-width: 12rem;
     margin: 0;
   }
 }

--- a/www/src/js/views/timetable/TimetableActions.scss
+++ b/www/src/js/views/timetable/TimetableActions.scss
@@ -1,4 +1,4 @@
-@import './_variables.scss';
+@import "./_variables.scss";
 
 .sidebarIcon {
   composes: svg svg-small from global;
@@ -53,7 +53,7 @@
 
 .rightButtonGroup {
   justify-content: space-between;
-  min-width: 19rem;
+  min-width: 16rem;
 
   > * {
     width: calc(50% - 0.25rem);

--- a/www/src/js/views/timetable/TimetableActions.scss
+++ b/www/src/js/views/timetable/TimetableActions.scss
@@ -75,7 +75,7 @@
 
 .leftButtonGroup {
   justify-content: space-between;
-  min-width: 19rem;
+  min-width: 17rem;
 
   > * {
     width: calc(50% - 0.25rem);

--- a/www/src/styles/components/buttons.scss
+++ b/www/src/styles/components/buttons.scss
@@ -2,7 +2,6 @@
   $size: 1.1rem;
 
   width: $size;
-  height: $size;
 }
 
 .btn-svg {


### PR DESCRIPTION
Fixes 2 issues on iOS. Before/after screenshots attached below

1. QR code display on iPhone 5-sized devices on iOS 10
![qr](https://user-images.githubusercontent.com/12784593/34902526-3ab734f4-f858-11e7-9003-e320069979f8.png)
2. Oversized timetable action buttons on iPhone 5-sized devices, and icon display on iOS 10. These screenshots are outdated since #709 added the title button, but this PR has been tested with that button present.
![buttons](https://user-images.githubusercontent.com/12784593/34902529-54a9176a-f858-11e7-8b87-da7bda372244.png)

Do note that the "Download As" text has been changed to "Download" on all display sizes, since the down arrow beside the word should be enough to indicate that a menu will be displayed when clicked.