### PR TITLE
Fix JSON parse error and add tests

### DIFF
--- a/www/src/js/storage/localStorage.js
+++ b/www/src/js/storage/localStorage.js
@@ -1,0 +1,56 @@
+let usableLocalStorage;
+
+// Adapted from https://gist.github.com/juliocesar/926500
+// Exported for unit tests
+export function createLocalStorageShim() {
+  const storage = {
+    privData: {},
+    clear() {
+      storage.privData = {};
+    },
+    setItem(key, val) {
+      storage.privData[String(key)] = JSON.stringify(val);
+    },
+    getItem(key) {
+      const storedValue = storage.privData[String(key)];
+      return storedValue && JSON.parse(storedValue);
+    },
+    removeItem: (key) => delete storage.privData[String(key)],
+  };
+  return storage;
+}
+
+// Shim localStorage if it doesn't exist
+// Returns an object that behaves like localStorage
+export default function getLocalStorage() {
+  // If we've performed all our checks before, just assume results will be the same
+  // Key assumption: writability of localStorage doesn't change while page is loaded
+  if (usableLocalStorage) return usableLocalStorage;
+
+  try {
+    // Ensure that accessing localStorage doesn't throw
+    // Next line throws on Chrome with cookies disabled
+    const storage = window.localStorage;
+
+    // Ensure that localStorage isn't null
+    // Resolves https://sentry.io/share/issue/d65da46a7e19406aaee298fb89a635d6/
+    if (!storage) throw new Error();
+
+    // Ensure that if setItem throws, it's not because of private browsing
+    // If storage is empty AND setItem throws, we're probably in iOS <=10 private browsing
+    if (storage.length === 0) {
+      storage.setItem('____writetest', 1);
+      storage.removeItem('____writetest');
+    }
+
+    // Only set storage AFTER we know it can be used
+    usableLocalStorage = storage;
+  } catch (e) {
+    // Shim if we can't use localStorage
+    // Once set, don't override
+    if (!usableLocalStorage) {
+      usableLocalStorage = createLocalStorageShim();
+    }
+  }
+  return usableLocalStorage;
+}

--- a/www/src/js/storage/localStorage.test.js
+++ b/www/src/js/storage/localStorage.test.js
@@ -8,6 +8,22 @@ describe('#createLocalStorageShim', () => {
     expect(shim.getItem('key')).toEqual(toStore);
   });
 
+  test('should remove keys and clear', () => {
+    const shim = createLocalStorageShim();
+    shim.setItem('key1', 1);
+    shim.setItem('key2', 1);
+    shim.setItem('key3', 3.14159);
+    expect(Object.keys(shim.privData)).toHaveLength(3);
+
+    // Expect removeItem to remove item
+    shim.removeItem('key1');
+    expect(shim.privData.key1).toBeUndefined();
+
+    // Expect clear to clear all keys
+    shim.clear();
+    expect(shim.privData).toEqual({});
+  });
+
   test('should not throw when setting null/undefined', () => {
     const shim = createLocalStorageShim();
     expect(() => shim.setItem('key', null)).not.toThrow();
@@ -16,6 +32,8 @@ describe('#createLocalStorageShim', () => {
 
   test('should return undefined when getting nonexistent data', () => {
     const shim = createLocalStorageShim();
+    expect(shim.getItem('key')).toBeUndefined();
+    shim.setItem('key', undefined);
     expect(shim.getItem('key')).toBeUndefined();
   });
 

--- a/www/src/js/storage/localStorage.test.js
+++ b/www/src/js/storage/localStorage.test.js
@@ -1,0 +1,26 @@
+import { createLocalStorageShim } from './localStorage';
+
+describe('#createLocalStorageShim', () => {
+  test('should store and return data', () => {
+    const shim = createLocalStorageShim();
+    const toStore = { key: 'value', key2: 2 };
+    shim.setItem('key', toStore);
+    expect(shim.getItem('key')).toEqual(toStore);
+  });
+
+  test('should not throw when setting null/undefined', () => {
+    const shim = createLocalStorageShim();
+    expect(() => shim.setItem('key', null)).not.toThrow();
+    expect(() => shim.setItem('key', undefined)).not.toThrow();
+  });
+
+  test('should return undefined when getting nonexistent data', () => {
+    const shim = createLocalStorageShim();
+    expect(shim.getItem('key')).toBeUndefined();
+  });
+
+  test('should not throw when removing nonexistent key', () => {
+    const shim = createLocalStorageShim();
+    expect(() => shim.removeItem('key')).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #711, caused by mistakes made in #701.

- Checks if stored value is undefined before parsing.
- Add tests for shim

Manually confirmed that error no longer occurs on iOS 10 in private browsing.