### PR TITLE
Rethrow error in requests middleware

### DIFF
--- a/www/src/js/middlewares/requests-middleware.js
+++ b/www/src/js/middlewares/requests-middleware.js
@@ -61,7 +61,7 @@ const requestMiddleware: Middleware<State, *, *> = () => (next) => (action) => {
           },
         }),
       ),
-    (error) =>
+    (error) => {
       next(
         constructActionWith({
           type: type + FAILURE,
@@ -72,7 +72,10 @@ const requestMiddleware: Middleware<State, *, *> = () => (next) => (action) => {
             request: payload,
           },
         }),
-      ),
+      );
+
+      throw error;
+    },
   );
 };
 


### PR DESCRIPTION
Fixes #704 -ish. 

The reason the error is happening is because it depends on `fetchModules` rejecting the promise if the request fails for some reason, but that's not the case right now. This should not break anything else I *think*, and it seems like a more logical design. (We probably will be discarding request middleware in favor of GraphQL soon-ish). 