### PR TITLE
Fix OpenSearch plugin 

### DIFF
--- a/www/static/opensearch.xml
+++ b/www/static/opensearch.xml
@@ -1,7 +1,9 @@
-<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>NUSMods Modules</ShortName>
   <Description>Search for modules on NUSMods</Description>
-  <Url type="text/html" method="get" template="https://nusmods.com/modules?q={searchTerms}"/>
+  <Url type="text/html" method="GET" template="https://nusmods.com/modules?q={searchTerms}"/>
+  <Query role="example" searchTerms="Programming Methodology" />
   <Image height="16" width="16" type="image/png">https://nusmods.com/favicon-16x16.png</Image>
   <Contact>mods@nusmods.com</Contact>
   <moz:SearchForm>https://nusmods.com/modules/</moz:SearchForm>

--- a/www/static/opensearch.xml
+++ b/www/static/opensearch.xml
@@ -1,7 +1,8 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-  <ShortName>NUSMods Module Search</ShortName>
+  <ShortName>NUSMods Modules</ShortName>
   <Description>Search for modules on NUSMods</Description>
-  <Url type="text/html" method="get" template="https://nusmods.com/modules/{searchTerms}"/>
-  <Image height="16" width="16" type="image/x-icon">https://nusmods.com/favicon.ico</Image>
+  <Url type="text/html" method="get" template="https://nusmods.com/modules?q={searchTerms}"/>
+  <Image height="16" width="16" type="image/png">https://nusmods.com/favicon-16x16.png</Image>
   <Contact>mods@nusmods.com</Contact>
+  <moz:SearchForm>https://nusmods.com/modules/</moz:SearchForm>
 </OpenSearchDescription>

--- a/www/static/opensearch.xml
+++ b/www/static/opensearch.xml
@@ -2,7 +2,7 @@
                        xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>NUSMods Modules</ShortName>
   <Description>Search for modules on NUSMods</Description>
-  <Url type="text/html" method="GET" template="https://nusmods.com/modules?q={searchTerms}"/>
+  <Url type="text/html" template="https://nusmods.com/modules?q={searchTerms}"/>
   <Query role="example" searchTerms="Programming Methodology" />
   <Image height="16" width="16" type="image/png">https://nusmods.com/favicon-16x16.png</Image>
   <Contact>mods@nusmods.com</Contact>


### PR DESCRIPTION
Not sure how we missed this, but the OpenSearch plugin was borked for a bit 

- The favicon is broken 
- The `ShortName` is too long (MDN says 16 characters max - works on Chrome, but seems to be broken on Firefox) 

Also switch to the new module search so this is a proper search engine now, yay 