### PR TITLE
Account for half hour lessons blocks in iCal export

### DIFF
--- a/www/src/js/utils/ical.js
+++ b/www/src/js/utils/ical.js
@@ -27,10 +27,10 @@ function dayIndex(weekday: string) {
 }
 
 /**
- * Parse out the hour component from a time string in the format of hh:mm
+ * Parse out the hour component from a time string in the format of hhmm
  */
-function getTimeHour(time: string) {
-  return parseInt(time.slice(0, 2), 10);
+export function getTimeHour(time: string) {
+  return parseInt(time.slice(0, 2), 10) + parseInt(time.slice(2), 10) / 60;
 }
 
 // needed cos the utils method formats the date for display
@@ -50,9 +50,9 @@ export function daysAfter(startDate: Date, days: number): Date {
 /**
  * Return a copy of the original Date incremented by the given number of hours
  */
-function hoursAfter(date: Date, sgHour: number) {
+export function hoursAfter(date: Date, sgHour: number) {
   const d = new Date(date.valueOf());
-  d.setUTCHours(d.getUTCHours() + sgHour);
+  d.setUTCHours(d.getUTCHours() + Math.floor(sgHour), (sgHour % 1) * 60);
   return d;
 }
 

--- a/www/src/js/utils/ical.test.js
+++ b/www/src/js/utils/ical.test.js
@@ -9,6 +9,8 @@ import iCalForTimetable, {
   iCalEventForExam,
   isTutorial,
   calculateExclusion,
+  getTimeHour,
+  hoursAfter,
 } from 'utils/ical';
 
 import bfs1001 from '__mocks__/modules/BFS1001.json';
@@ -82,6 +84,22 @@ test('daysAfter should create a date days after', () => {
   expect(daysAfter(new Date('2016-11-23T09:00+0800'), 1)).toEqual(
     new Date('2016-11-24T09:00+0800'),
   );
+});
+
+test('getTimeHour should return number of hours represented by a time string', () => {
+  expect(getTimeHour('0000')).toEqual(0);
+  expect(getTimeHour('1000')).toEqual(10);
+  expect(getTimeHour('1200')).toEqual(12);
+  expect(getTimeHour('2000')).toEqual(20);
+  expect(getTimeHour('1030')).toEqual(10.5);
+});
+
+test('hoursAfter should return a date incremented by the given number of hours', () => {
+  const d = new Date('2016-11-23T00:00+0800');
+  expect(hoursAfter(d, 0)).toEqual(new Date('2016-11-23T00:00+0800'));
+  expect(hoursAfter(d, 5)).toEqual(new Date('2016-11-23T05:00+0800'));
+  expect(hoursAfter(d, 20)).toEqual(new Date('2016-11-23T20:00+0800'));
+  expect(hoursAfter(d, 10.5)).toEqual(new Date('2016-11-23T10:30+0800'));
 });
 
 test('iCalEventForExam should generate event', () => {
@@ -206,6 +224,42 @@ test('iCalEventForLesson generates correct output', () => {
   const expected = {
     start: new Date('2016-08-08T14:00+0800'),
     end: new Date('2016-08-08T17:00+0800'),
+    summary: 'BFS1001 Sectional Teaching',
+    description: 'Personal Development & Career Management\nSectional Teaching Group A1',
+    location: 'BIZ1-0303',
+    url:
+      'https://myaces.nus.edu.sg/cors/jsp/report/ModuleDetailedInfo.jsp?' +
+      'acad_y=2016/2017&sem_c=1&mod_c=BFS1001',
+    repeating: {
+      freq: 'WEEKLY',
+      count: 14,
+      byDay: ['Mo'],
+      exclude: expect.arrayContaining([]), // Tested in previous tests
+    },
+  };
+
+  expect(actual).toEqual(expected);
+});
+
+test('work for half hour lesson offsets', () => {
+  const actual: EventOption = iCalEventForLesson(
+    {
+      ClassNo: 'A1',
+      DayText: 'Monday',
+      EndTime: '2030',
+      LessonType: 'Sectional Teaching',
+      StartTime: '1830',
+      Venue: 'BIZ1-0303',
+      WeekText: 'Every Week',
+    },
+    bfs1001,
+    1,
+    new Date('2016-08-08T00:00+0800'),
+  );
+
+  const expected = {
+    start: new Date('2016-08-08T18:30+0800'),
+    end: new Date('2016-08-08T20:30+0800'),
     summary: 'BFS1001 Sectional Teaching',
     description: 'Personal Development & Career Management\nSectional Teaching Group A1',
     location: 'BIZ1-0303',


### PR DESCRIPTION
Fixes #724 

Primarily caused by incorrect assumptions made in lesson time parsing. The code is pretty old and seems to duplicate stuff done in utils/timify.js, so we should take some time to deduplicate this logic. It's not done here because that would have taken more time, and this bug is pretty urgent. 