### PR TITLE
Prevent cells from misaligning when titles are displayed

### DIFF
--- a/www/src/js/views/timetable/TimetableDay.scss
+++ b/www/src/js/views/timetable/TimetableDay.scss
@@ -75,7 +75,7 @@
 .dayRows {
   position: relative;
   display: flex;
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   flex-direction: column;
   min-height: $timetable-row-height;
   padding-bottom: 0.3rem;


### PR DESCRIPTION
Solves issue #738, doesn't solve #519 though