### PR TITLE
Handle pre-Redux Persist migration's data format

### DIFF
--- a/export/data.js
+++ b/export/data.js
@@ -50,6 +50,7 @@ function validateExportData(data) {
   }
 
   // Handles pre-persist-migration data format
+  // TODO: Remove after AY2017/18 Sem 2 when the Redux Persist migration is also removed
   if (!_.isObject(data.hidden)) {
     data.hidden = _.get(data, 'settings.hiddenInTimetable', []);
   }

--- a/export/data.js
+++ b/export/data.js
@@ -49,6 +49,15 @@ function validateExportData(data) {
     throw new Error('Invalid semester');
   }
 
+  // Handles pre-persist-migration data format
+  if (!_.isObject(data.hidden)) {
+    data.hidden = _.get(data, 'settings.hiddenInTimetable', []);
+  }
+
+  if (!_.isObject(data.colors)) {
+    data.colors = _.get(data, 'theme.colors', {});
+  }
+
   // TODO: Improve these validation
   if (!_.isObject(data.timetable)) {
     throw new Error('Invalid timetable');


### PR DESCRIPTION
Related to #743 - this ensures the export server doesn't crash if it receives the old data format. It seems many users have somehow not migrated over yet. 