### PR TITLE
Fix export server Raven error reporting

### DIFF
--- a/export/data.js
+++ b/export/data.js
@@ -31,7 +31,7 @@ function parseExportData(ctx, next) {
       validateExportData(data);
       ctx.state.data = data;
     } catch (e) {
-      ctx.throw(422, e, { original: e });
+      ctx.throw({ status: 422, original: e });
     }
   }
 

--- a/export/data.js
+++ b/export/data.js
@@ -31,7 +31,7 @@ function parseExportData(ctx, next) {
       validateExportData(data);
       ctx.state.data = data;
     } catch (e) {
-      ctx.throw({ status: 422, original: e });
+      ctx.throw(422, null, { original: e });
     }
   }
 


### PR DESCRIPTION
Turns out the second parameter to `ctx.throw` is not the original error object, and if you tried to feed it that weird things would happen. 

Verified manually by pulling into staging and recreating the offending query on staging. 