### PR TITLE
Add exam date function to NUSModerator 

### DIFF
--- a/packages/nusmoderator/package.json
+++ b/packages/nusmoderator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nusmoderator",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A lightweight library with helpful functions for NUS-related matters",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/nusmoderator/src/academicCalendar.js
+++ b/packages/nusmoderator/src/academicCalendar.js
@@ -173,6 +173,38 @@ export function getAcadWeekInfo(date) {
   };
 }
 
+/**
+ * Get the first day of the exam week for the given semester
+ * @param {string} year
+ * @param {number} semester
+ * @returns {Date}
+ */
+export function getExamWeek(year, semester) {
+  const startDate = acadYearStartDates[year];
+
+  if (!startDate) {
+    console.warn(`[nusmoderator] Unsupported year: ${year}`);
+    return null;
+  }
+
+  const examWeek = {
+    1: 16,
+    2: 38,
+    3: 45,
+    4: 51,
+  };
+
+  const weeks = examWeek[semester];
+  if (!weeks) {
+    console.warn(`[nusmoderator] Unknown semester: ${semester}`);
+    return null;
+  }
+
+  const d = new Date(startDate.valueOf());
+  d.setDate(startDate.getDate() + (weeks * 7));
+  return d;
+}
+
 export default {
   acadYearStartDates,
   getAcadYear,

--- a/packages/nusmoderator/src/academicCalendar.js
+++ b/packages/nusmoderator/src/academicCalendar.js
@@ -211,4 +211,5 @@ export default {
   getAcadSem,
   getAcadWeekName,
   getAcadWeekInfo,
+  getExamWeek,
 };

--- a/packages/nusmoderator/src/academicCalendar.test.js
+++ b/packages/nusmoderator/src/academicCalendar.test.js
@@ -4,6 +4,7 @@ import {
   getAcadSem,
   getAcadWeekName,
   getAcadWeekInfo,
+  getExamWeek,
 } from '../src/academicCalendar';
 
 /* eslint-disable no-console */
@@ -163,5 +164,23 @@ describe('getAcadWeekInfo', () => {
     expect(getAcadWeekInfo(new Date('August 7, 2017'))).toEqual({
       year: '17/18', sem: 'Semester 1', type: 'Orientation', num: null,
     });
+  });
+});
+
+describe('getExamWeek', () => {
+  it('returns the first day of exams', () => {
+    expect(getExamWeek('17/18', 1)).toEqual(new Date('November 27, 2017'));
+    expect(getExamWeek('17/18', 2)).toEqual(new Date('30 April, 2018'));
+    expect(getExamWeek('17/18', 3)).toEqual(new Date('18 June, 2018'));
+    expect(getExamWeek('16/17', 4)).toEqual(new Date('24 July, 2017'));
+  });
+
+  it('returns null for unsupported years', () => {
+    expect(getExamWeek('09/10', 1)).toBeNull();
+  });
+
+  it('returns null for unknown semesters', () => {
+    expect(getExamWeek('16/17', 0)).toBeNull();
+    expect(getExamWeek('16/17', 5)).toBeNull();
   });
 });


### PR DESCRIPTION
This helps with the upcoming exam timetable view. The function returns the first day of the exam week for a given year and semester. 