### PR TITLE
Update README for export and nusmoderator

### DIFF
--- a/export/README.md
+++ b/export/README.md
@@ -22,7 +22,7 @@ yarn start
 yarn start:export
 
 # Start export server - use "yarn devtools" if need to see the graphical browser with  
-# developer tools. Note that PDF export in devtools mode. 
+# developer tools. Note that PDF export does not work in devtools mode. 
 cd ../export 
 yarn dev
 ```
@@ -70,5 +70,37 @@ Download PNG image of the timetable.
 ### GET `/debug`
 
 Returns the HTML content of the page that Puppeteer renders.
+
+## Deployment
+
+In production the app runs behind forever in addition to nodemon, so the app will automatically restart when its files are changed or if the app crashes.
+
+Export depends on build artifacts from `www`. The deploy script for `www` will automatically push updated versions of the artifacts to the correct folder, but staging needs to be updated manually. Use `yarn rsync:export ../exports/dist-timetable` from the `www` folder in staging to do this.
+
+Here are the steps for deploying. We rsync everything over, including the `node_modules`, so it is not necesary to run `yarn` in the production folder.
+
+``` bash
+# Update the files from the repo
+$ git pull 
+
+# Install dependencies
+$ yarn 
+
+# Deploy the files to production - optionally add --dry-run to check which files are changed first
+$ yarn deploy
+
+# Starting the app, if the app is not already running 
+# Use port 3300 for production and 3301 for staging 
+$ cd ../../nusmods-export
+$ PORT=3300 NODE_ENV=production yarn start 
+
+# Check that the app is running - also monitor Sentry for errors
+$ forever list
+$ forever logs <index>
+
+# Stopping the app - it may be necessary to manually kill the node and chrome processes 
+# if they did not manage to shutdown properly
+$ forever stop <index>
+```
 
 [puppeteer]: https://github.com/GoogleChrome/puppeteer

--- a/packages/nusmoderator/README.md
+++ b/packages/nusmoderator/README.md
@@ -16,10 +16,11 @@ yarn add nusmoderator
 
 #### Table of Contents
 
-* [getAcadYear](#getacadyear)
-* [getAcadSem](#getacadsem)
-* [getAcadWeekName](#getacadweekname)
-* [getAcadWeekInfo](#getacadweekinfo)
+-   [getAcadYear](#getacadyear)
+-   [getAcadSem](#getacadsem)
+-   [getAcadWeekName](#getacadweekname)
+-   [getAcadWeekInfo](#getacadweekinfo)
+-   [getExamWeek](#getexamweek)
 
 ### getAcadYear
 
@@ -30,7 +31,7 @@ If the date is too early (not within supported range), null is returned.
 
 **Parameters**
 
-* `date` **[Date](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date)**
+-   `date` **[Date](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date)** 
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** acadYearObject - { year: "15/16", startDate: Date }
 
@@ -41,12 +42,12 @@ Expects a week number of a year.
 
 **Parameters**
 
-* `acadWeekNumber` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)**
+-   `acadWeekNumber` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 **Examples**
 
 ```javascript
-acadWeekNumber(3);
+acadWeekNumber(3)
 ```
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** semester - "Semester 1"
@@ -58,12 +59,12 @@ Expects a week number of a semester.
 
 **Parameters**
 
-* `acadWeekNumber` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)**
+-   `acadWeekNumber` **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 **Examples**
 
 ```javascript
-acadWeekNumber(3);
+acadWeekNumber(3)
 ```
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** semester - "Recess" | "Reading" | "Examination"
@@ -74,7 +75,7 @@ Computes the current academic week and return in an object of acad date componen
 
 **Parameters**
 
-* `date` **[Date](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date)**
+-   `date` **[Date](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date)** 
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** {
 year: "15/16",
@@ -82,3 +83,14 @@ sem: 'Semester 1'|'Semester 2'|'Special Sem 1'|'Special Sem 2',
 type: 'Instructional'|'Reading'|'Examination'|'Recess'|'Vacation'|'Orientation',
 num: <weekNum>
 }
+
+### getExamWeek
+
+Get the first day of the exam week for the given semester
+
+**Parameters**
+
+-   `year` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `semester` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **[Date](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date)** 


### PR DESCRIPTION
- Adds deployment and production instructions for export 
- Fix typo left by last update 
- Update nusmoderator docs

(Not sure why `documentation` is adding a bunch of unnecessary whitespace and removing the semi-colons here? @li-kai) 