### PR TITLE
Add redirection for v2 routes to R

### DIFF
--- a/www/src/js/views/routes/Routes.jsx
+++ b/www/src/js/views/routes/Routes.jsx
@@ -29,6 +29,24 @@ export default function Routes() {
       <Route path="/team" component={TeamContainer} />
       <Route path="/contributors" component={ContributorsContainer} />
       <Route path="/apps" component={AppsContainer} />
+
+      {/* v2 routes */}
+      <Redirect from="/venueavailability" to="/venues" />
+      <Redirect from="/contribute/developers" to="/contributors" />
+      <Route
+        path="/news/nusdiscount"
+        render={() => {
+          window.location = 'https://www.facebook.com/nusdiscount/';
+        }}
+      />
+      <Route
+        path="/news/bareNUS"
+        render={() => {
+          window.location = 'https://www.facebook.com/bareNUS';
+        }}
+      />
+
+      {/* 404 page */}
       <Route component={NotFoundPage} />
     </Switch>
   );


### PR DESCRIPTION
We have some 404 errors from users trying to access these v2 routes (possibly because they've bookmarked it? Or do we have existing sites linking to these pages?). This fixes that by redirecting them to the same pages in NUSMods R. 