### PR TITLE
Silence replaceState spam error on Safari

### DIFF
--- a/www/src/js/utils/HistoryDebouncer.js
+++ b/www/src/js/utils/HistoryDebouncer.js
@@ -31,7 +31,17 @@ export default class HistoryDebouncer {
     if (Date.now() - this.lastPush > this.wait) {
       this.history.push(path, state);
     } else {
-      this.history.replace(path, state);
+      try {
+        this.history.replace(path, state);
+      } catch (e) {
+        if (
+          e.message ===
+          'Attempt to use history.replaceState() more than 100 times per 30.000000 seconds'
+        ) {
+          return;
+        }
+        throw e;
+      }
     }
 
     this.lastPush = Date.now();


### PR DESCRIPTION
Fixes #763.

Add a try/catch block around call to `this.history.replace` in `HistoryDebounce`. We only catch the exact error that Safari is throwing so that we don't inadvertently catch actual errors. Other errors will still be thrown.

Also confirmed that Safari still throws errors with that English message even if the phone's language is different.