### PR TITLE
Update ical-generator to our fork to fix macOS calendar bug 

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -105,7 +105,7 @@
     "classnames": "^2.2.5",
     "core-js": "^2.5.1",
     "downshift": "^1.22.3",
-    "ical-generator": "^0.2.10",
+    "ical-generator": "https://github.com/ZhangYiJiang/ical-generator.git#ed6928fe",
     "immutability-helper": "^2.3.1",
     "json2mq": "^0.2.0",
     "localforage": "^1.5.5",

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -4054,9 +4054,9 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-ical-generator@^0.2.10:
+"ical-generator@https://github.com/ZhangYiJiang/ical-generator.git#ed6928fe":
   version "0.2.10"
-  resolved "https://registry.yarnpkg.com/ical-generator/-/ical-generator-0.2.10.tgz#f3d91201411c63b26985b7c59bd5ed91801084ef"
+  resolved "https://github.com/ZhangYiJiang/ical-generator.git#ed6928fecce6789db4d99f856413074de7eb5a1e"
 
 icalendar@^0.7.1:
   version "0.7.1"


### PR DESCRIPTION
Fixes #772 

This uses a new EXDATE field for each excluded date, which should hopefully make it work for macOS. Unfortunately none of *us* can repro the bug. The other possibility is that the file they've imported may be corrupted somehow (and the file they sent us is a new copy, which is somehow uncorrupted), but in that case it seems unlikely all of the events still would show up. 

For reference, the patch to ical-generator: https://github.com/ZhangYiJiang/ical-generator/commit/ed6928fecce6789db4d99f856413074de7eb5a1e