### PR TITLE
Fix Invariant Violation in Routes

### DIFF
--- a/www/src/js/views/routes/Routes.jsx
+++ b/www/src/js/views/routes/Routes.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, { type Node } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 
 import TimetableContainer from 'views/timetable/TimetableContainer';
@@ -35,14 +35,16 @@ export default function Routes() {
       <Redirect from="/contribute/developers" to="/contributors" />
       <Route
         path="/news/nusdiscount"
-        render={() => {
+        render={(): Node => {
           window.location = 'https://www.facebook.com/nusdiscount/';
+          return null;
         }}
       />
       <Route
         path="/news/bareNUS"
-        render={() => {
+        render={(): Node => {
           window.location = 'https://www.facebook.com/bareNUS';
+          return null;
         }}
       />
 


### PR DESCRIPTION
Stupid mistake. It doesn't really affect functionality since the redirection still works, although the "oops" page will appear briefly before the user is redirected since the error bubbled up to AppShell. 

Side note: Why did Flow not catch this? https://github.com/nusmodifications/nusmods/blob/375634dac1c480ce28d843e1cbd0cf5a41b3fb0b/www/flow-typed/npm/react-router-dom_v4.x.x.js#L132 indicates that it should right? 