### PR TITLE
Fix timetable deserialization crash

### DIFF
--- a/www/src/js/utils/timetables.js
+++ b/www/src/js/utils/timetables.js
@@ -309,12 +309,14 @@ function parseModuleConfig(serialized: ?string): ModuleLessonConfig {
   const config = {};
   if (!serialized) return config;
 
-  serialized.split(LESSON_SEP).forEach((lesson) => {
-    const [lessonTypeAbbr, classNo] = lesson.split(LESSON_TYPE_SEP);
-    const lessonType = LESSON_ABBREV_TYPE[lessonTypeAbbr];
-    // Ignore unparsable/invalid keys
-    if (!lessonType) return;
-    config[lessonType] = classNo;
+  _.castArray(serialized).forEach((serializedModule) => {
+    serializedModule.split(LESSON_SEP).forEach((lesson) => {
+      const [lessonTypeAbbr, classNo] = lesson.split(LESSON_TYPE_SEP);
+      const lessonType = LESSON_ABBREV_TYPE[lessonTypeAbbr];
+      // Ignore unparsable/invalid keys
+      if (!lessonType) return;
+      config[lessonType] = classNo;
+    });
   });
 
   return config;

--- a/www/src/js/utils/timetables.test.js
+++ b/www/src/js/utils/timetables.test.js
@@ -408,6 +408,7 @@ test('findExamClashes should return empty object if exams do not clash', () => {
 test('timetable serialization/deserialization', () => {
   const configs: SemTimetableConfig[] = [
     {},
+    { CS1010S: {} },
     {
       GER1000: { Tutorial: 'B01' },
     },
@@ -423,6 +424,25 @@ test('timetable serialization/deserialization', () => {
 
   configs.forEach((config) => {
     expect(deserializeTimetable(serializeTimetable(config))).toEqual(config);
+  });
+});
+
+test('deserializing edge cases', () => {
+  // Duplicate module code
+  expect(deserializeTimetable('CS1010S=LEC:01&CS1010S=REC:11')).toEqual({
+    CS1010S: {
+      Lecture: '01',
+      Recitation: '11',
+    },
+  });
+
+  // No lessons
+  expect(deserializeTimetable('CS1010S&CS3217&CS2105=LEC:1')).toEqual({
+    CS1010S: {},
+    CS3217: {},
+    CS2105: {
+      Lecture: '1',
+    },
   });
 });
 


### PR DESCRIPTION
So erm, you know [that last time](https://github.com/nusmodifications/nusmods/pull/707) I promised I'll read the docs properly? Turns out I didn't *properly* properly read it. I have done so now. I think. 

If this function has another bug due to be not reading the docs properly I promise I'll buy everyone on the team pizza (except @yangshun he's too far away) 