### PR TITLE
Restore repeated iCal downloads

### DIFF
--- a/www/src/js/views/timetable/ExportMenu.jsx
+++ b/www/src/js/views/timetable/ExportMenu.jsx
@@ -28,10 +28,9 @@ type Props = {
 };
 
 export class ExportMenuComponent extends PureComponent<Props> {
-  onChange = (item: ExportAction) => {
-    const { semester } = this.props;
+  onSelect = (item: ExportAction) => {
     if (item === CALENDAR) {
-      this.props.downloadAsIcal(semester);
+      this.props.downloadAsIcal(this.props.semester);
     }
   };
 
@@ -93,7 +92,7 @@ export class ExportMenuComponent extends PureComponent<Props> {
   };
 
   render() {
-    return <Downshift onChange={this.onChange} render={this.renderDropdown} />;
+    return <Downshift onSelect={this.onSelect} render={this.renderDropdown} />;
   }
 }
 


### PR DESCRIPTION
Fixes #785 by changing export menu `onChange` prop to `onSelect`. `onSelect` is a rather new prop added to Downshift in Oct 2017.

The bug was caused as repeated clicks of iCal download does not change the selected index of the dropdown. `onSelect` fixes the bug as it is fired when any item is selected, as opposed to `onChange`, which is only fired when the selected index changes.