### PR TITLE
Update CORS URL to current acad year

### DIFF
--- a/www/src/js/config/app-config.json
+++ b/www/src/js/config/app-config.json
@@ -3,7 +3,7 @@
   "academicYear": "2017/2018",
   "apiBaseUrl": "https://nusmods.com/api",
   "semester": 2,
-  "corsUrl": "https://myaces.nus.edu.sg/cors/jsp/report/ModuleDetailedInfo.jsp?acad_y=2016/2017&sem_c=2&mod_c=",
+  "corsUrl": "https://myaces.nus.edu.sg/cors/jsp/report/ModuleDetailedInfo.jsp?acad_y=2017/2018&sem_c=2&mod_c=",
   "ivleUrl": "http://ivle.nus.edu.sg/lms/public/list_course_public.aspx?code=<ModuleCode>",
   "disqusShortname": "nusmods-prod",
   "googleAnalyticsId": "UA-33503218-6",

--- a/www/src/js/config/app-config.json
+++ b/www/src/js/config/app-config.json
@@ -3,7 +3,7 @@
   "academicYear": "2017/2018",
   "apiBaseUrl": "https://nusmods.com/api",
   "semester": 2,
-  "corsUrl": "https://myaces.nus.edu.sg/cors/jsp/report/ModuleDetailedInfo.jsp?acad_y=2017/2018&sem_c=2&mod_c=",
+  "corsUrl": "https://myaces.nus.edu.sg/cors/jsp/report/ModuleDetailedInfo.jsp?acad_y=<AcademicYear>&sem_c=<Semester>&mod_c=",
   "ivleUrl": "http://ivle.nus.edu.sg/lms/public/list_course_public.aspx?code=<ModuleCode>",
   "disqusShortname": "nusmods-prod",
   "googleAnalyticsId": "UA-33503218-6",

--- a/www/src/js/config/app-config.json
+++ b/www/src/js/config/app-config.json
@@ -3,7 +3,7 @@
   "academicYear": "2017/2018",
   "apiBaseUrl": "https://nusmods.com/api",
   "semester": 2,
-  "corsUrl": "https://myaces.nus.edu.sg/cors/jsp/report/ModuleDetailedInfo.jsp?acad_y=<AcademicYear>&sem_c=<Semester>&mod_c=",
+  "corsUrl": "https://myaces.nus.edu.sg/cors/jsp/report/ModuleDetailedInfo.jsp?acad_y=<AcademicYear>&sem_c=<Semester>&mod_c=<ModuleCode>",
   "ivleUrl": "http://ivle.nus.edu.sg/lms/public/list_course_public.aspx?code=<ModuleCode>",
   "disqusShortname": "nusmods-prod",
   "googleAnalyticsId": "UA-33503218-6",

--- a/www/src/js/config/index.js
+++ b/www/src/js/config/index.js
@@ -73,6 +73,9 @@ function convertCorsDate(roundData: Object): CorsRound {
 
 const augmentedConfig: Config = {
   ...appConfig,
+  corsUrl: appConfig.corsUrl
+    .replace('<AcademicYear>', appConfig.academicYear)
+    .replace('<Semester>', appConfig.semester),
 
   holidays: holidays.map((date) => new Date(date)),
 

--- a/www/src/js/config/index.js
+++ b/www/src/js/config/index.js
@@ -73,9 +73,6 @@ function convertCorsDate(roundData: Object): CorsRound {
 
 const augmentedConfig: Config = {
   ...appConfig,
-  corsUrl: appConfig.corsUrl
-    .replace('<AcademicYear>', appConfig.academicYear)
-    .replace('<Semester>', appConfig.semester),
 
   holidays: holidays.map((date) => new Date(date)),
 

--- a/www/src/js/views/components/module-info/LessonTimetable.jsx
+++ b/www/src/js/views/components/module-info/LessonTimetable.jsx
@@ -69,14 +69,11 @@ export class LessonTimetableComponent extends PureComponent<Props, State> {
 
     return (
       <Fragment>
-        {semesters.length > 1 && (
-          <SemesterPicker
-            semesters={semesters}
-            selectedSemester={this.state.selectedSem}
-            onSelectSemester={this.onSelectSemester}
-          />
-        )}
-
+        <SemesterPicker
+          semesters={semesters}
+          selectedSemester={this.state.selectedSem}
+          onSelectSemester={this.onSelectSemester}
+        />
         <div className={styles.lessonTimetable}>{this.renderTimetable()}</div>
       </Fragment>
     );

--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -65,6 +65,15 @@ export class ModulePageContentComponent extends Component<Props, State> {
     const pageTitle = `${ModuleCode} ${ModuleTitle}`;
     const semesters = getSemestersOffered(module);
 
+    const modSem = semesters.includes(config.semester) ? config.semester : semesters[0]; // Pick a sem if mod isn't available this sem
+    const ivleUrl = config.ivleUrl.replace('<ModuleCode>', ModuleCode);
+    const corsUrl =
+      semesters.length > 0 && // CORS URL only exists if mod is held in >=1 sem
+      config.corsUrl
+        .replace('<ModuleCode>', ModuleCode)
+        .replace('<AcademicYear>', module.AcadYear)
+        .replace('<Semester>', modSem.toString());
+
     return (
       <div className={classnames('page-container', styles.moduleInfoPage)}>
         <Title>{pageTitle}</Title>
@@ -173,10 +182,10 @@ export class ModulePageContentComponent extends Component<Props, State> {
                     <h3 className={styles.descriptionHeading}>Official Links</h3>
                     {intersperse(
                       [
-                        <a key="ivle" href={config.ivleUrl.replace('<ModuleCode>', ModuleCode)}>
+                        <a key="ivle" href={ivleUrl}>
                           IVLE
                         </a>,
-                        <a key="cors" href={config.corsUrl + ModuleCode}>
+                        <a key="cors" href={corsUrl}>
                           CORS
                         </a>,
                       ],

--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -67,12 +67,10 @@ export class ModulePageContentComponent extends Component<Props, State> {
 
     const modSem = semesters.includes(config.semester) ? config.semester : semesters[0]; // Pick a sem if mod isn't available this sem
     const ivleUrl = config.ivleUrl.replace('<ModuleCode>', ModuleCode);
-    const corsUrl =
-      semesters.length > 0 && // CORS URL only exists if mod is held in >=1 sem
-      config.corsUrl
-        .replace('<ModuleCode>', ModuleCode)
-        .replace('<AcademicYear>', module.AcadYear)
-        .replace('<Semester>', modSem.toString());
+    const corsUrl = config.corsUrl
+      .replace('<ModuleCode>', ModuleCode)
+      .replace('<AcademicYear>', module.AcadYear)
+      .replace('<Semester>', modSem ? modSem.toString() : '');
 
     return (
       <div className={classnames('page-container', styles.moduleInfoPage)}>

--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -5,12 +5,12 @@ import { connect, type MapStateToProps } from 'react-redux';
 import ScrollSpy from 'react-scrollspy';
 import { map, mapValues, kebabCase, values } from 'lodash';
 
-import type { Module } from 'types/modules';
+import type { Module, Semester } from 'types/modules';
 
 import config from 'config';
 import { formatExamDate, getSemestersOffered } from 'utils/modules';
 import { intersperse } from 'utils/array';
-import { BULLET, scrollToHash } from 'utils/react';
+import { BULLET, noBreak, scrollToHash } from 'utils/react';
 import { NAVTAB_HEIGHT } from 'views/layout/Navtabs';
 import ModuleTree from 'views/modules/ModuleTree';
 import LinkModuleCodes from 'views/components/LinkModuleCodes';
@@ -58,6 +58,15 @@ export class ModulePageContentComponent extends Component<Props, State> {
 
   toggleMenu = (isMenuOpen: boolean) => this.setState({ isMenuOpen });
 
+  getCorsUrl(semester: Semester): string {
+    const { module } = this.props;
+
+    return config.corsUrl
+      .replace('<ModuleCode>', module.ModuleCode)
+      .replace('<AcademicYear>', module.AcadYear)
+      .replace('<Semester>', String(semester));
+  }
+
   render() {
     const { module } = this.props;
     const { ModuleCode, ModuleTitle } = module;
@@ -65,12 +74,7 @@ export class ModulePageContentComponent extends Component<Props, State> {
     const pageTitle = `${ModuleCode} ${ModuleTitle}`;
     const semesters = getSemestersOffered(module);
 
-    const modSem = semesters.includes(config.semester) ? config.semester : semesters[0]; // Pick a sem if mod isn't available this sem
     const ivleUrl = config.ivleUrl.replace('<ModuleCode>', ModuleCode);
-    const corsUrl = config.corsUrl
-      .replace('<ModuleCode>', ModuleCode)
-      .replace('<AcademicYear>', module.AcadYear)
-      .replace('<Semester>', modSem ? modSem.toString() : '');
 
     return (
       <div className={classnames('page-container', styles.moduleInfoPage)}>
@@ -183,9 +187,11 @@ export class ModulePageContentComponent extends Component<Props, State> {
                         <a key="ivle" href={ivleUrl}>
                           IVLE
                         </a>,
-                        <a key="cors" href={corsUrl}>
-                          CORS
-                        </a>,
+                        ...semesters.map((semester) => (
+                          <a key={`cors-${semester}`} href={this.getCorsUrl(semester)}>
+                            {noBreak(`CORS (${config.shortSemesterNames[semester]})`)}
+                          </a>
+                        )),
                       ],
                       BULLET,
                     )}

--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -5,12 +5,12 @@ import { connect, type MapStateToProps } from 'react-redux';
 import ScrollSpy from 'react-scrollspy';
 import { map, mapValues, kebabCase, values } from 'lodash';
 
-import type { Module, Semester } from 'types/modules';
+import type { Module } from 'types/modules';
 
 import config from 'config';
 import { formatExamDate, getSemestersOffered } from 'utils/modules';
 import { intersperse } from 'utils/array';
-import { BULLET, noBreak, scrollToHash } from 'utils/react';
+import { BULLET, scrollToHash } from 'utils/react';
 import { NAVTAB_HEIGHT } from 'views/layout/Navtabs';
 import ModuleTree from 'views/modules/ModuleTree';
 import LinkModuleCodes from 'views/components/LinkModuleCodes';
@@ -58,23 +58,12 @@ export class ModulePageContentComponent extends Component<Props, State> {
 
   toggleMenu = (isMenuOpen: boolean) => this.setState({ isMenuOpen });
 
-  getCorsUrl(semester: Semester): string {
-    const { module } = this.props;
-
-    return config.corsUrl
-      .replace('<ModuleCode>', module.ModuleCode)
-      .replace('<AcademicYear>', module.AcadYear)
-      .replace('<Semester>', String(semester));
-  }
-
   render() {
     const { module } = this.props;
     const { ModuleCode, ModuleTitle } = module;
 
     const pageTitle = `${ModuleCode} ${ModuleTitle}`;
     const semesters = getSemestersOffered(module);
-
-    const ivleUrl = config.ivleUrl.replace('<ModuleCode>', ModuleCode);
 
     return (
       <div className={classnames('page-container', styles.moduleInfoPage)}>
@@ -184,14 +173,12 @@ export class ModulePageContentComponent extends Component<Props, State> {
                     <h3 className={styles.descriptionHeading}>Official Links</h3>
                     {intersperse(
                       [
-                        <a key="ivle" href={ivleUrl}>
+                        <a key="ivle" href={config.ivleUrl.replace('<ModuleCode>', ModuleCode)}>
                           IVLE
                         </a>,
-                        ...semesters.map((semester) => (
-                          <a key={`cors-${semester}`} href={this.getCorsUrl(semester)}>
-                            {noBreak(`CORS (${config.shortSemesterNames[semester]})`)}
-                          </a>
-                        )),
+                        <a key="cors" href={config.corsUrl.replace('<ModuleCode>', ModuleCode)}>
+                          CORS
+                        </a>,
                       ],
                       BULLET,
                     )}


### PR DESCRIPTION
The CORS link on the module info page was pointing to the AY2016/2017 page on CORS. I wonder how we didn't catch this earlier.

We'll need to add this to #284.