### PR TITLE
Fix modal glyph display

### DIFF
--- a/www/src/js/views/components/CloseButton.jsx
+++ b/www/src/js/views/components/CloseButton.jsx
@@ -4,12 +4,14 @@ import React from 'react';
 import classnames from 'classnames';
 import { Close } from 'views/components/icons';
 
+import styles from './CloseButton.scss';
+
 type Props = {
   onClick: Function,
   className?: string,
 };
 
-export default function({ onClick, className }: Props) {
+export default function CloseButton({ onClick, className }: Props) {
   return (
     <button
       className={classnames('close', className)}
@@ -19,5 +21,15 @@ export default function({ onClick, className }: Props) {
     >
       <Close />
     </button>
+  );
+}
+
+// Absolute positioned CloseButton
+// For use in modals where we don't want the CloseButton to affect the layout of other elements.
+export function AbsCloseButton(props: Props) {
+  return (
+    <div className={styles.closeContainer}>
+      <CloseButton {...props} className={classnames(props.className, styles.absCloseBtn)} />
+    </div>
   );
 }

--- a/www/src/js/views/components/CloseButton.jsx
+++ b/www/src/js/views/components/CloseButton.jsx
@@ -9,9 +9,10 @@ import styles from './CloseButton.scss';
 type Props = {
   onClick: Function,
   className?: string,
+  absolutePositioned?: boolean, // For use in modals where we don't want the CloseButton to affect the layout of other elements.
 };
 
-export default function CloseButton({ onClick, className }: Props) {
+function RawCloseButton({ onClick, className }: Props) {
   return (
     <button
       className={classnames('close', className)}
@@ -24,12 +25,11 @@ export default function CloseButton({ onClick, className }: Props) {
   );
 }
 
-// Absolute positioned CloseButton
-// For use in modals where we don't want the CloseButton to affect the layout of other elements.
-export function AbsCloseButton(props: Props) {
+export default function CloseButton(props: Props) {
+  if (!props.absolutePositioned) return <RawCloseButton {...props} />;
   return (
     <div className={styles.closeContainer}>
-      <CloseButton {...props} className={classnames(props.className, styles.absCloseBtn)} />
+      <RawCloseButton {...props} className={classnames(props.className, styles.absCloseBtn)} />
     </div>
   );
 }

--- a/www/src/js/views/components/CloseButton.scss
+++ b/www/src/js/views/components/CloseButton.scss
@@ -1,0 +1,8 @@
+.closeContainer {
+  position: relative;
+
+  .absCloseBtn {
+    position: absolute;
+    right: 0;
+  }
+}

--- a/www/src/js/views/components/FeedbackModal.jsx
+++ b/www/src/js/views/components/FeedbackModal.jsx
@@ -8,7 +8,7 @@ import type { State } from 'reducers';
 import config from 'config';
 import { toggleFeedback } from 'actions/app';
 import { Heart, GitHub, Facebook, Mail } from './icons';
-import CloseButton from './CloseButton';
+import { AbsCloseButton } from './CloseButton';
 import Modal from './Modal';
 import styles from './FeedbackModal.scss';
 
@@ -25,7 +25,7 @@ export class FeedbackModalComponent extends PureComponent<Props> {
         onRequestClose={this.props.toggleFeedback}
         className={styles.modal}
       >
-        <CloseButton onClick={this.props.toggleFeedback} />
+        <AbsCloseButton onClick={this.props.toggleFeedback} />
         <div className={styles.content}>
           <Heart className={styles.topIcon} />
           <h1>Let us know what you think!</h1>

--- a/www/src/js/views/components/FeedbackModal.jsx
+++ b/www/src/js/views/components/FeedbackModal.jsx
@@ -8,7 +8,7 @@ import type { State } from 'reducers';
 import config from 'config';
 import { toggleFeedback } from 'actions/app';
 import { Heart, GitHub, Facebook, Mail } from './icons';
-import { AbsCloseButton } from './CloseButton';
+import CloseButton from './CloseButton';
 import Modal from './Modal';
 import styles from './FeedbackModal.scss';
 
@@ -25,7 +25,7 @@ export class FeedbackModalComponent extends PureComponent<Props> {
         onRequestClose={this.props.toggleFeedback}
         className={styles.modal}
       >
-        <AbsCloseButton onClick={this.props.toggleFeedback} />
+        <CloseButton absolutePositioned onClick={this.props.toggleFeedback} />
         <div className={styles.content}>
           <Heart className={styles.topIcon} />
           <h1>Let us know what you think!</h1>

--- a/www/src/js/views/timetable/ShareTimetable.jsx
+++ b/www/src/js/views/timetable/ShareTimetable.jsx
@@ -12,7 +12,7 @@ import config from 'config';
 import { absolutePath, timetableShare } from 'views/routes/paths';
 import { Repeat, Copy, Mail } from 'views/components/icons';
 import Modal from 'views/components/Modal';
-import CloseButton from 'views/components/CloseButton';
+import { AbsCloseButton } from 'views/components/CloseButton';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 
 import styles from './ShareTimetable.scss';
@@ -204,7 +204,7 @@ export default class ShareTimetable extends PureComponent<Props, State> {
         </button>
 
         <Modal isOpen={isOpen} onRequestClose={this.closeModal}>
-          <CloseButton onClick={this.closeModal} />
+          <AbsCloseButton onClick={this.closeModal} />
           <div className={styles.header}>
             <Repeat />
 

--- a/www/src/js/views/timetable/ShareTimetable.jsx
+++ b/www/src/js/views/timetable/ShareTimetable.jsx
@@ -12,7 +12,7 @@ import config from 'config';
 import { absolutePath, timetableShare } from 'views/routes/paths';
 import { Repeat, Copy, Mail } from 'views/components/icons';
 import Modal from 'views/components/Modal';
-import { AbsCloseButton } from 'views/components/CloseButton';
+import CloseButton from 'views/components/CloseButton';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 
 import styles from './ShareTimetable.scss';
@@ -204,7 +204,7 @@ export default class ShareTimetable extends PureComponent<Props, State> {
         </button>
 
         <Modal isOpen={isOpen} onRequestClose={this.closeModal}>
-          <AbsCloseButton onClick={this.closeModal} />
+          <CloseButton absolutePositioned onClick={this.closeModal} />
           <div className={styles.header}>
             <Repeat />
 


### PR DESCRIPTION
The nice big glyphs in these two modals were not centered because of the close button.

This PR defines `AbsCloseButton`, a new absolute positioned `CloseButton` wrapped in a relative positioned `div`. It can be used as a drop-in replacement for `CloseButton` when needed. As `CloseButton` is untouched, it will not affect the other components which use it.

Tested in Chrome 56, Safari 10.1, Edge 15, Firefox 50 (although other CSS elements are broken on that version).

Before:
![nusmods com_timetable_sem-2](https://user-images.githubusercontent.com/12784593/35789620-52f0d462-0a78-11e8-9fb4-f1cb743732a4.png)
![nusmods com_timetable_sem-2 1](https://user-images.githubusercontent.com/12784593/35789623-54847298-0a78-11e8-9207-407c059512a4.png)

After:
![localhost_8080_ 1](https://user-images.githubusercontent.com/12784593/35789637-6d4a8b1e-0a78-11e8-9e6e-ebc8dceeaced.png)
![localhost_8080_](https://user-images.githubusercontent.com/12784593/35789638-6e850ea0-0a78-11e8-892a-427ccdd0f1ad.png)