### PR TITLE
RFC: Add babel-plugin-expose-privates

### DIFF
--- a/www/.babelrc
+++ b/www/.babelrc
@@ -34,6 +34,7 @@
     },
     "test": {
       "plugins": [
+        "./scripts/babel-plugin-expose-privates",
         "transform-es2015-modules-commonjs",
         "dynamic-import-node"
       ],

--- a/www/scripts/babel-plugin-expose-privates.js
+++ b/www/scripts/babel-plugin-expose-privates.js
@@ -1,0 +1,114 @@
+module.exports = (babel) => {
+  const { types: t } = babel;
+  const GLOBAL_EXPOSURE_IDENTIFIER = 'babelPluginExposePrivates';
+  const HOIST_PRAGMA = 'babel-plugin-expose-privates';
+  const identifiers = new Set();
+
+  function attachToGlobalObject(path, identifierName) {
+    identifiers.add(identifierName);
+    // Attach to global object to be exposed for exporting later.
+    path.insertAfter(
+      t.expressionStatement(
+        t.assignmentExpression(
+          '=',
+          t.memberExpression(
+            t.identifier(GLOBAL_EXPOSURE_IDENTIFIER),
+            t.identifier(identifierName),
+          ),
+          t.identifier(identifierName),
+        ),
+      ),
+    );
+  }
+
+  return {
+    visitor: {
+      Program: {
+        enter: function(path) {
+          // Inject a global object for us to inject the exports into.
+          path.node.body.unshift(
+            t.variableDeclaration('const', [
+              t.variableDeclarator(
+                t.identifier(GLOBAL_EXPOSURE_IDENTIFIER),
+                t.objectExpression([]),
+              ),
+            ]),
+          );
+        },
+        exit: function(path) {
+          if (identifiers.size === 0) {
+            return;
+          }
+          identifiers.forEach((id) => {
+            const variableInGlobalScope = path.scope.hasOwnBinding(id);
+            // If not in global scope, declare it in global scope.
+            if (!variableInGlobalScope) {
+              path.node.body.push(
+                t.variableDeclaration('const', [
+                  t.variableDeclarator(
+                    t.identifier(id),
+                    t.memberExpression(t.identifier(GLOBAL_EXPOSURE_IDENTIFIER), t.identifier(id)),
+                  ),
+                ]),
+              );
+            }
+          });
+          // Add the export statements.
+          path.node.body.push(
+            t.exportNamedDeclaration(
+              null,
+              Array.from(identifiers).map((id) =>
+                t.exportSpecifier(t.identifier(id), t.identifier(id)),
+              ),
+            ),
+          );
+        },
+      },
+      'FunctionDeclaration|ClassDeclaration'(path) {
+        if (!path.node.leadingComments || path.node.leadingComments.length === 0) {
+          return;
+        }
+        const lastCommentValue =
+          path.node.leadingComments[path.node.leadingComments.length - 1].value;
+        if (lastCommentValue.includes(HOIST_PRAGMA)) {
+          attachToGlobalObject(path, path.node.id.name);
+        }
+      },
+      VariableDeclaration(path) {
+        if (!path.node.leadingComments || path.node.leadingComments.length === 0) {
+          return;
+        }
+        const lastCommentValue =
+          path.node.leadingComments[path.node.leadingComments.length - 1].value;
+        if (
+          !(
+            lastCommentValue.includes(HOIST_PRAGMA) &&
+            path.node.declarations &&
+            path.node.declarations.length > 0
+          )
+        ) {
+          return;
+        }
+        path.node.declarations.forEach((node) => {
+          const id = node.id;
+          switch (id.type) {
+            case 'Identifier':
+              // Handle cases like: const a = 'foo';
+              attachToGlobalObject(path, id.name);
+              break;
+            case 'ObjectPattern':
+              // Handle cases like: const { a, b, c } = obj;
+              id.properties.forEach((property) => {
+                if (property.computed || !property.key) {
+                  return;
+                }
+                attachToGlobalObject(path, property.key.name);
+              });
+            default:
+              break;
+          }
+        });
+      },
+    },
+  };
+};

--- a/www/src/js/views/components/cors-info/CorsNotification.jsx
+++ b/www/src/js/views/components/cors-info/CorsNotification.jsx
@@ -54,7 +54,8 @@ export function corsNotificationText(
   );
 }
 
-export class CorsNotificationComponent extends PureComponent<Props> {
+// babel-plugin-expose-privates
+class CorsNotificationComponent extends PureComponent<Props> {
   currentTime() {
     const debugRound = qs.parse(this.props.location.search).round;
 

--- a/www/src/js/views/components/cors-info/CorsNotification.test.jsx
+++ b/www/src/js/views/components/cors-info/CorsNotification.test.jsx
@@ -5,6 +5,7 @@ import moment from 'moment';
 
 import config, { type CorsRound, type CorsPeriod, type CorsPeriodType } from 'config';
 import createHistory from 'test-utils/createHistory';
+// $FlowFixMe - Unexported import
 import { CorsNotificationComponent } from './CorsNotification';
 
 // Save the original CORS schedule for this test and restore it afterwards

--- a/www/src/js/views/venues/VenuesContainer.jsx
+++ b/www/src/js/views/venues/VenuesContainer.jsx
@@ -53,7 +53,8 @@ type State = {|
 
 const pageHead = <Title>Venues</Title>;
 
-export class VenuesContainerComponent extends Component<Props, State> {
+// babel-plugin-expose-privates
+class VenuesContainerComponent extends Component<Props, State> {
   history: HistoryDebouncer;
 
   constructor(props: Props) {

--- a/www/src/js/views/venues/VenuesContainer.test.jsx
+++ b/www/src/js/views/venues/VenuesContainer.test.jsx
@@ -11,6 +11,7 @@ import mockDom from 'test-utils/mockDom';
 import { sortVenues } from 'utils/venues';
 import { venuePage } from 'views/routes/paths';
 import VenueDetails from 'views/venues/VenueDetails';
+// $FlowFixMe - Unexported import
 import { VenuesContainerComponent } from './VenuesContainer';
 
 function createComponent(selectedVenue: ?Venue, search?: string) {


### PR DESCRIPTION
I was playing around with solving the problem of exposing private functions to be used in tests, and arrived at an approach where I add a pragma to a declaration I want to export and wrote a Babel plugin to add those lines of export during transformation. Basic idea is as follows:

**Original:**

```js
function add(a, b) {
  return a + b;
}

// babel-plugin-expose-privates
function mul(a, b) {
  return a * b;
}
```

**Transformed:**

```js
function add(a, b) {
  return a + b;
}

// babel-plugin-expose-privates
function mul(a, b) {
  return a * b;
}

export { mul }; // Only mul is expoted because of the pragma.
```

I added them to some www components where we were exporting them just for the sake of testing, but hit a roadblock where Flow was complaining about not being able to find the export in the original file (of course!). I silenced those errors as a quick fix. Honestly, not sure what's a proper way to fix it. Flow isn't that configurable to silence that specific error for tests.

I'm not 100% certain this Babel plugin approach is a good idea, but thought I would put it up for review and get your opinions? WDYT? 😄 