### PR TITLE
Fix settings page button and page height style

### DIFF
--- a/www/src/js/views/layout/GlobalSearch.scss
+++ b/www/src/js/views/layout/GlobalSearch.scss
@@ -21,6 +21,7 @@ $icon-dist-lg: $input-width-open-lg - $input-width;
 
 .icon {
   position: absolute;
+  top: 0.3rem; // For Safari 9
   right: $icon-dist + $container-padding;
   width: $icon-size;
   height: $icon-size;

--- a/www/src/js/views/settings/SettingsContainer.scss
+++ b/www/src/js/views/settings/SettingsContainer.scss
@@ -52,6 +52,7 @@
   float: left;
   width: 25%;
   margin-bottom: 0.4rem;
+  background: none;
 
   @include media-breakpoint-down('sm') {
     width: 50%;

--- a/www/src/styles/layout/site.scss
+++ b/www/src/styles/layout/site.scss
@@ -1,16 +1,23 @@
 // This file contains the styles for the overall site
 
-// HACK: Stops this rule from activating on small screens - mainly to stop
-// this from running on iOS Safari 9
-@media (min-height: 50rem) {
+html,
+body,
+#app,
+.app-container {
+  // Ensures the page always fill the height of the page. Combined with the
+  // flexbox on .app-container, this allows the footer to be aligned to the
+  // page bottom when there's insufficient page content
+  height: 100%;
+}
+
+// Disables the above rule on iOS 9 - on Mobile Safari 9 the browser takes 100% to
+// be 100% of the viewport only, which means the page becomes unscrollerable and the
+// footer appears at the bottom of the page with no scrolling
+// See https://solvit.io/bcf61b6 for the hack
+@supports (overflow: -webkit-marquee) and (justify-content: inherit) {
   html,
-  body,
-  #app,
-  .app-container {
-    // Ensures the page always fill the height of the page. Combined with the
-    // flexbox on .app-container, this allows the footer to be aligned to the
-    // page bottom when there's insufficient page content
-    height: 100%;
+  body {
+    height: auto;
   }
 }
 


### PR DESCRIPTION
Fixes three separate style bugs 

- Settings page theme select button background removed 
- Page height set to 100% (except on iOS 9 because of browser bug which causes it to use viewport height instead) 
- Global search icon vertical positioning on Safari 9 