### PR TITLE
Stop collapsing whitespace in HTML

### DIFF
--- a/www/webpack/webpack.config.prod.js
+++ b/www/webpack/webpack.config.prod.js
@@ -76,7 +76,6 @@ const productionConfig = merge([
         minify: {
           removeComments: true,
           removeRedundantAttributes: true,
-          collapseWhitespace: true,
         },
         // For use as a variable under htmlWebpackPlugin.options in the template
         moduleListUrl: nusmods.moduleListUrl(),


### PR DESCRIPTION
The amount of bytes saved is trivial, and making the HTML readable as well as improving stack trace is more important