### PR TITLE
Remove hourly PR limit for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,5 +35,6 @@
       "extends": ["config:js-lib"]
     }
   ],
-  "ignorePaths": ["api/data", "scrapers/nus", ".nvmrc"]
+  "ignorePaths": ["api/data", "scrapers/nus", ".nvmrc"],
+  "prHourlyLimit": 0
 }


### PR DESCRIPTION
As described in [this comment](https://github.com/nusmodifications/nusmods/pull/935#issuecomment-374123274), our current config allows 2 PRs per hour, and only 3 hours per Monday, effectively only allowing 6 PRs per week. Since that PR rate limit is meant to prevent Renovate from swamping CI, we can just remove it since CircleCI has proven that it can handle it and nobody will be awake to approve the PRs at 3am anyway.