### PR TITLE
Fix duplicate React Helmet meta tags

### DIFF
--- a/www/src/index.html
+++ b/www/src/index.html
@@ -10,21 +10,21 @@
     <link href="${htmlWebpackPlugin.files.publicPath}manifest.json" rel="manifest">
     <link href="${htmlWebpackPlugin.options.moduleListUrl}" rel="preload" as="fetch">
     <link href="${htmlWebpackPlugin.options.venuesUrl}" rel="prefetch">
-    <title>NUSMods</title>
-    <meta name="description" content="NUSMods is a timetable builder and knowledge platform, providing students with a better way to plan their school timetable and useful module-related information that are community-driven.">
+    <title>${htmlWebpackPlugin.options.brandName}</title>
+    <meta name="description" content="${htmlWebpackPlugin.options.description}">
     <!-- Open Graph general (Facebook, Pinterest & Google+) -->
-    <meta name="og:title" content="NUSMods">
-    <meta name="og:description" content="NUSMods is a timetable builder and knowledge platform, providing students with a better way to plan their school timetable and useful module-related information that are community-driven.">
+    <meta name="og:title" content="${htmlWebpackPlugin.options.brandName}">
+    <meta name="og:description" content="${htmlWebpackPlugin.options.description}">
     <meta name="og:image" content="${htmlWebpackPlugin.files.publicPath}share.png">
-    <meta name="og:site_name" content="NUSMods">
+    <meta name="og:site_name" content="${htmlWebpackPlugin.options.brandName}">
     <meta name="og:type" content="website">
     <!-- Open Search -->
-    <link href="${htmlWebpackPlugin.files.publicPath}opensearch.xml" rel="search" title="NUSMods Modules" type="application/opensearchdescription+xml">
+    <link href="${htmlWebpackPlugin.files.publicPath}opensearch.xml" rel="search" title="${htmlWebpackPlugin.options.brandName} Modules" type="application/opensearchdescription+xml">
     <meta name="theme-color" content="#ffffff" />
   </head>
   <body>
     <div id="app"></div>
-    <noscript>Please enable JavaScript to use NUSMods</noscript>
+    <noscript>Please enable JavaScript to use ${htmlWebpackPlugin.options.brandName}</noscript>
     <script async src="https://www.google-analytics.com/analytics.js"></script>
   </body>
 </html>

--- a/www/src/index.html
+++ b/www/src/index.html
@@ -11,10 +11,11 @@
     <link href="${htmlWebpackPlugin.options.moduleListUrl}" rel="preload" as="fetch">
     <link href="${htmlWebpackPlugin.options.venuesUrl}" rel="prefetch">
     <title>${htmlWebpackPlugin.options.brandName}</title>
-    <meta name="description" content="${htmlWebpackPlugin.options.description}">
+    <!-- data-react-helmet="true" is set on tags which should be replaced by React Helmet (See <Title> component) -->
+    <meta name="description" content="${htmlWebpackPlugin.options.description}" data-react-helmet="true">
     <!-- Open Graph general (Facebook, Pinterest & Google+) -->
-    <meta name="og:title" content="${htmlWebpackPlugin.options.brandName}">
-    <meta name="og:description" content="${htmlWebpackPlugin.options.description}">
+    <meta name="og:title" content="${htmlWebpackPlugin.options.brandName}" data-react-helmet="true">
+    <meta name="og:description" content="${htmlWebpackPlugin.options.description}" data-react-helmet="true">
     <meta name="og:image" content="${htmlWebpackPlugin.files.publicPath}share.png">
     <meta name="og:site_name" content="${htmlWebpackPlugin.options.brandName}">
     <meta name="og:type" content="website">

--- a/www/src/js/config/app-config.json
+++ b/www/src/js/config/app-config.json
@@ -1,5 +1,6 @@
 {
   "brandName": "NUSMods",
+  "defaultDescription": "NUSMods is a timetable builder and knowledge platform, providing students with a better way to plan their school timetable and useful module-related information that are community-driven.",
   "academicYear": "2017/2018",
   "apiBaseUrl": "https://nusmods.com/api",
   "semester": 2,

--- a/www/webpack/webpack.config.prod.js
+++ b/www/webpack/webpack.config.prod.js
@@ -80,6 +80,8 @@ const productionConfig = merge([
         // For use as a variable under htmlWebpackPlugin.options in the template
         moduleListUrl: nusmods.moduleListUrl(),
         venuesUrl: nusmods.venuesUrl(config.semester),
+        brandName: config.brandName,
+        description: config.defaultDescription,
       }),
       new ScriptExtHtmlWebpackPlugin({
         inline: /manifest/,


### PR DESCRIPTION
In #948 I used React Helmet to add `<meta>` description tags to the pages, but didn't notice that Helmet duplicated the tag when it inserted its own set of tags. According to https://github.com/nfl/react-helmet/issues/341 you can work around this by adding the `data-react-helmet="true"` attribute. This will cause React Helmet to recognize the meta tag and replace it. A bit of a hack, but short of an official solution this seems to work fine. Having two sets of tags isn't a dealbreaker anyway - it's just slightly ugly and we don't really know the SEO effect of it.

On the bright side, this means we can now legitimately claim our app is "server-side rendered" :wink: 