### PR TITLE
Implement dbfy script in data server

### DIFF
--- a/api/data/.babelrc
+++ b/api/data/.babelrc
@@ -4,7 +4,6 @@
       "env",
       {
         "targets": { "node": "current" },
-        "modules": false,
         "loose": true,
         "useBuiltIns": true
       }

--- a/api/data/README.md
+++ b/api/data/README.md
@@ -29,25 +29,31 @@ through the code and schema.
     $ yarn start # start the GraphQL server
     ```
 
-#### Incomplete scraper set up (optional)
+### Database Setup
 
-There is an incomplete (and unused) scraper implementation present in this
-project as well. It is intended to replace the existing scrapers at some point,
-and save all scraped data straight to a SQLite database instead of saving to
-static files.
-
-Currently, it is incomplete and can't do anything useful, but this is how to
-set it up if you want to work on it.
+This project includes a `dbfy` script, which populates the SQLite database with
+module and venue data from the JSON files. It is intended to be used by the
+GraphQL server in the future.
 
 1. Copy `.env.example` to a file named `.env`.
 
 1. Download and install [sqlite3](https://www.sqlite.org/download.html).
 
+1. Set `NODE_ENV`.
+
+1. Ensure that the JSON data files are in the `dataFolder` directory as
+   specified in config.js.
+
 1. Run the following commands in a terminal:
     ```bash
-    $ npx knex migrate:latest # set up db tables
-    $ npx knex seed:run # set up basic information
+    $ yarn db:init # set up db
+    $ yarn dbfy # run dbfy script to populate the db
     ```
+
+Also, there is an incomplete (and unused) scraper implementation present in this
+project. It is intended to replace the existing scrapers at some point, and
+save all scraped data straight to a SQLite database instead of saving to static
+files. Currently, it is incomplete and can't do anything useful.
 
 ## REST API
 

--- a/api/data/config.js
+++ b/api/data/config.js
@@ -3,4 +3,8 @@ import 'dotenv/config';
 export default {
   dataFolder: '../../data/nus',
   modulesFileName: 'modules.json',
+  defaults: {
+    maxCacheAge: process.env.NODE_ENV === 'production' ? 0 : 86400,
+    cachePath: '../../scrapers/nus/cache',
+  },
 };

--- a/api/data/config.js
+++ b/api/data/config.js
@@ -3,6 +3,7 @@ import 'dotenv/config';
 export default {
   dataFolder: '../../data/nus',
   modulesFileName: 'modules.json',
+  venuesFileName: 'venues.json',
   defaults: {
     maxCacheAge: process.env.NODE_ENV === 'production' ? 0 : 86400,
     cachePath: '../../scrapers/nus/cache',

--- a/api/data/migrations/20170101000000_initial.js
+++ b/api/data/migrations/20170101000000_initial.js
@@ -45,7 +45,106 @@ exports.up = (knex, Promise) => {
     table.unique(['school_id', 'name']);
   });
 
-  return Promise.all([schoolsTable, departmentsTable, venuesTable]);
+  const modulesTable = knex.schema.createTable('modules', (table) => {
+    table
+      .increments('id')
+      .notNullable()
+      .primary();
+    table
+      .integer('school_id')
+      .notNullable()
+      .references('id')
+      .inTable('schools')
+      .onDelete('CASCADE')
+      .onUpdate('CASCADE');
+    table.string('acadYear').notNullable();
+    table.integer('semester').notNullable();
+    table.string('code').notNullable();
+    table.string('title').notNullable();
+    table.string('description');
+    table.string('credit').notNullable();
+    table.integer('workload');
+    table.dateTime('examDate');
+    table.string('department');
+    table.string('lecturePeriods');
+    table.string('tutorialPeriods');
+    table.string('types');
+    table.string('prerequisite');
+    table.string('preclusion');
+    table.string('corequisite');
+    table.unique(['school_id', 'code', 'acadYear', 'semester']);
+  });
+
+  const classTable = knex.schema.createTable('classes', (table) => {
+    table
+      .increments('id')
+      .notNullable()
+      .primary();
+    table
+      .integer('module_id')
+      .notNullable()
+      .references('id')
+      .inTable('modules')
+      .onDelete('CASCADE')
+      .onUpdate('CASCADE');
+    table
+      .integer('venue_id')
+      .notNullable()
+      .references('id')
+      .inTable('venues')
+      .onDelete('CASCADE')
+      .onUpdate('CASCADE');
+    table.string('classNo').notNullable();
+    table.string('type').notNullable();
+    table.string('weekFrequency').notNullable();
+    table.string('day').notNullable();
+    table.integer('startTime').notNullable();
+    table.integer('endTime').notNullable();
+    table.unique(['module_id', 'classNo', 'type', 'day', 'startTime', 'endTime']);
+  });
+
+  const corsBiddingStatsTable = knex.schema.createTable('corsBiddingStats', (table) => {
+    table
+      .increments('id')
+      .notNullable()
+      .primary();
+    table
+      .integer('module_id')
+      .notNullable()
+      .references('id')
+      .inTable('modules')
+      .onDelete('CASCADE')
+      .onUpdate('CASCADE');
+    table.string('acadYear').notNullable();
+    table.integer('semester').notNullable();
+    table.string('round').notNullable();
+    table.string('group').notNullable();
+    table.string('faculty').notNullable();
+    table.string('studentAcctType').notNullable();
+    table.integer('quota').notNullable();
+    table.integer('bidders').notNullable();
+    table.integer('lowestBid').notNullable();
+    table.integer('lowestSuccessfulBid').notNullable();
+    table.integer('highestBid').notNullable();
+    table.unique([
+      'module_id',
+      'acadYear',
+      'semester',
+      'round',
+      'group',
+      'faculty',
+      'studentAcctType',
+    ]);
+  });
+
+  return Promise.all([
+    schoolsTable,
+    departmentsTable,
+    venuesTable,
+    modulesTable,
+    classTable,
+    corsBiddingStatsTable,
+  ]);
 };
 
 exports.down = (knex, Promise) => {

--- a/api/data/migrations/20170101000000_initial.js
+++ b/api/data/migrations/20170101000000_initial.js
@@ -146,7 +146,7 @@ exports.up = (knex, Promise) => {
 };
 
 exports.down = (knex, Promise) => {
-  const tables = ['schools', 'departments', 'venues'];
+  const tables = ['schools', 'departments', 'venues', 'modules', 'classes', 'corsBiddingStats'];
   return Promise.all(
     tables.map((table) => knex.schema.dropTableIfExists(table).then(() => table)),
   ).then((tbls) => {

--- a/api/data/migrations/20170101000000_initial.js
+++ b/api/data/migrations/20170101000000_initial.js
@@ -89,7 +89,6 @@ exports.up = (knex, Promise) => {
       .onUpdate('CASCADE');
     table
       .integer('venue_id')
-      .notNullable()
       .references('id')
       .inTable('venues')
       .onDelete('CASCADE')
@@ -100,7 +99,6 @@ exports.up = (knex, Promise) => {
     table.string('day').notNullable();
     table.integer('startTime').notNullable();
     table.integer('endTime').notNullable();
-    table.unique(['module_id', 'classNo', 'type', 'day', 'startTime', 'endTime']);
   });
 
   const corsBiddingStatsTable = knex.schema.createTable('corsBiddingStats', (table) => {

--- a/api/data/migrations/20170101000000_initial.js
+++ b/api/data/migrations/20170101000000_initial.js
@@ -5,10 +5,10 @@ exports.up = (knex, Promise) => {
       .notNullable()
       .primary();
     table
-      .string('name')
+      .string('longName')
       .notNullable()
       .unique();
-    table.string('abbreviation', 32);
+    table.string('shortName', 32);
   });
 
   const departmentsTable = knex.schema.createTable('departments', (table) => {

--- a/api/data/package.json
+++ b/api/data/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "ci": "yarn lint && yarn test",
     "start": "cross-env NODE_ENV=development nodemon src --exec babel-node --watch src | bunyan -o short --color",
+    "dbfy": "babel-node src/dbfy",
     "dbfy:watch": "cross-env NODE_ENV=development nodemon src/dbfy --exec babel-node --watch src | bunyan -o short --color",
     "test": "jest --config jest.config.js --coverage",
     "test:watch": "jest --config jest.config.js --watch",

--- a/api/data/package.json
+++ b/api/data/package.json
@@ -14,7 +14,8 @@
     "test": "jest --config jest.config.js --coverage",
     "test:watch": "jest --config jest.config.js --watch",
     "lint": "eslint . --ignore-path ../../.gitignore",
-    "lint:fix": "eslint . --ignore-path ../../.gitignore --fix"
+    "lint:fix": "eslint . --ignore-path ../../.gitignore --fix",
+    "db:init": "knex migrate:latest && knex seed:run"
   },
   "repository": {
     "type": "git",

--- a/api/data/package.json
+++ b/api/data/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "ci": "yarn lint && yarn test",
     "start": "cross-env NODE_ENV=development nodemon src --exec babel-node --watch src | bunyan -o short --color",
+    "dbfy:watch": "cross-env NODE_ENV=development nodemon src/dbfy --exec babel-node --watch src | bunyan -o short --color",
     "test": "jest --config jest.config.js --coverage",
     "test:watch": "jest --config jest.config.js --watch",
     "lint": "eslint . --ignore-path ../../.gitignore",

--- a/api/data/seeds/schools.js
+++ b/api/data/seeds/schools.js
@@ -5,8 +5,8 @@ exports.seed = (knex) =>
     .then(() =>
       // Inserts seed entries
       knex('schools').insert([
-        { name: 'National Univerity of Singapore', abbreviation: 'NUS' },
-        { name: 'National Technological Univesity', abbreviation: 'NTU' },
-        { name: 'Singapore Management University', abbreviation: 'SMU' },
+        { longName: 'National University of Singapore', shortName: 'NUS' },
+        { longName: 'National Technological University', shortName: 'NTU' },
+        { longName: 'Singapore Management University', shortName: 'SMU' },
       ]),
     );

--- a/api/data/src/dbfy/index.js
+++ b/api/data/src/dbfy/index.js
@@ -20,6 +20,5 @@ import populateModules from './modules';
 
   await populateVenues(db);
   await populateModules(db);
-  // console.log('Done');
   process.exit();
 })();

--- a/api/data/src/dbfy/index.js
+++ b/api/data/src/dbfy/index.js
@@ -4,6 +4,10 @@ import db from '../db';
 import populateVenues from './venues';
 import populateModules from './modules';
 
+/**
+ * IIFE which clears db and populates it with venue and module data from the
+ * JSON files in the data folder.
+ */
 (async function dbfy() {
   // Clear tables
   const tables = ['venues', 'modules', 'classes', 'corsBiddingStats'];

--- a/api/data/src/dbfy/index.js
+++ b/api/data/src/dbfy/index.js
@@ -2,15 +2,20 @@
 
 import db from '../db';
 import populateVenues from './venues';
+import populateModules from './modules';
 
 (async function dbfy() {
   // Clear tables
-  await db
-    .select()
-    .table('venues')
-    .del();
+  const tables = ['venues', 'modules', 'classes', 'corsBiddingStats'];
+  await Promise.map(tables, async (table) =>
+    db
+      .select()
+      .table(table)
+      .del(),
+  );
 
   await populateVenues(db);
+  await populateModules(db);
   // console.log('Done');
   process.exit();
 })();

--- a/api/data/src/dbfy/index.js
+++ b/api/data/src/dbfy/index.js
@@ -1,0 +1,16 @@
+// @flow
+
+import db from '../db';
+import populateVenues from './venues';
+
+(async function dbfy() {
+  // Clear tables
+  await db
+    .select()
+    .table('venues')
+    .del();
+
+  await populateVenues(db);
+  // console.log('Done');
+  process.exit();
+})();

--- a/api/data/src/dbfy/modules.js
+++ b/api/data/src/dbfy/modules.js
@@ -1,0 +1,121 @@
+// @flow
+
+import type { Knex } from 'knex';
+import R from 'ramda';
+import { map, filter } from 'lodash';
+
+import config from '../../config';
+import mapKeysDeep from '../util/mapKeysDeep';
+import { walkJsonDir } from '../util/walkDir';
+import { maxInsertSize } from '../util/db';
+
+const SCHOOL_ID = { school_id: 1 };
+
+const removeModuleKeys = mapKeysDeep((key) => key.replace('Module', ''));
+const camelizeAllKeys = mapKeysDeep((key) => key.replace(/[A-Z]/, R.toLower));
+const processData = R.pipe(removeModuleKeys, camelizeAllKeys, R.values);
+
+async function storeSemData(
+  db: Knex,
+  semData,
+  acadYear: string,
+  sem: string,
+  venues: { [string]: number },
+) {
+  const { modules } = semData;
+  const semester = parseInt(sem, 10);
+  const processed = processData(modules);
+
+  // Store modules
+  const modsToStore = processed.map((mod) => {
+    const toStore = {
+      ...SCHOOL_ID,
+      acadYear,
+      semester,
+      ...mod,
+    };
+    return R.pick(
+      [
+        'acadYear',
+        'semester',
+        'school_id',
+        'code',
+        'title',
+        'description',
+        'credit',
+        'workload',
+        'examDate',
+        'department',
+        'lecturePeriods',
+        'tutorialPeriods',
+        'types',
+        'prerequisite',
+        'preclusion',
+        'corequisite',
+      ],
+      toStore,
+    );
+  });
+  await db.batchInsert('modules', modsToStore, maxInsertSize(16));
+
+  // Map inserted module codes to module IDs
+  const modRows = await db
+    .select('id', 'code')
+    .from('modules')
+    .where({ ...SCHOOL_ID, acadYear, semester });
+  const mods: { [string]: number } = R.map(R.prop('id'), R.indexBy(R.prop('code'), modRows));
+
+  // Store classes
+  const timetables = processed.map((mod) => {
+    if (!mod.timetable) return null;
+    return mod.timetable.map((modClass) => {
+      const { venue, dayText, lessonType, weekText, ...cleanModClass } = modClass;
+      return {
+        ...cleanModClass,
+        day: dayText,
+        type: lessonType,
+        weekFrequency: weekText,
+        venue_id: venues[venue],
+        module_id: mods[mod.code],
+      };
+    });
+  });
+  const classes = R.flatten(filter(timetables));
+  await db.batchInsert('classes', classes, maxInsertSize(8));
+
+  // Store bidding stats
+  const biddingStats = processed.map((mod) => {
+    if (!mod.corsBiddingStats) return null;
+    return mod.corsBiddingStats.map((bidStats) => ({
+      ...bidStats,
+      module_id: mods[mod.code],
+    }));
+  });
+  const stats = R.flatten(filter(biddingStats));
+  await db.batchInsert('corsBiddingStats', stats, maxInsertSize(12));
+}
+
+export default async function populateModules(db: Knex) {
+  const { dataFolder } = config;
+  const rawData = await walkJsonDir(dataFolder, 'index.json', 4);
+
+  const venueRows = await db
+    .select('id', 'name')
+    .from('venues')
+    .where(SCHOOL_ID);
+  const venues: { [string]: number } = R.map(R.prop('id'), R.indexBy(R.prop('name'), venueRows));
+
+  await Promise.all(
+    map(rawData, async (ayData, acadYear) => {
+      // Only read data from valid acadYears
+      if (!/^[0-9]{4}-[0-9]{4}$/.test(acadYear)) return;
+      await Promise.all(
+        map(ayData, async (semData, sem) => {
+          // Only read data from valid sems
+          if (isNaN(sem)) return; // eslint-disable-line no-restricted-globals
+          await storeSemData(db, semData, acadYear, sem, venues);
+        }),
+      );
+    }),
+  );
+}

--- a/api/data/src/dbfy/modules.js
+++ b/api/data/src/dbfy/modules.js
@@ -9,36 +9,29 @@ import mapKeysDeep from '../util/mapKeysDeep';
 import { walkJsonDir } from '../util/walkDir';
 import { maxInsertSize } from '../util/db';
 
+// Type of object which maps a key (e.g. venue name, mod code) to a db id.
+type IdMap = { [string]: number };
+
+// NUS has ID 1
 const SCHOOL_ID = { school_id: 1 };
 
+// Functions which normalize module data obtained from JSON files
 const removeModuleKeys = mapKeysDeep((key) => key.replace('Module', ''));
 const camelizeAllKeys = mapKeysDeep((key) => key.replace(/[A-Z]/, R.toLower));
 const processData = R.pipe(removeModuleKeys, camelizeAllKeys, R.values);
 
-async function storeSemData(
-  db: Knex,
-  semData,
-  acadYear: string,
-  sem: string,
-  venues: { [string]: number },
-) {
-  const { modules } = semData;
-  const semester = parseInt(sem, 10);
-  const processed = processData(modules);
-
-  // Store modules
-  const modsToStore = processed.map((mod) => {
-    const toStore = {
-      ...SCHOOL_ID,
-      acadYear,
-      semester,
-      ...mod,
-    };
-    return R.pick(
+/**
+ * Store modules for acadYear and semester into db.
+ *
+ * @param db database to store into
+ * @param mods array of modules to be stored
+ * @param acadYear the mods' academic year
+ * @param semester the mods' semester
+ */
+async function storeModules(db: Knex, mods: Object[], acadYear: string, semester: number) {
+  const modsToStore = mods.map((mod) => {
+    const cleanMod = R.pick(
       [
-        'acadYear',
-        'semester',
-        'school_id',
         'code',
         'title',
         'description',
@@ -53,20 +46,28 @@ async function storeSemData(
         'preclusion',
         'corequisite',
       ],
-      toStore,
+      mod,
     );
+    return {
+      ...SCHOOL_ID,
+      acadYear,
+      semester,
+      ...cleanMod,
+    };
   });
-  await db.batchInsert('modules', modsToStore, maxInsertSize(16));
+  return db.batchInsert('modules', modsToStore, maxInsertSize(16));
+}
 
-  // Map inserted module codes to module IDs
-  const modRows = await db
-    .select('id', 'code')
-    .from('modules')
-    .where({ ...SCHOOL_ID, acadYear, semester });
-  const mods: { [string]: number } = R.map(R.prop('id'), R.indexBy(R.prop('code'), modRows));
-
-  // Store classes
-  const timetables = processed.map((mod) => {
+/**
+ * Store classes in mods into db.
+ *
+ * @param db database to store into
+ * @param mods array of modules with classes to be stored
+ * @param venueIdMap a map from venue names to their IDs in db
+ * @param modIdMap a map from module codes to their IDs in db
+ */
+async function storeClasses(db: Knex, mods: Object[], venueIdMap: IdMap, modIdMap: IdMap) {
+  const timetables = mods.map((mod) => {
     if (!mod.timetable) return null;
     return mod.timetable.map((modClass) => {
       const { venue, dayText, lessonType, weekText, ...cleanModClass } = modClass;
@@ -75,26 +76,73 @@ async function storeSemData(
         day: dayText,
         type: lessonType,
         weekFrequency: weekText,
-        venue_id: venues[venue],
-        module_id: mods[mod.code],
+        venue_id: venueIdMap[venue],
+        module_id: modIdMap[mod.code],
       };
     });
   });
   const classes = R.flatten(filter(timetables));
-  await db.batchInsert('classes', classes, maxInsertSize(8));
+  return db.batchInsert('classes', classes, maxInsertSize(8));
+}
 
-  // Store bidding stats
-  const biddingStats = processed.map((mod) => {
+/**
+ * Store CORS bidding stats in mods into db.
+ *
+ * @param db database to store into
+ * @param mods array of modules with CORS bidding stats to be stored
+ * @param modIdMap a map from module codes to their IDs in db
+ */
+async function storeBiddingStats(db: Knex, mods: Object[], modIdMap: IdMap) {
+  const biddingStats = mods.map((mod) => {
     if (!mod.corsBiddingStats) return null;
     return mod.corsBiddingStats.map((bidStats) => ({
       ...bidStats,
-      module_id: mods[mod.code],
+      module_id: modIdMap[mod.code],
     }));
   });
   const stats = R.flatten(filter(biddingStats));
   await db.batchInsert('corsBiddingStats', stats, maxInsertSize(12));
 }
 
+/**
+ * Store an acad year + semester's data into db.
+ *
+ * @param db database to store into
+ * @param data data object to be stored
+ * @param acadYear the mods' academic year
+ * @param semester the mods' semester
+ * @param venueIdMap a map from venue names to their IDs in db
+ */
+async function storeSemData(
+  db: Knex,
+  data: Object,
+  acadYear: string,
+  sem: string,
+  venueIdMap: IdMap,
+) {
+  const semester = parseInt(sem, 10);
+  const mods: Object[] = processData(data.modules);
+
+  // Store modules
+  await storeModules(db, mods, acadYear, semester);
+
+  // Map inserted module codes to module IDs
+  const modRows = await db
+    .select('id', 'code')
+    .from('modules')
+    .where({ ...SCHOOL_ID, acadYear, semester });
+  const modIdMap: IdMap = R.map(R.prop('id'), R.indexBy(R.prop('code'), modRows));
+
+  // Store other stuff
+  await storeClasses(db, mods, venueIdMap, modIdMap);
+  await storeBiddingStats(db, mods, modIdMap);
+}
+
+/**
+ * Store module data into db.
+ *
+ * @param db database to store into
+ */
 export default async function populateModules(db: Knex) {
   const { dataFolder } = config;
   const rawData = await walkJsonDir(dataFolder, 'index.json', 4);
@@ -103,7 +151,7 @@ export default async function populateModules(db: Knex) {
     .select('id', 'name')
     .from('venues')
     .where(SCHOOL_ID);
-  const venues: { [string]: number } = R.map(R.prop('id'), R.indexBy(R.prop('name'), venueRows));
+  const venueIdMap: IdMap = R.map(R.prop('id'), R.indexBy(R.prop('name'), venueRows));
 
   await Promise.all(
     map(rawData, async (ayData, acadYear) => {
@@ -113,7 +161,7 @@ export default async function populateModules(db: Knex) {
         map(ayData, async (semData, sem) => {
           // Only read data from valid sems
           if (isNaN(sem)) return; // eslint-disable-line no-restricted-globals
-          await storeSemData(db, semData, acadYear, sem, venues);
+          await storeSemData(db, semData, acadYear, sem, venueIdMap);
         }),
       );
     }),

--- a/api/data/src/dbfy/venues.js
+++ b/api/data/src/dbfy/venues.js
@@ -1,0 +1,24 @@
+// @flow
+
+import type { Knex } from 'knex';
+import R from 'ramda';
+
+import config from '../../config';
+import { walkJsonDir } from '../util/walkDir';
+
+const SCHOOL_ID = { school_id: 1 };
+// Prevent "Too many SQL variable errors thrown by SQLite"
+// Default by SQLite is 999. Since we have 4 variables per row...
+const MAX_INSERT_SIZE = Math.floor(999 / 4);
+
+export default async function populateVenues(db: Knex) {
+  const { dataFolder } = config;
+  const rawData = await walkJsonDir(dataFolder, 'venues.json', 2);
+
+  const mapToRow = (venueName: string) => ({ ...SCHOOL_ID, name: venueName });
+  const getVenues = R.compose(R.map(mapToRow), R.uniq, R.flatten, R.map(R.values), R.values);
+  const venues = getVenues(rawData);
+  // console.log(venues);
+
+  await db.batchInsert('venues', venues, MAX_INSERT_SIZE);
+}

--- a/api/data/src/dbfy/venues.js
+++ b/api/data/src/dbfy/venues.js
@@ -5,20 +5,18 @@ import R from 'ramda';
 
 import config from '../../config';
 import { walkJsonDir } from '../util/walkDir';
+import { maxInsertSize } from '../util/db';
 
 const SCHOOL_ID = { school_id: 1 };
-// Prevent "Too many SQL variable errors thrown by SQLite"
-// Default by SQLite is 999. Since we have 4 variables per row...
-const MAX_INSERT_SIZE = Math.floor(999 / 4);
 
 export default async function populateVenues(db: Knex) {
-  const { dataFolder } = config;
-  const rawData = await walkJsonDir(dataFolder, 'venues.json', 2);
+  const { dataFolder, venuesFileName } = config;
+  const rawData = await walkJsonDir(dataFolder, venuesFileName, 2);
 
   const mapToRow = (venueName: string) => ({ ...SCHOOL_ID, name: venueName });
   const getVenues = R.compose(R.map(mapToRow), R.uniq, R.flatten, R.map(R.values), R.values);
   const venues = getVenues(rawData);
   // console.log(venues);
 
-  await db.batchInsert('venues', venues, MAX_INSERT_SIZE);
+  await db.batchInsert('venues', venues, maxInsertSize(4));
 }

--- a/api/data/src/dbfy/venues.js
+++ b/api/data/src/dbfy/venues.js
@@ -9,6 +9,11 @@ import { maxInsertSize } from '../util/db';
 
 const SCHOOL_ID = { school_id: 1 };
 
+/**
+ * Store venue data into db.
+ *
+ * @param db database to store into
+ */
 export default async function populateVenues(db: Knex) {
   const { dataFolder, venuesFileName } = config;
   const rawData = await walkJsonDir(dataFolder, venuesFileName, 2);

--- a/api/data/src/scrapers/BaseTask.test.js
+++ b/api/data/src/scrapers/BaseTask.test.js
@@ -6,7 +6,7 @@ import BaseTask from './BaseTask';
 jest.mock('fs-extra');
 jest.unmock('bunyan');
 
-describe('BaseTask', () => {
+describe(BaseTask, () => {
   let base;
   beforeAll(() => {
     base = new BaseTask();

--- a/api/data/src/scrapers/HttpService.test.js
+++ b/api/data/src/scrapers/HttpService.test.js
@@ -9,7 +9,7 @@ jest.mock('../../config.js', () => ({
   },
 }));
 
-describe('getCacheFilePath', () => {
+describe(getCacheFilePath, () => {
   const getFilePath = (url, params) => getCacheFilePath({ url, params });
 
   it('should output root to domain with index.html', () => {
@@ -63,7 +63,7 @@ describe('getCacheFilePath', () => {
   });
 });
 
-describe('getFileModifiedTime', () => {
+describe(getFileModifiedTime, () => {
   const mockFileSystemMeta = {
     testFile: {
       isFile: () => true,
@@ -92,7 +92,7 @@ describe('getFileModifiedTime', () => {
   });
 });
 
-describe('HttpService', () => {
+describe(HttpService, () => {
   const HOST = 'http://example.com';
   const EPOCH = new Date(0);
   const cachedData = 'cached test';

--- a/api/data/src/scrapers/VenuesScraper.test.js
+++ b/api/data/src/scrapers/VenuesScraper.test.js
@@ -1,6 +1,6 @@
 import VenuesScraper from './VenuesScraper';
 
-describe('VenuesScraper', () => {
+describe(VenuesScraper, () => {
   const scraper = new VenuesScraper();
   const FIELDS = ['school_id', 'name', 'type', 'owned_by'];
 

--- a/api/data/src/util/db.js
+++ b/api/data/src/util/db.js
@@ -1,0 +1,12 @@
+// @flow
+
+/**
+ * Calculate the ideal batch insert size to prevent "Too many SQL variable
+ * errors thrown by SQLite" error.
+ * @param {number} numVars number of variables in the inserted rows
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function maxInsertSize(numVars: number) {
+  // Default by SQLite is 999. Since we have numVars variables per row...
+  return Math.floor(999 / numVars);
+}

--- a/api/data/src/util/mapKeysDeep.test.js
+++ b/api/data/src/util/mapKeysDeep.test.js
@@ -1,6 +1,6 @@
 import mapKeysDeep from './mapKeysDeep';
 
-describe('mapKeysDeep', () => {
+describe(mapKeysDeep, () => {
   const appendXToKeys = mapKeysDeep((key) => `${key}X`);
 
   const testString = 'testString';

--- a/api/data/src/util/walkDir.js
+++ b/api/data/src/util/walkDir.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
+import { pickBy } from 'lodash';
 
 /**
  * Walks the directory, and returns all nested files of designated file name.
@@ -8,19 +9,26 @@ import fs from 'fs-extra';
  * @param {string} folderPath folder path to traverse
  * @param {string} destFileName file name to match
  */
-async function walkJsonDir(folderPath, destFileName) {
-  const folders = await fs.readdir(folderPath);
+async function walkJsonDir(folderPath, destFileName, depth) {
+  const folders = await fs.readdir(folderPath).catch(() => null);
+  if (!folders) return null;
+
   const folderToJsonMap = {};
   await Promise.all(
     folders.map(async (folder) => {
-      const filePath = path.join(folderPath, folder, destFileName);
-      const fileContent = await fs.readJson(filePath).catch(() => null);
-      if (fileContent) {
-        folderToJsonMap[folder] = fileContent;
+      if (depth > 1) {
+        const fPath = path.join(folderPath, folder);
+        folderToJsonMap[folder] = await walkJsonDir(fPath, destFileName, depth - 1);
+      } else {
+        const filePath = path.join(folderPath, folder, destFileName);
+        const fileContent = await fs.readJson(filePath).catch(() => null);
+        if (fileContent) {
+          folderToJsonMap[folder] = fileContent;
+        }
       }
     }),
   );
-  return folderToJsonMap;
+  return pickBy(folderToJsonMap);
 }
 
 /**

--- a/api/data/src/util/walkDir.js
+++ b/api/data/src/util/walkDir.js
@@ -1,43 +1,80 @@
+// @flow
+
 import path from 'path';
 import fs from 'fs-extra';
-import { pickBy } from 'lodash';
+import { pickBy, setWith } from 'lodash';
+
+/**
+ * Walks the directory to specified depth, and calls dataCallback with the
+ * contents of all nested files of designated file name.
+ * @example walkJsonDirCallback('test', 'test.json', 1, () => true, () => null)
+ * will find 'test/1/test.json'
+ * @param {string} folderPath folder path to traverse
+ * @param {string} destFileName file name to match
+ * @param {number} depth depth to search until
+ * @param {number} shouldReadFile callback that should return if the file at
+ * path should be read
+ * @param {number} dataCallback callback that is called for every file's
+ * contents
+ */
+export async function walkJsonDirCallback(
+  folderPath: string,
+  destFileName: string,
+  depth: number,
+  shouldReadFile: (path: string) => boolean,
+  dataCallback: (data: Object, filePath: string) => void,
+) {
+  const folders = await fs.readdir(folderPath).catch(() => null);
+  if (!folders) return null;
+
+  return Promise.all(
+    folders.map(async (folder) => {
+      if (depth > 1) {
+        const fPath = path.join(folderPath, folder);
+        await walkJsonDirCallback(fPath, destFileName, depth - 1, shouldReadFile, dataCallback);
+      } else {
+        const filePath = path.join(folderPath, folder, destFileName);
+        if (!shouldReadFile(filePath)) return;
+        const fileContent = await fs.readJson(filePath).catch(() => null);
+        if (fileContent) {
+          dataCallback(fileContent, filePath);
+        }
+      }
+    }),
+  );
+}
 
 /**
  * Walks the directory, and returns all nested files of designated file name.
+ * @example walkJsonDir('test', 'test.json') will find 'test/1/test.json'
+ * @param {string} folderPath folder path to traverse
+ * @param {string} destFileName file name to match
+ * @param {number} depth depth to search until
+ */
+export async function walkJsonDir(folderPath: string, destFileName: string, depth: number) {
+  const folders = await fs.readdir(folderPath).catch(() => null);
+  if (!folders) return null;
+
+  const folderToJsonMap = {};
+  const pathFilter = () => true;
+  const dataCallback = (data, filePath) => {
+    const relativePath = path.dirname(path.relative(folderPath, filePath));
+    const objPath = relativePath.replace(/\//g, '.');
+    setWith(folderToJsonMap, objPath, data, Object);
+  };
+  await walkJsonDirCallback(folderPath, destFileName, depth, pathFilter, dataCallback);
+
+  return pickBy(folderToJsonMap);
+}
+
+/**
+ * Sync version of walkJsonDir.
  * Only traverses one layer.
  * @example walkJsonDir('test', 'test.json') will find 'test/1/test.json'
  * @param {string} folderPath folder path to traverse
  * @param {string} destFileName file name to match
  */
-async function walkJsonDir(folderPath, destFileName, depth) {
-  const folders = await fs.readdir(folderPath).catch(() => null);
-  if (!folders) return null;
-
-  const folderToJsonMap = {};
-  await Promise.all(
-    folders.map(async (folder) => {
-      if (depth > 1) {
-        const fPath = path.join(folderPath, folder);
-        folderToJsonMap[folder] = await walkJsonDir(fPath, destFileName, depth - 1);
-      } else {
-        const filePath = path.join(folderPath, folder, destFileName);
-        const fileContent = await fs.readJson(filePath).catch(() => null);
-        if (fileContent) {
-          folderToJsonMap[folder] = fileContent;
-        }
-      }
-    }),
-  );
-  return pickBy(folderToJsonMap);
-}
-
-/**
- * Sync version of walkJsonDir
- * @example walkJsonDir('test', 'test.json') will find 'test/1/test.json'
- * @param {string} folderPath folder path to traverse
- * @param {string} destFileName file name to match
- */
-function walkJsonDirSync(folderPath, destFileName) {
+export function walkJsonDirSync(folderPath: string, destFileName: string) {
   const folders = fs.readdirSync(folderPath);
   const folderToJsonMap = {};
   folders.forEach((folder) => {
@@ -50,5 +87,3 @@ function walkJsonDirSync(folderPath, destFileName) {
   });
   return folderToJsonMap;
 }
-
-export { walkJsonDir, walkJsonDirSync };

--- a/api/data/src/util/walkDir.test.js
+++ b/api/data/src/util/walkDir.test.js
@@ -4,7 +4,7 @@ import { walkJsonDir, walkJsonDirSync } from './walkDir';
 
 jest.mock('fs-extra');
 
-describe('walkJsonDir', () => {
+describe(walkJsonDir, () => {
   it('walks the api directory for relevant files', async () => {
     const mockFileSystem = {
       app: {
@@ -24,11 +24,11 @@ describe('walkJsonDir', () => {
       '2017-2018': ['test1'],
     };
     const apiPath = path.join('app', 'api');
-    expect(await walkJsonDir(apiPath, 'modules.json')).toEqual(expected);
+    expect(await walkJsonDir(apiPath, 'modules.json', 1)).toEqual(expected);
   });
 });
 
-describe('walkJsonDirSync', () => {
+describe(walkJsonDirSync, () => {
   it('walks the api directory for relevant files', async () => {
     const mockFileSystem = {
       app: {

--- a/api/data/src/util/walkDir.test.js
+++ b/api/data/src/util/walkDir.test.js
@@ -1,51 +1,84 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { walkJsonDir, walkJsonDirSync } from './walkDir';
+import { walkJsonDir, walkJsonDirCallback, walkJsonDirSync } from './walkDir';
 
 jest.mock('fs-extra');
 
-describe(walkJsonDir, () => {
-  it('walks the api directory for relevant files', async () => {
-    const mockFileSystem = {
-      app: {
-        api: {
-          '2016-2017': {
-            'modules.json': '["test"]',
-          },
-          '2017-2018': {
-            'modules.json': '["test1"]',
-          },
+const mockFileSystem = {
+  app: {
+    api: {
+      '2016-2017': {
+        '0': {
+          'modules.json': '["test0"]',
+        },
+        '1': {
+          'modules.json': '["test1"]',
         },
       },
-    };
-    fs.setMock(mockFileSystem);
+      '2017-2018': {
+        'modules.json': '["test2"]',
+      },
+    },
+  },
+};
+fs.setMock(mockFileSystem);
+
+describe(walkJsonDir, () => {
+  it('walks the api directory for relevant files', async () => {
     const expected = {
-      '2016-2017': ['test'],
-      '2017-2018': ['test1'],
+      '2016-2017': {
+        '0': ['test0'],
+        '1': ['test1'],
+      },
     };
     const apiPath = path.join('app', 'api');
-    expect(await walkJsonDir(apiPath, 'modules.json', 1)).toEqual(expected);
+    expect(await walkJsonDir(apiPath, 'modules.json', 2)).toEqual(expected);
+  });
+});
+
+describe(walkJsonDirCallback, () => {
+  it('walks to depth', async () => {
+    const apiPath = path.join('app', 'api');
+    const pathFilter = jest.fn().mockReturnValue(true);
+    const dataCallback = jest.fn();
+
+    await walkJsonDirCallback(apiPath, 'modules.json', 2, pathFilter, dataCallback);
+
+    expect(pathFilter).toHaveBeenCalledTimes(3);
+    expect(dataCallback).toHaveBeenCalledTimes(2); // 2017-2018 will have null content
+    expect(dataCallback).toHaveBeenCalledWith(
+      ['test0'],
+      path.join(apiPath, '2016-2017', '0', 'modules.json'),
+    );
+    expect(dataCallback).toHaveBeenCalledWith(
+      ['test1'],
+      path.join(apiPath, '2016-2017', '1', 'modules.json'),
+    );
+  });
+
+  it('skips directories', async () => {
+    const apiPath = path.join('app', 'api');
+    const pathFilter = jest
+      .fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
+    const dataCallback = jest.fn();
+
+    await walkJsonDirCallback(apiPath, 'modules.json', 1, pathFilter, dataCallback);
+
+    expect(pathFilter).toHaveBeenCalledTimes(Object.keys(mockFileSystem.app.api).length);
+    expect(dataCallback).toHaveBeenCalledTimes(1);
+    expect(dataCallback).toHaveBeenCalledWith(
+      ['test2'],
+      path.join(apiPath, '2017-2018', 'modules.json'),
+    );
   });
 });
 
 describe(walkJsonDirSync, () => {
   it('walks the api directory for relevant files', async () => {
-    const mockFileSystem = {
-      app: {
-        api: {
-          '2016-2017': {
-            'modules.json': '["test"]',
-          },
-          '2017-2018': {
-            'modules.json': '["test1"]',
-          },
-        },
-      },
-    };
-    fs.setMock(mockFileSystem);
     const expected = {
-      '2016-2017': ['test'],
-      '2017-2018': ['test1'],
+      '2017-2018': ['test2'],
     };
     const apiPath = path.join('app', 'api');
     expect(walkJsonDirSync(apiPath, 'modules.json')).toEqual(expected);


### PR DESCRIPTION
This PR implements a new `dbfy` script for the data server, which populates the SQLite database with existing JSON data (i.e. dbfying our JSON data).

It is meant to help us move quicker to GraphQL. While replacing the scrapers with new ones that save data directly into a database is a good idea, I think it is taking too long and will possibly introduce more bugs. And that's holding up our adoption of GraphQL.

These temporary scripts will help us transition to a db, allowing work on the GraphQL server and the client to proceed while we decide on what to do with the scrapers. As such, the dbfy code is intended to be simple and standalone, and can be easily nuked in favor of better approaches when the time comes.

## Work done

- Add new tables to database: `modules`, `classes`, and `corsBiddingStats`.
- Implement JS scripts in /api/data/src/dbfy which clears and then populates a database with venues and module data from the existing JSON data files.
- Add depth param to `walkJsonDir` so that we can work with per-sem data for every acad year. This function still loads all the JSON data into RAM at once.
- Implement unused `walkJsonDirCallback` function, which executes a callback for every file. Intended to be a memory-efficient alternative to `walkJsonDir`. Not used because we actually want to group all data for a sem into one big object before storing it, but this function will execute the callback for every *mod's* data.
- Rename fields in `schools` table - `abbreviation` was a little long.
- Fix some typos in uni seed names.
- Replace Jest test names with function names where possible.

## TODO

- [x] Add actual `dbfy` script that doesn't watch code for changes (as `dbfy:watch` does)
- [x] Update READMEs to include docs for `dbfy` as well as `db:init` script.

## Next steps

- Deployment: Hope that loading all the venue and module data into RAM at once won't fill the server's RAM completely :pray:. If it does, we should replace `walkJsonDir` with `walkJsonDirCallback`.
- Replace in-memory data with database in data server
- Add queries for venues to data server