### PR TITLE
Fix outdated browser detection config for Edge

### DIFF
--- a/www/src/js/bootstrapping/browser.js
+++ b/www/src/js/bootstrapping/browser.js
@@ -26,7 +26,7 @@ const browserCanUseLocalStorage = canUseBrowserLocalStorage();
 if (
   !bowser.check(
     {
-      edge: '14',
+      msedge: '14',
       chrome: '56',
       firefox: '52',
       safari: '9',


### PR DESCRIPTION
Microsoft Edge was incorrectly detected as outdated because we used `edge` instead of `msedge` for our browser compat map. https://github.com/lancedikson/bowser#rendering-engine-flags 