### PR TITLE
Fix 6.30pm exam timing

### DIFF
--- a/www/src/js/views/timetable/ExamCalendar.jsx
+++ b/www/src/js/views/timetable/ExamCalendar.jsx
@@ -52,6 +52,7 @@ function getTimeSegment(time: string): TimeSegment {
     case '2:30 PM':
       return 'Afternoon';
     case '5:00 PM':
+    case '6:30 PM':
       return 'Evening';
     default:
       throw new Error(`Unrecognized exam time: ${time}`);


### PR DESCRIPTION
Fixes #1005 

Adds 6.30pm as an exam timing. This does mean that if a student adds two conflicting modules with exam at 5pm and another at 6.30pm the label would be inaccurate, but that's very unlikely. As far as I can tell it exists only for some level 5000 modules, so this is very unlikely to affect actual users. 