### PR TITLE
Add special 404 page for modules

### DIFF
--- a/www/src/js/views/errors/ModuleNotFoundPage.jsx
+++ b/www/src/js/views/errors/ModuleNotFoundPage.jsx
@@ -1,0 +1,45 @@
+// @flow
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Raven from 'raven-js';
+
+import type { ModuleCode } from 'types/modules';
+import Title from 'views/components/Title';
+import styles from './ErrorPage.scss';
+
+type Props = {
+  moduleCode: ModuleCode,
+};
+
+export default function NotFoundPage({ moduleCode }: Props) {
+  Raven.captureMessage('404 - Module Not Found');
+  const eventId = Raven.lastEventId();
+
+  return (
+    <div>
+      <Title>Module Not Found</Title>
+
+      <div className={styles.container}>
+        <h1 className={styles.header}>
+          <span className={styles.expr}>Oops...</span>
+          module {moduleCode} not found.
+        </h1>
+        <p>
+          This usually means you have a typo in the module code, or the module is not offered this
+          year.
+        </p>
+        <p>
+          If you think something <em>should</em> be here,{' '}
+          <button className={styles.link} onClick={() => Raven.showReportDialog({ eventId })}>
+            do tell us
+          </button>!
+        </p>
+
+        <p>
+          Otherwise, <Link to="/">go back to nusmods.com</Link> or{' '}
+          <Link to="/modules">try the module finder</Link>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/www/src/js/views/modules/ModulePageContainer.jsx
+++ b/www/src/js/views/modules/ModulePageContainer.jsx
@@ -12,8 +12,8 @@ import type { Module, ModuleCode } from 'types/modules';
 
 import { fetchModule } from 'actions/moduleBank';
 import { retry } from 'utils/promise';
-import NotFoundPage from 'views/errors/NotFoundPage';
 import ErrorPage from 'views/errors/ErrorPage';
+import ModuleNotFoundPage from 'views/errors/ModuleNotFoundPage';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import { modulePage } from 'views/routes/paths';
 
@@ -94,7 +94,7 @@ export class ModulePageContainerComponent extends PureComponent<Props, State> {
     const { module, moduleCode, match, location } = this.props;
 
     if (!this.doesModuleExist(moduleCode)) {
-      return <NotFoundPage />;
+      return <ModuleNotFoundPage moduleCode={moduleCode} />;
     }
 
     if (error) {

--- a/www/src/js/views/modules/ModulePageContainer.test.jsx
+++ b/www/src/js/views/modules/ModulePageContainer.test.jsx
@@ -11,7 +11,7 @@ import type { Module, ModuleCode } from 'types/modules';
 
 /* @var {Module} */
 import cs1010s from '__mocks__/modules/CS1010S.json';
-import NotFoundPage from 'views/errors/NotFoundPage';
+import ModuleNotFoundPage from 'views/errors/ModuleNotFoundPage';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import { ModulePageContainerComponent } from './ModulePageContainer';
 
@@ -49,7 +49,7 @@ function assertRedirect(component, redirectTo = CANONICAL) {
 }
 
 test('should show 404 page when the module code does not exist', () => {
-  expect(make('CS1234', '/modules/CS1234').type()).toEqual(NotFoundPage);
+  expect(make('CS1234', '/modules/CS1234').type()).toEqual(ModuleNotFoundPage);
 });
 
 test('should redirect to canonical URL', () => {


### PR DESCRIPTION
404 on module pages makes up a large majority of our 404 errors. Adjusting the error message slightly should make it more helpful to students who may have landed on the page via a stale link, or by searching for a module code from an old page. 