### PR TITLE
Highlight lessons with the same class number on hover

### DIFF
--- a/www/src/js/types/timetables.js
+++ b/www/src/js/types/timetables.js
@@ -47,3 +47,10 @@ export type TimetableDayArrangement = ColoredLesson[][];
 export type TimetableArrangement = {
   [DayText]: TimetableDayArrangement,
 };
+
+// Represents the lesson which the user is currently hovering over.
+// Used to highlight lessons which have the same classNo
+export type HoverLesson = {
+  classNo: ClassNo,
+  moduleCode: ModuleCode,
+};

--- a/www/src/js/views/timetable/Timetable.jsx
+++ b/www/src/js/views/timetable/Timetable.jsx
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { values, flattenDeep, noop } from 'lodash';
 
-import type { Lesson } from 'types/modules';
+import type { ClassNo, Lesson } from 'types/modules';
 import type { TimetableArrangement } from 'types/timetables';
 
 import {
@@ -25,7 +25,11 @@ type Props = {
   onModifyCell: Function,
 };
 
-class Timetable extends PureComponent<Props> {
+type State = {
+  hoverClassNo: ?ClassNo,
+};
+
+class Timetable extends PureComponent<Props, State> {
   interval: IntervalID;
 
   static defaultProps = {
@@ -33,6 +37,10 @@ class Timetable extends PureComponent<Props> {
     isScrolledHorizontally: false,
     showTitle: false,
     onModifyCell: noop,
+  };
+
+  state = {
+    hoverClassNo: null,
   };
 
   componentDidMount() {
@@ -44,6 +52,10 @@ class Timetable extends PureComponent<Props> {
   componentWillUnmount() {
     clearInterval(this.interval);
   }
+
+  onCellHover = (hoverClassNo: ?ClassNo) => {
+    this.setState({ hoverClassNo });
+  };
 
   render() {
     const schoolDays = SCHOOLDAYS.filter(
@@ -82,6 +94,8 @@ class Timetable extends PureComponent<Props> {
                 startingIndex={startingIndex}
                 endingIndex={endingIndex}
                 onModifyCell={this.props.onModifyCell}
+                hoverClassNo={this.state.hoverClassNo}
+                onCellHover={this.onCellHover}
                 verticalMode={this.props.isVerticalOrientation}
                 showTitle={this.props.showTitle}
                 dayLessonRows={this.props.lessons[day] || [[]]}

--- a/www/src/js/views/timetable/Timetable.jsx
+++ b/www/src/js/views/timetable/Timetable.jsx
@@ -2,8 +2,8 @@
 import React, { PureComponent } from 'react';
 import { values, flattenDeep, noop } from 'lodash';
 
-import type { ClassNo, Lesson } from 'types/modules';
-import type { TimetableArrangement } from 'types/timetables';
+import type { Lesson } from 'types/modules';
+import type { HoverLesson, TimetableArrangement } from 'types/timetables';
 
 import {
   SCHOOLDAYS,
@@ -26,7 +26,7 @@ type Props = {
 };
 
 type State = {
-  hoverClassNo: ?ClassNo,
+  hoverLesson: ?HoverLesson,
 };
 
 class Timetable extends PureComponent<Props, State> {
@@ -40,7 +40,7 @@ class Timetable extends PureComponent<Props, State> {
   };
 
   state = {
-    hoverClassNo: null,
+    hoverLesson: null,
   };
 
   componentDidMount() {
@@ -53,8 +53,8 @@ class Timetable extends PureComponent<Props, State> {
     clearInterval(this.interval);
   }
 
-  onCellHover = (hoverClassNo: ?ClassNo) => {
-    this.setState({ hoverClassNo });
+  onCellHover = (hoverLesson: ?HoverLesson) => {
+    this.setState({ hoverLesson });
   };
 
   render() {
@@ -94,7 +94,7 @@ class Timetable extends PureComponent<Props, State> {
                 startingIndex={startingIndex}
                 endingIndex={endingIndex}
                 onModifyCell={this.props.onModifyCell}
-                hoverClassNo={this.state.hoverClassNo}
+                hoverLesson={this.state.hoverLesson}
                 onCellHover={this.onCellHover}
                 verticalMode={this.props.isVerticalOrientation}
                 showTitle={this.props.showTitle}

--- a/www/src/js/views/timetable/TimetableCell.jsx
+++ b/www/src/js/views/timetable/TimetableCell.jsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import classnames from 'classnames';
 
-import type { ClassNo, Lesson } from 'types/modules';
+import type { Lesson } from 'types/modules';
+import type { HoverLesson } from 'types/timetables';
 
 import { LESSON_TYPE_ABBREV } from 'utils/timetables';
 
@@ -13,8 +14,8 @@ type Props = {
   lesson: Lesson,
   style?: Object,
   onClick?: Function,
-  onHover: ?(?ClassNo) => void,
-  hoverClassNo: ?ClassNo,
+  onHover: ?(?HoverLesson) => void,
+  hoverLesson: ?HoverLesson,
 };
 
 /**
@@ -23,12 +24,17 @@ type Props = {
  * might explore other representations e.g. grouped lessons
  */
 function TimetableCell(props: Props) {
-  const { lesson, showTitle, onClick, onHover, hoverClassNo } = props;
+  const { lesson, showTitle, onClick, onHover, hoverLesson } = props;
 
   const moduleName = showTitle ? `${lesson.ModuleCode} ${lesson.ModuleTitle}` : lesson.ModuleCode;
   const conditionalProps = { onClick };
 
   const Cell = props.onClick ? 'button' : 'div';
+  const hover =
+    hoverLesson &&
+    lesson.ClassNo === hoverLesson.classNo &&
+    lesson.ModuleCode === hoverLesson.moduleCode;
+
   /* eslint-disable */
   return (
     <Cell // $FlowFixMe
@@ -40,12 +46,14 @@ function TimetableCell(props: Props) {
         // $FlowFixMe
         [styles.active]: lesson.isActive,
         // Local hover style for the timetable planner timetable,
-        [styles.hover]: lesson.ClassNo === hoverClassNo,
+        [styles.hover]: hover,
         // Global hover style for module page timetable
-        hover: lesson.ClassNo === hoverClassNo,
+        hover,
       })}
       style={props.style}
-      onMouseEnter={() => onHover && onHover(lesson.ClassNo)}
+      onMouseEnter={() =>
+        onHover && onHover({ classNo: lesson.ClassNo, moduleCode: lesson.ModuleCode })
+      }
       onMouseLeave={() => onHover && onHover(null)}
       {...conditionalProps}
     >

--- a/www/src/js/views/timetable/TimetableCell.jsx
+++ b/www/src/js/views/timetable/TimetableCell.jsx
@@ -34,11 +34,11 @@ function TimetableCell(props: Props) {
     <Cell // $FlowFixMe
       className={classnames(styles.cell, `color-${lesson.colorIndex}`, {
         hoverable: !!props.onClick,
-        [styles.cellIsClickable]: !!onClick,
+        [styles.clickable]: !!onClick,
         // $FlowFixMe
-        [styles.cellIsAvailable]: lesson.isAvailable,
+        [styles.available]: lesson.isAvailable,
         // $FlowFixMe
-        [styles.cellIsActive]: lesson.isActive,
+        [styles.active]: lesson.isActive,
         // Local hover style for the timetable planner timetable,
         [styles.hover]: lesson.ClassNo === hoverClassNo,
         // Global hover style for module page timetable

--- a/www/src/js/views/timetable/TimetableCell.jsx
+++ b/www/src/js/views/timetable/TimetableCell.jsx
@@ -39,7 +39,10 @@ function TimetableCell(props: Props) {
         [styles.cellIsAvailable]: lesson.isAvailable,
         // $FlowFixMe
         [styles.cellIsActive]: lesson.isActive,
+        // Local hover style for the timetable planner timetable,
         [styles.hover]: lesson.ClassNo === hoverClassNo,
+        // Global hover style for module page timetable
+        hover: lesson.ClassNo === hoverClassNo,
       })}
       style={props.style}
       onMouseEnter={() => onHover && onHover(lesson.ClassNo)}

--- a/www/src/js/views/timetable/TimetableCell.jsx
+++ b/www/src/js/views/timetable/TimetableCell.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import classnames from 'classnames';
 
-import type { Lesson } from 'types/modules';
+import type { ClassNo, Lesson } from 'types/modules';
 
 import { LESSON_TYPE_ABBREV } from 'utils/timetables';
 
@@ -13,6 +13,8 @@ type Props = {
   lesson: Lesson,
   style?: Object,
   onClick?: Function,
+  onHover: ?(?ClassNo) => void,
+  hoverClassNo: ?ClassNo,
 };
 
 /**
@@ -21,12 +23,13 @@ type Props = {
  * might explore other representations e.g. grouped lessons
  */
 function TimetableCell(props: Props) {
-  const { lesson, showTitle, onClick } = props;
+  const { lesson, showTitle, onClick, onHover, hoverClassNo } = props;
 
   const moduleName = showTitle ? `${lesson.ModuleCode} ${lesson.ModuleTitle}` : lesson.ModuleCode;
   const conditionalProps = { onClick };
 
   const Cell = props.onClick ? 'button' : 'div';
+  /* eslint-disable */
   return (
     <Cell // $FlowFixMe
       className={classnames(styles.cell, `color-${lesson.colorIndex}`, {
@@ -36,8 +39,11 @@ function TimetableCell(props: Props) {
         [styles.cellIsAvailable]: lesson.isAvailable,
         // $FlowFixMe
         [styles.cellIsActive]: lesson.isActive,
+        [styles.hover]: lesson.ClassNo === hoverClassNo,
       })}
       style={props.style}
+      onMouseEnter={() => onHover && onHover(lesson.ClassNo)}
+      onMouseLeave={() => onHover && onHover(null)}
       {...conditionalProps}
     >
       <div className={styles.cellContainer}>

--- a/www/src/js/views/timetable/TimetableCell.scss
+++ b/www/src/js/views/timetable/TimetableCell.scss
@@ -36,12 +36,12 @@ $cell-border-radius: 6px;
   padding: 0;
 }
 
-.cellIsClickable {
+.clickable {
   border-radius: $cell-border-radius;
   cursor: pointer;
 }
 
-.cellIsAvailable {
+.available {
   opacity: $cell-opacity;
 
   :global {
@@ -54,7 +54,7 @@ $cell-border-radius: 6px;
   }
 }
 
-.cellIsActive {
+.active {
   z-index: $timetable-selected-cell-z-index;
   animation-duration: 1s;
   animation-iteration-count: infinite;

--- a/www/src/js/views/timetable/TimetableCell.scss
+++ b/www/src/js/views/timetable/TimetableCell.scss
@@ -48,7 +48,8 @@ $cell-border-radius: 6px;
     animation-name: zoomIn;
   }
 
-  &:hover {
+  &:hover,
+  &.hover {
     opacity: 1;
   }
 }

--- a/www/src/js/views/timetable/TimetableCell.test.jsx
+++ b/www/src/js/views/timetable/TimetableCell.test.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
+import type { HoverLesson } from 'types/timetables';
 import TimetableCell from './TimetableCell';
 
 const DEFAULT_LESSON = {
@@ -17,35 +18,84 @@ const DEFAULT_LESSON = {
   colorIndex: 1,
 };
 
-describe('<TimetableCell />', () => {
+type Props = {
+  onClick?: Function,
+  showTitle?: boolean,
+  onHover?: ?(?HoverLesson) => void,
+  hoverLesson?: ?HoverLesson,
+};
+
+describe(TimetableCell, () => {
+  function make(additionalProps: Props = {}) {
+    const props = {
+      onHover: jest.fn(),
+      showTitle: false,
+      hoverLesson: (null: ?HoverLesson),
+      ...additionalProps,
+    };
+
+    const onClick = jest.fn();
+
+    return {
+      onClick,
+      onHover: props.onHover,
+      wrapper: shallow(<TimetableCell onClick={onClick} lesson={DEFAULT_LESSON} {...props} />),
+    };
+  }
+
   describe('when onClick is passed', () => {
     it('simulates click events and renders a button', () => {
-      const onButtonClick = jest.fn();
-      const wrapper = shallow(
-        <TimetableCell onClick={onButtonClick} lesson={DEFAULT_LESSON} showTitle />,
-      );
+      const { onClick, wrapper } = make();
+
       const buttons = wrapper.find('button');
       buttons.at(0).simulate('click', { preventDefault() {} });
-      expect(onButtonClick).toBeCalled();
+      expect(onClick).toBeCalled();
     });
 
     it('has clickable class styling', () => {
-      const onButtonClick = jest.fn();
-      const wrapper = shallow(
-        <TimetableCell onClick={onButtonClick} lesson={DEFAULT_LESSON} showTitle />,
-      );
+      const { wrapper } = make();
+
       const button = wrapper.find('button').at(0);
-      expect(button.hasClass('cellIsClickable')).toBeTruthy();
+      expect(button.hasClass('clickable')).toBe(true);
     });
   });
 
-  describe('when onClick is not passed', () => {
-    it('does not simulates click events and renders a div', () => {
-      const onButtonClick = jest.fn();
-      const wrapper = shallow(<TimetableCell lesson={DEFAULT_LESSON} showTitle />);
-      const buttons = wrapper.find('div');
-      buttons.at(0).simulate('click', { preventDefault() {} });
-      expect(onButtonClick).not.toBeCalled();
+  describe('hoverLesson', () => {
+    it('should highlight lesson when module code and classNo matches', () => {
+      const { wrapper } = make({
+        hoverLesson: {
+          moduleCode: 'CS1010',
+          classNo: '1',
+        },
+      });
+
+      const button = wrapper.find('button').at(0);
+      expect(button.hasClass('hover')).toBe(true);
+    });
+
+    it('should not highlight lesson when only module code and classNo match', () => {
+      let button;
+      button = make({
+        hoverLesson: {
+          moduleCode: 'CS1010',
+          classNo: '2',
+        },
+      })
+        .wrapper.find('button')
+        .at(0);
+
+      expect(button.hasClass('hover')).toBe(false);
+
+      button = make({
+        hoverLesson: {
+          moduleCode: 'CS1101S',
+          classNo: '1',
+        },
+      })
+        .wrapper.find('button')
+        .at(0);
+
+      expect(button.hasClass('hover')).toBe(false);
     });
   });
 });

--- a/www/src/js/views/timetable/TimetableDay.jsx
+++ b/www/src/js/views/timetable/TimetableDay.jsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import classnames from 'classnames';
 
-import type { TimetableDayArrangement } from 'types/timetables';
-import type { ClassNo } from 'types/modules';
+import type { TimetableDayArrangement, HoverLesson } from 'types/timetables';
 
 import styles from './TimetableDay.scss';
 import TimetableRow from './TimetableRow';
@@ -20,8 +19,8 @@ type Props = {
   onModifyCell: Function,
   isCurrentDay: boolean,
   currentTimeIndicatorStyle: Object,
-  hoverClassNo: ?ClassNo,
-  onCellHover: ?(?ClassNo) => void,
+  hoverLesson: ?HoverLesson,
+  onCellHover: ?(?HoverLesson) => void,
 };
 
 // Height of timetable per hour in vertical mode
@@ -59,7 +58,7 @@ function TimetableDay(props: Props) {
             showTitle={props.showTitle}
             lessons={dayLessonRow}
             onModifyCell={props.onModifyCell}
-            hoverClassNo={props.hoverClassNo}
+            hoverLesson={props.hoverLesson}
             onCellHover={props.onCellHover}
           />
         ))}

--- a/www/src/js/views/timetable/TimetableDay.jsx
+++ b/www/src/js/views/timetable/TimetableDay.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import classnames from 'classnames';
 
 import type { TimetableDayArrangement } from 'types/timetables';
+import type { ClassNo } from 'types/modules';
 
 import styles from './TimetableDay.scss';
 import TimetableRow from './TimetableRow';
@@ -19,6 +20,8 @@ type Props = {
   onModifyCell: Function,
   isCurrentDay: boolean,
   currentTimeIndicatorStyle: Object,
+  hoverClassNo: ?ClassNo,
+  onCellHover: ?(?ClassNo) => void,
 };
 
 // Height of timetable per hour in vertical mode
@@ -46,6 +49,7 @@ function TimetableDay(props: Props) {
       </div>
       <div className={styles.dayRows} style={rowStyle}>
         <CurrentTimeIndicator style={props.currentTimeIndicatorStyle} />
+
         {props.dayLessonRows.map((dayLessonRow, i) => (
           <TimetableRow
             key={i}
@@ -55,6 +59,8 @@ function TimetableDay(props: Props) {
             showTitle={props.showTitle}
             lessons={dayLessonRow}
             onModifyCell={props.onModifyCell}
+            hoverClassNo={props.hoverClassNo}
+            onCellHover={props.onCellHover}
           />
         ))}
       </div>

--- a/www/src/js/views/timetable/TimetableRow.jsx
+++ b/www/src/js/views/timetable/TimetableRow.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 
-import type { ColoredLesson } from 'types/modules';
+import type { ClassNo, ColoredLesson } from 'types/modules';
 
 import { convertTimeToIndex } from 'utils/timify';
 import styles from './TimetableRow.scss';
@@ -10,6 +10,8 @@ import TimetableCell from './TimetableCell';
 type Props = {
   verticalMode: boolean,
   showTitle: boolean,
+  hoverClassNo: ?ClassNo,
+  onCellHover: ?(?ClassNo) => void,
   startingIndex: number,
   endingIndex: number,
   lessons: ColoredLesson[],
@@ -59,12 +61,15 @@ function TimetableRow(props: Props) {
               },
             }
           : {};
+
         return (
           <TimetableCell
             key={lesson.StartTime}
             style={style}
             lesson={lesson}
             showTitle={props.showTitle}
+            hoverClassNo={props.hoverClassNo}
+            onHover={props.onCellHover}
             {...conditionalProps}
           />
         );

--- a/www/src/js/views/timetable/TimetableRow.jsx
+++ b/www/src/js/views/timetable/TimetableRow.jsx
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react';
 
-import type { ClassNo, ColoredLesson } from 'types/modules';
+import type { ColoredLesson } from 'types/modules';
+import type { HoverLesson } from 'types/timetables';
 
 import { convertTimeToIndex } from 'utils/timify';
 import styles from './TimetableRow.scss';
@@ -10,8 +11,8 @@ import TimetableCell from './TimetableCell';
 type Props = {
   verticalMode: boolean,
   showTitle: boolean,
-  hoverClassNo: ?ClassNo,
-  onCellHover: ?(?ClassNo) => void,
+  hoverLesson: ?HoverLesson,
+  onCellHover: ?(?HoverLesson) => void,
   startingIndex: number,
   endingIndex: number,
   lessons: ColoredLesson[],
@@ -68,7 +69,7 @@ function TimetableRow(props: Props) {
             style={style}
             lesson={lesson}
             showTitle={props.showTitle}
-            hoverClassNo={props.hoverClassNo}
+            hoverLesson={props.hoverLesson}
             onHover={props.onCellHover}
             {...conditionalProps}
           />

--- a/www/src/styles/utils/mixins.scss
+++ b/www/src/styles/utils/mixins.scss
@@ -3,7 +3,8 @@
   border-color: darken($color, 20%);
   background-color: $color;
 
-  &.hoverable:hover {
+  &.hoverable:hover,
+  &.hoverable.hover {
     background-color: darken($color, 10%);
   }
 }


### PR DESCRIPTION
Fixes #754 

Implemented via state declared at `<Timetable>` and a prop and event handler passed all the way down to `<TimetableCell>`. In addition `.hover` has been added as a theme CSS class, which has the same style as `:hover` but can be programmatically triggered. This allows the timetable on the module page to achieve the same effect.

To test this use ES1531Critical Thinking And Writing. 

![peek 2018-05-27 16-44](https://user-images.githubusercontent.com/445650/40585199-e561fabe-61e0-11e8-9c70-1f66306cff08.gif)
