### PR TITLE
Merge dual coded modules on venue pages 

### DIFF
--- a/www/src/js/utils/react.jsx
+++ b/www/src/js/utils/react.jsx
@@ -6,6 +6,7 @@ import { escapeRegExp, castArray } from 'lodash';
 
 // Define some useful Unicode characters as constants
 export const NBSP = '\u00a0';
+export const ZWSP = '\u200b';
 export const BULLET = ' • ';
 
 /**

--- a/www/src/js/utils/venues.js
+++ b/www/src/js/utils/venues.js
@@ -60,7 +60,14 @@ export function filterAvailability(
 }
 
 export function getDuplicateModules(classes: VenueLesson[]): ModuleCode[] {
-  const lessonsByTime = values(groupBy(classes, (lesson) => [lesson.StartTime, lesson.WeekText]));
+  const lessonsByTime = values(
+    groupBy(classes, (lesson) => [
+      lesson.StartTime,
+      lesson.EndTime,
+      lesson.WeekText,
+      lesson.DayText,
+    ]),
+  );
   for (let i = 0; i < lessonsByTime.length; i++) {
     const lessons = lessonsByTime[i];
     if (lessons.length > 1 && lessons.every((lesson) => lesson.WeekText === lessons[0].WeekText)) {

--- a/www/src/js/utils/venues.js
+++ b/www/src/js/utils/venues.js
@@ -4,6 +4,7 @@ import type { ModuleCode } from 'types/modules';
 import type { VenueInfo, VenueSearchOptions, VenueDetailList, VenueLesson } from 'types/venues';
 import { OCCUPIED } from 'types/venues';
 import { range, entries, padStart, groupBy, values } from 'lodash';
+import { ZWSP } from 'utils/react';
 
 import { tokenize } from './moduleSearch';
 import { SCHOOLDAYS } from './timify';

--- a/www/src/js/utils/venues.js
+++ b/www/src/js/utils/venues.js
@@ -1,8 +1,9 @@
 // @flow
 
-import type { VenueInfo, VenueSearchOptions, VenueDetailList } from 'types/venues';
-import { range, entries, padStart } from 'lodash';
+import type { ModuleCode } from 'types/modules';
+import type { VenueInfo, VenueSearchOptions, VenueDetailList, VenueLesson } from 'types/venues';
 import { OCCUPIED } from 'types/venues';
+import { range, entries, padStart, groupBy, values } from 'lodash';
 
 import { tokenize } from './moduleSearch';
 import { SCHOOLDAYS } from './timify';
@@ -55,4 +56,43 @@ export function filterAvailability(
 
     return true;
   });
+}
+
+export function getDuplicateModules(classes: VenueLesson[]): ModuleCode[] {
+  const lessonsByTime = values(groupBy(classes, (lesson) => [lesson.StartTime, lesson.WeekText]));
+  for (let i = 0; i < lessonsByTime.length; i++) {
+    const lessons = lessonsByTime[i];
+    if (lessons.length > 1 && lessons.every((lesson) => lesson.WeekText === lessons[0].WeekText)) {
+      return lessons.map((lesson) => lesson.ModuleCode);
+    }
+  }
+
+  return [];
+}
+
+export function mergeModules(classes: VenueLesson[], modules: ModuleCode[]): VenueLesson[] {
+  const mergedModuleCode = modules.join(`/${ZWSP}`);
+  const removeModuleCodes = new Set(modules.slice(1));
+
+  return classes.filter((lesson) => !removeModuleCodes.has(lesson.ModuleCode)).map(
+    (lesson) =>
+      lesson.ModuleCode === modules[0]
+        ? {
+            ...lesson,
+            ModuleCode: mergedModuleCode,
+          }
+        : lesson,
+  );
+}
+
+export function mergeDualCodedModules(classes: VenueLesson[]): VenueLesson[] {
+  let mergedModules = classes;
+  let duplicateModules = getDuplicateModules(mergedModules);
+
+  while (duplicateModules.length) {
+    mergedModules = mergeModules(mergedModules, duplicateModules);
+    duplicateModules = getDuplicateModules(mergedModules);
+  }
+
+  return mergedModules;
 }

--- a/www/src/js/utils/venues.test.js
+++ b/www/src/js/utils/venues.test.js
@@ -2,6 +2,7 @@
 import venueInfo from '__mocks__/venueInformation.json';
 
 import type { WeekText, ModuleCode, StartTime } from 'types/modules';
+import { ZWSP } from 'utils/react';
 import {
   searchVenue,
   filterAvailability,
@@ -151,7 +152,7 @@ describe(getDuplicateModules, () => {
 describe(mergeDualCodedModules, () => {
   it('should merge modules with the same starting time', () => {
     expect(mergeDualCodedModules([makeVenueLesson('GEK1901'), makeVenueLesson('GET1001')])).toEqual(
-      [makeVenueLesson('GEK1901/GET1001')],
+      [makeVenueLesson(`GEK1901/${ZWSP}GET1001`)],
     );
   });
 
@@ -166,9 +167,9 @@ describe(mergeDualCodedModules, () => {
         makeVenueLesson('GES1001', { StartTime: '1200' }),
       ]),
     ).toEqual([
-      makeVenueLesson('GEK1901/GET1001', { StartTime: '1000' }),
-      makeVenueLesson('GEK1901/GET1001', { StartTime: '1400' }),
-      makeVenueLesson('GEK1902/GES1001', { StartTime: '1200' }),
+      makeVenueLesson(`GEK1901/${ZWSP}GET1001`, { StartTime: '1000' }),
+      makeVenueLesson(`GEK1901/${ZWSP}GET1001`, { StartTime: '1400' }),
+      makeVenueLesson(`GEK1902/${ZWSP}GES1001`, { StartTime: '1200' }),
     ]);
   });
 

--- a/www/src/js/utils/venues.test.js
+++ b/www/src/js/utils/venues.test.js
@@ -1,10 +1,32 @@
 // @flow
 import venueInfo from '__mocks__/venueInformation.json';
 
-import { searchVenue, filterAvailability, sortVenues } from './venues';
+import type { WeekText, ModuleCode, StartTime } from 'types/modules';
+import {
+  searchVenue,
+  filterAvailability,
+  sortVenues,
+  getDuplicateModules,
+  mergeDualCodedModules,
+} from './venues';
 
 const venues = sortVenues(venueInfo);
 const getVenues = (...names) => venues.filter(([name]) => names.includes(name));
+
+const makeVenueLesson = (
+  moduleCode: ModuleCode,
+  props: { WeekText?: WeekText, StartTime?: StartTime } = {},
+) => ({
+  ClassNo: '1',
+  DayText: 'Monday',
+  LessonType: 'Lecture',
+  EndTime: '1000',
+  StartTime: '0900',
+  Venue: 'LT1',
+  WeekText: 'Every Week',
+  ModuleCode: moduleCode,
+  ...props,
+});
 
 describe('sortVenues', () => {
   test('handle empty venue object', () => {
@@ -97,5 +119,68 @@ describe('filterAvailability()', () => {
         duration: 14,
       }),
     ).toEqual(getVenues('CQT/SR0622'));
+  });
+});
+
+describe(getDuplicateModules, () => {
+  it('should return an array of duplicated module codes', () => {
+    expect(getDuplicateModules([makeVenueLesson('GEK1901'), makeVenueLesson('GET1001')])).toEqual([
+      'GEK1901',
+      'GET1001',
+    ]);
+
+    expect(
+      getDuplicateModules([
+        makeVenueLesson('GEK1901', { WeekText: 'Odd Week' }),
+        makeVenueLesson('GET1001', { WeekText: 'Odd Week' }),
+        makeVenueLesson('GET1002', { WeekText: 'Even Week' }),
+      ]),
+    ).toEqual(['GEK1901', 'GET1001']);
+  });
+
+  it('should not consider modules happening on different weeks as duplicates', () => {
+    expect(
+      getDuplicateModules([
+        makeVenueLesson('GEK1901', { WeekText: 'Odd Week' }),
+        makeVenueLesson('GET1001', { WeekText: 'Even Week' }),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe(mergeDualCodedModules, () => {
+  it('should merge modules with the same starting time', () => {
+    expect(mergeDualCodedModules([makeVenueLesson('GEK1901'), makeVenueLesson('GET1001')])).toEqual(
+      [makeVenueLesson('GEK1901/GET1001')],
+    );
+  });
+
+  it('should merge module sets of modules with the same starting time', () => {
+    expect(
+      mergeDualCodedModules([
+        makeVenueLesson('GEK1901', { StartTime: '1000' }),
+        makeVenueLesson('GEK1901', { StartTime: '1400' }),
+        makeVenueLesson('GET1001', { StartTime: '1000' }),
+        makeVenueLesson('GET1001', { StartTime: '1400' }),
+        makeVenueLesson('GEK1902', { StartTime: '1200' }),
+        makeVenueLesson('GES1001', { StartTime: '1200' }),
+      ]),
+    ).toEqual([
+      makeVenueLesson('GEK1901/GET1001', { StartTime: '1000' }),
+      makeVenueLesson('GEK1901/GET1001', { StartTime: '1400' }),
+      makeVenueLesson('GEK1902/GES1001', { StartTime: '1200' }),
+    ]);
+  });
+
+  it('should not merge modules on different weeks', () => {
+    expect(
+      mergeDualCodedModules([
+        makeVenueLesson('GEK1901', { WeekText: 'Odd Week' }),
+        makeVenueLesson('GET1001', { WeekText: 'Even Week' }),
+      ]),
+    ).toEqual([
+      makeVenueLesson('GEK1901', { WeekText: 'Odd Week' }),
+      makeVenueLesson('GET1001', { WeekText: 'Even Week' }),
+    ]);
   });
 });

--- a/www/src/js/views/venues/VenueDetails.jsx
+++ b/www/src/js/views/venues/VenueDetails.jsx
@@ -15,6 +15,7 @@ import Timetable from 'views/timetable/Timetable';
 import makeResponsive from 'views/hocs/makeResponsive';
 import { modulePage, venuePage } from 'views/routes/paths';
 import Title from 'views/components/Title';
+import { mergeDualCodedModules } from 'utils/venues';
 import { breakpointDown } from 'utils/css';
 
 import styles from './VenueDetails.scss';
@@ -32,9 +33,10 @@ type Props = {
 
 export class VenueDetailsComponent extends PureComponent<Props> {
   arrangedLessons() {
-    const lessons = flatMap(this.props.availability, (day): VenueLesson[] => day.Classes).map(
-      (venueLesson) => ({ ...venueLesson, ModuleTitle: '', isModifiable: true }),
-    );
+    const lessons = flatMap(this.props.availability, (day): VenueLesson[] =>
+      mergeDualCodedModules(day.Classes),
+    ).map((venueLesson) => ({ ...venueLesson, ModuleTitle: '', isModifiable: true }));
+
     const coloredLessons = colorLessonsByKey(lessons, 'ModuleCode');
     return arrangeLessonsForWeek(coloredLessons);
   }


### PR DESCRIPTION
Part of #538 

This PR merges dual coded modules on venue pages. Dual coded modules are the same modules given two different module codes and show up as two different modules on CORS, but has the exact same lesson timing and venue. The merging logic is simple - if two or more lessons have the same StartTime, EndTime, WeekText and DayText, then they are considered duplicates and will be merged. This reduce the size and clutter of the timetable, which makes it easier to read. 

Before: 

![screenshot from 2018-05-28 18-56-20](https://user-images.githubusercontent.com/445650/40611424-d78d988a-62a8-11e8-8812-242a31cbd70c.png)

After 

![screenshot from 2018-05-28 18-56-49](https://user-images.githubusercontent.com/445650/40611443-e7b28b58-62a8-11e8-8892-739dd0f8f02d.png)

