### PR TITLE
Fix cors scraper by filtering no result pages

### DIFF
--- a/scrapers/nus/gulp-tasks/remote/cors.js
+++ b/scrapers/nus/gulp-tasks/remote/cors.js
@@ -33,11 +33,15 @@ const ROOT_URLS = {
 };
 
 const MODULE_TYPES = ['Module', 'GEM2015', 'GEM', 'SSM', 'UEM', 'CFM'];
+const NO_INFO = 'The module information that you are looking for is currently not available.';
 
 const log = bunyan.createLogger({ name: 'cors' });
 
 function processModulePage(webpage, moduleInfo) {
   const $ = cheerio.load(webpage);
+  if ($.text().includes(NO_INFO)) {
+    return null;
+  }
   const timestamp = $('h2')
     .text()
     .match(TIMESTAMP_REGEX)
@@ -178,7 +182,7 @@ async function processListings(rootUrl, type, lessonTypes, config) {
   return {
     academicYear,
     semester,
-    modules,
+    modules: R.filter(R.identity, modules), // remove nulls
   };
 }
 


### PR DESCRIPTION
Seems like cors is return webpages with no data in them, causing errors to be thrown. I don't even know how to find a selector for this as it's the second <tr> in <body> with no <table> 🤕.

This doesn't solve the main problem though. Cors hasn't updated since March 30th. No signs of any updates yet.