### PR TITLE
Archive old timetables with new academic year 

### DIFF
--- a/www/src/js/reducers/index.js
+++ b/www/src/js/reducers/index.js
@@ -24,7 +24,10 @@ import createUndoReducer from './undoHistory';
 // Persisted reducers
 import moduleBankReducer, { persistConfig as moduleBankPersistConfig } from './moduleBank';
 import venueBankReducer, { persistConfig as venueBankPersistConfig } from './venueBank';
-import timetablesReducer from './timetables';
+import timetablesReducer, {
+  PERSIST_KEY as timetablesPersistKey,
+  persistConfig as timetablesPersistConfig,
+} from './timetables';
 import themeReducer from './theme';
 import settingsReducer from './settings';
 
@@ -43,7 +46,7 @@ export type State = {
 // Persist reducers
 const moduleBank = persistReducer('moduleBank', moduleBankReducer, moduleBankPersistConfig);
 const venueBank = persistReducer('venueBank', venueBankReducer, venueBankPersistConfig);
-const timetables = persistReducer('timetables', timetablesReducer);
+const timetables = persistReducer(timetablesPersistKey, timetablesReducer, timetablesPersistConfig);
 const theme = persistReducer('theme', themeReducer);
 const settings = persistReducer('settings', settingsReducer);
 

--- a/www/src/js/reducers/index.test.js
+++ b/www/src/js/reducers/index.test.js
@@ -70,6 +70,7 @@ test('reducers should set export data state', () => {
     },
     hidden: { [1]: ['PC1222'] },
     academicYear: expect.any(String),
+    archive: {},
   });
 
   expect(state.settings).toMatchObject({

--- a/www/src/js/reducers/timetables.test.js
+++ b/www/src/js/reducers/timetables.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import reducer, { defaultTimetableState } from 'reducers/timetables';
+import reducer, { defaultTimetableState, PERSIST_KEY } from 'reducers/timetables';
 import {
   ADD_MODULE,
   SET_TIMETABLE,
@@ -10,8 +10,12 @@ import {
   setLessonConfig,
 } from 'actions/timetables';
 import type { TimetablesState } from 'types/reducers';
+import { REHYDRATE } from 'redux-persist';
+import config from 'config';
 
 const initialState = defaultTimetableState;
+
+jest.mock('config');
 
 /* eslint-disable no-useless-computed-key */
 describe('color reducers', () => {
@@ -156,6 +160,43 @@ describe('lesson reducer', () => {
           },
         },
       },
+    });
+  });
+});
+
+describe('root reducer', () => {
+  test('should archive old timetables', () => {
+    const oldLessons = {
+      [1]: {
+        CS1010S: {
+          Lecture: '1',
+          Recitation: '2',
+        },
+      },
+      [2]: {
+        CS3217: {
+          Lecture: '1',
+        },
+      },
+    };
+
+    const action: any = {
+      type: REHYDRATE,
+      key: PERSIST_KEY,
+      payload: {
+        ...initialState,
+        lessons: oldLessons,
+        academicYear: '2016/2017',
+      },
+    };
+
+    expect(reducer(initialState, action)).toEqual({
+      ...initialState,
+      lessons: {},
+      archive: {
+        '2016/2017': oldLessons,
+      },
+      academicYear: config.academicYear,
     });
   });
 });

--- a/www/src/js/storage/migrateLegacyStorage.js
+++ b/www/src/js/storage/migrateLegacyStorage.js
@@ -46,6 +46,7 @@ export default function migrateLegacyStorage(original: ?Object) {
       hidden: splitHiddenModules(timetables, get(original, 'settings.hiddenInTimetable', [])),
       // Add academic year key
       academicYear: config.academicYear,
+      archive: {},
     }: TimetablesState);
   }
 

--- a/www/src/js/storage/migrateLegacyStorage.test.js
+++ b/www/src/js/storage/migrateLegacyStorage.test.js
@@ -77,6 +77,7 @@ test('move timetables state', () => {
       [2]: ['CS1010S'],
     },
     academicYear: '2017/2018',
+    archive: {},
   });
 });
 

--- a/www/src/js/types/reducers.js
+++ b/www/src/js/types/reducers.js
@@ -104,6 +104,8 @@ export type TimetablesState = {
   +colors: SemesterColorMap,
   +hidden: HiddenModulesMap,
   +academicYear: string,
+  // Mapping of academic year to old timetable config
+  +archive: { [string]: TimetableConfig },
 };
 
 /* moduleBank.js */


### PR DESCRIPTION
This PR adds a new `archive` key to the `timetables` state and clears the `lessons` state if the new AY does not match the old persisted one. This will prevent the student's old timetable from being used in the new AY, while keeping the old timetable in case we want to develop new features for it in the future. 

The code is a bit rough around the ages. For how rehydration and migration work, refer to https://github.com/rt2zz/redux-persist/#state-reconciler and https://github.com/rt2zz/redux-persist/blob/master/docs/migrations.md