### PR TITLE
Add sems 1 and 2 to bulletinModules scraper

### DIFF
--- a/scrapers/nus/gulpfile.babel.js
+++ b/scrapers/nus/gulpfile.babel.js
@@ -30,7 +30,7 @@ gulp.task('bulletinModules', () => {
   const subtasks = iterateSems({
     from: yearStart,
     to: yearEnd,
-    semesters: [0, 3, 4],
+    semesters: [0, 1, 2, 3, 4],
     config: config.bulletinModules,
   });
 


### PR DESCRIPTION
Sems 1 and 2 weren't being scraped. These sems were disabled in #681 as
the bulletin modules API wasn't responding. However, it seems to be back
up for AY18/19, and we also need that facultyDepartments.json file.

Tested in prod - seems to work.