### PR TITLE
Fix timetable archiving

### DIFF
--- a/www/src/js/reducers/timetables.js
+++ b/www/src/js/reducers/timetables.js
@@ -20,7 +20,7 @@ import {
 } from 'actions/timetables';
 import { SET_EXPORTED_DATA } from 'actions/export';
 import { getNewColor } from 'utils/colors';
-import { createMigrate, REHYDRATE, type PersistConfig } from 'redux-persist';
+import { createMigrate, type PersistConfig } from 'redux-persist';
 
 const EMPTY_OBJECT = {};
 
@@ -173,35 +173,8 @@ export const defaultTimetableState: TimetablesState = {
 };
 
 function timetables(state: TimetablesState = defaultTimetableState, action: FSA): TimetablesState {
-  if (!action.payload) {
-    return state;
-  }
-
-  // Archive old timetables on rehydration and clear the timetable for the new AY
-  if (action.type === REHYDRATE) {
-    // Redux Persist does not follow FSA, so we cast to any to let Flow
-    // give us a pass here
-    const { key, payload } = (action: any);
-
-    if (key !== PERSIST_KEY || !payload || payload.academicYear === config.academicYear) {
-      return state;
-    }
-
-    return {
-      ...state,
-      academicYear: config.academicYear,
-      lessons: {},
-      colors: {},
-      hidden: {},
-      archive: {
-        ...(state.archive || EMPTY_OBJECT),
-        [payload.academicYear]: payload.lessons,
-      },
-    };
-  }
-
   // All normal timetable actions should specify their semester
-  if (!action.payload.semester) {
+  if (!action.payload || !action.payload.semester) {
     return state;
   }
 

--- a/www/src/js/storage/persistReducer.js
+++ b/www/src/js/storage/persistReducer.js
@@ -16,6 +16,7 @@ export default function persistReducer(
     {
       key,
       storage,
+      debug: process.env.NODE_ENV !== 'production',
       ...options,
     },
     reducer,


### PR DESCRIPTION
Turns out Redux Persist's reconciliation algorithm is... not very good - see: https://github.com/rt2zz/redux-persist/blob/master/src/stateReconciler/autoMergeLevel1.js - inbound = deserialized persisted state, original = initial state, reduced = after REHYDRATE. The logic just checks if reduced != original, but does not check if reduced != inbound, which is why acad year was being reset to the old value. 

We'll just use our own instead of trying to hack it with the REHYDRATE action. 