### PR TITLE
Fix noscroll persisting after navigation when sidemenu is open 

### DIFF
--- a/www/src/js/utils/disableScrolling.js
+++ b/www/src/js/utils/disableScrolling.js
@@ -9,7 +9,7 @@ let isOn = false;
  * class on body because unfortunately toggling the no scroll styles
  * also affects position: sticky elements
  */
-export default function noScroll(active: boolean) {
+export default function disableScrolling(active: boolean) {
   const { body } = document;
   if (!body || active === isOn) return;
 

--- a/www/src/js/utils/disableScrolling.test.js
+++ b/www/src/js/utils/disableScrolling.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import noScrollNpm from 'no-scroll';
-import noScroll from './noScroll';
+import disableScrolling from './disableScrolling';
 
 jest.mock('no-scroll');
 
@@ -13,23 +13,23 @@ describe('noScroll()', () => {
   });
 
   test('turn noScroll on or off', () => {
-    noScroll(true);
+    disableScrolling(true);
     expect(noScrollNpm.toggle).toBeCalled();
     expect(body && body.classList.contains('no-scroll')).toBe(true);
 
-    noScroll(false);
+    disableScrolling(false);
     expect(noScrollNpm.toggle).toHaveBeenCalledTimes(2);
     expect(body && body.classList.contains('no-scroll')).toBe(false);
   });
 
   test('not do anything if it is already on/off', () => {
-    noScroll(false);
+    disableScrolling(false);
     expect(noScrollNpm.toggle).not.toHaveBeenCalled();
     expect(body && body.classList.contains('no-scroll')).toBe(false);
 
-    noScroll(true);
-    noScroll(true);
-    noScroll(true);
+    disableScrolling(true);
+    disableScrolling(true);
+    disableScrolling(true);
     expect(noScrollNpm.toggle).toHaveBeenCalledTimes(1);
     expect(body && body.classList.contains('no-scroll')).toBe(true);
   });

--- a/www/src/js/views/components/Modal.jsx
+++ b/www/src/js/views/components/Modal.jsx
@@ -4,7 +4,7 @@ import React, { type Node, Component } from 'react';
 import ReactModal from 'react-modal';
 import classnames from 'classnames';
 
-import noScroll from 'utils/noScroll';
+import disableScrolling from 'utils/disableScrolling';
 import styles from './Modal.scss';
 
 type Props = {
@@ -21,20 +21,20 @@ export default class Modal extends Component<Props> {
   };
 
   componentDidMount() {
-    noScroll(this.props.isOpen);
+    disableScrolling(this.props.isOpen);
   }
 
   // noScroll must trigger before actual opening of modal
   componentWillUpdate(nextProps: Props) {
     if (this.props.isOpen !== nextProps.isOpen) {
-      noScroll(nextProps.isOpen);
+      disableScrolling(nextProps.isOpen);
     }
   }
 
   componentWillUnmount() {
     // Ensure noScroll is disabled if the component is unmounted without
     // the modal closing
-    noScroll(false);
+    disableScrolling(false);
   }
 
   render() {

--- a/www/src/js/views/components/SideMenu.jsx
+++ b/www/src/js/views/components/SideMenu.jsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 
 import { Menu, Close } from 'views/components/icons';
 import makeResponsive from 'views/hocs/makeResponsive';
-import noScroll from 'utils/noScroll';
+import disableScrolling from 'utils/disableScrolling';
 import { breakpointUp } from 'utils/css';
 import Fab from './Fab';
 
@@ -30,17 +30,17 @@ export class SideMenuComponent extends PureComponent<Props> {
   };
 
   componentDidMount() {
-    noScroll(this.isSideMenuShown());
+    disableScrolling(this.isSideMenuShown());
   }
 
   componentDidUpdate() {
-    noScroll(this.isSideMenuShown());
+    disableScrolling(this.isSideMenuShown());
   }
 
   componentWillUnmount() {
     // Force unset noscroll when unmounting so the user gets scrolling back if
     // they navigate out of the parent component without closing the menu
-    noScroll(false);
+    disableScrolling(false);
   }
 
   isSideMenuShown() {

--- a/www/src/js/views/components/SideMenu.jsx
+++ b/www/src/js/views/components/SideMenu.jsx
@@ -37,6 +37,12 @@ export class SideMenuComponent extends PureComponent<Props> {
     noScroll(this.isSideMenuShown());
   }
 
+  componentWillUnmount() {
+    // Force unset noscroll when unmounting so the user gets scrolling back if
+    // they navigate out of the parent component without closing the menu
+    noScroll(false);
+  }
+
   isSideMenuShown() {
     return this.props.isOpen && !this.props.matchBreakpoint;
   }


### PR DESCRIPTION
If the user opens the side menu then navigates to another page immediately, noScroll is still in effect because the component never updated its state to closed. This fixes that by forcing `noScroll(false)`

Also rename noScroll to disableScrolling so it sounds a bit better. 