### PR TITLE
Add service worker upgrade notice

### DIFF
--- a/www/src/js/actions/app.js
+++ b/www/src/js/actions/app.js
@@ -37,3 +37,11 @@ export function popNotification(): FSA {
     payload: null,
   };
 }
+
+export const PROMPT_REFRESH = 'PROMPT_REFRESH';
+export function promptRefresh(): FSA {
+  return {
+    type: PROMPT_REFRESH,
+    payload: null,
+  };
+}

--- a/www/src/js/bootstrapping/configure-store.js
+++ b/www/src/js/bootstrapping/configure-store.js
@@ -32,6 +32,9 @@ export default function configureStore(defaultState?: State) {
       collapsed: true,
       duration: true,
       diff: true,
+      // Avoid diffing actions that insert a lot of stuff into the state to prevent console from lagging
+      diffPredicate: (getState, action) =>
+        !action.type.startsWith('FETCH_MODULE_LIST') && !action.type.startsWith('persist/'),
     });
     middlewares.push(logger);
   }

--- a/www/src/js/bootstrapping/configure-store.js
+++ b/www/src/js/bootstrapping/configure-store.js
@@ -1,6 +1,5 @@
 // @flow
-
-import { createStore, applyMiddleware, compose } from 'redux';
+import { createStore, applyMiddleware, compose, type Store } from 'redux';
 import { persistStore } from 'redux-persist';
 import thunk from 'redux-thunk';
 import rootReducer, { type State } from 'reducers';

--- a/www/src/js/bootstrapping/service-worker.js
+++ b/www/src/js/bootstrapping/service-worker.js
@@ -57,6 +57,12 @@ export default function initializeServiceWorker(store: Store<*, *, *>) {
         return;
       }
 
+      // Refresh the service worker regularly so that the user gets the update
+      // notice if they leave the tab open for a while
+      const updateIntervalId = window.setInterval(() => {
+        registration.update();
+      }, 60 * 60 * 1000);
+
       // When the user asks to refresh the UI, we'll need to reload the window
       let preventDevToolsReloadLoop;
       serviceWorker.addEventListener('controllerchange', () => {
@@ -69,6 +75,7 @@ export default function initializeServiceWorker(store: Store<*, *, *>) {
       onNewServiceWorker(registration, () => {
         currentRegistration = registration;
         store.dispatch(promptRefresh());
+        window.clearInterval(updateIntervalId);
       });
     })
     .catch((e) => {

--- a/www/src/js/bootstrapping/service-worker.js
+++ b/www/src/js/bootstrapping/service-worker.js
@@ -1,0 +1,77 @@
+// @flow
+import type { Store } from 'redux';
+import Raven from 'raven-js';
+import { promptRefresh } from 'actions/app';
+
+let currentRegistration: ServiceWorkerRegistration;
+
+export function getRegistration() {
+  return currentRegistration;
+}
+
+// Code taken from https://developers.google.com/web/tools/workbox/guides/advanced-recipes
+function onNewServiceWorker(registration: ServiceWorkerRegistration, callback: () => void) {
+  if (registration.waiting) {
+    // SW is waiting to activate. Can occur if multiple clients open and
+    // one of the clients is refreshed.
+    callback();
+    return;
+  }
+
+  const listenInstalledStateChange = () => {
+    if (!registration.installing) {
+      return;
+    }
+
+    registration.installing.addEventListener('statechange', (event) => {
+      // $FlowFixMe - Flow doesn't recognize the event's target as being a ServiceWorker object
+      if (event.target.state === 'installed') {
+        // A new service worker is available, inform the user
+        callback();
+      }
+    });
+  };
+
+  if (registration.installing) {
+    listenInstalledStateChange();
+  } else {
+    // We are currently controlled so a new SW may be found...
+    // Add a listener in case a new SW is found,
+    registration.addEventListener('updatefound', listenInstalledStateChange);
+  }
+}
+
+export default function initializeServiceWorker(store: Store<*, *, *>) {
+  const { serviceWorker } = navigator;
+  if (!serviceWorker) {
+    return;
+  }
+
+  serviceWorker
+    .register('/service-worker.js')
+    .then((registration) => {
+      // Track updates to the Service Worker.
+      if (!serviceWorker.controller) {
+        // The window client isn't currently controlled so it's a new service
+        // worker that will activate immediately
+        return;
+      }
+
+      // When the user asks to refresh the UI, we'll need to reload the window
+      let preventDevToolsReloadLoop;
+      serviceWorker.addEventListener('controllerchange', () => {
+        // Ensure refresh is only called once - This works around a bug in "force update on reload".
+        if (preventDevToolsReloadLoop) return;
+        preventDevToolsReloadLoop = true;
+        window.location.reload();
+      });
+
+      onNewServiceWorker(registration, () => {
+        currentRegistration = registration;
+        store.dispatch(promptRefresh());
+      });
+    })
+    .catch((e) => {
+      Raven.captureException(e);
+    });
+}

--- a/www/src/js/main.js
+++ b/www/src/js/main.js
@@ -6,7 +6,6 @@ import 'bootstrapping/browser';
 
 import ReactDOM from 'react-dom';
 import ReactModal from 'react-modal';
-import Raven from 'raven-js';
 
 import App from 'App';
 import storage from 'storage';
@@ -14,6 +13,7 @@ import storage from 'storage';
 import configureStore from 'bootstrapping/configure-store';
 import subscribeOnlineEvents from 'bootstrapping/subscribeOnlineEvents';
 import initializeGA from 'bootstrapping/google-analytics';
+import initializeServiceWorker from 'bootstrapping/service-worker';
 
 import '../styles/main.scss';
 
@@ -42,9 +42,7 @@ if (
   // Allow us to force Workbox to be enabled for debugging
   process.env.DEBUG_WORKBOX
 ) {
-  navigator.serviceWorker.register('/service-worker.js').catch((e) => {
-    Raven.captureException(e);
-  });
+  initializeServiceWorker(store);
 }
 
 if (process.env.NODE_ENV === 'production') {

--- a/www/src/js/reducers/app.js
+++ b/www/src/js/reducers/app.js
@@ -8,6 +8,7 @@ import { SELECT_SEMESTER } from 'actions/settings';
 import {
   OPEN_NOTIFICATION,
   POP_NOTIFICATION,
+  PROMPT_REFRESH,
   SET_ONLINE_STATUS,
   TOGGLE_FEEDBACK_MODAL,
 } from 'actions/app';
@@ -19,6 +20,7 @@ const defaultAppState = (): AppState => ({
   activeLesson: null,
   isOnline: navigator.onLine,
   isFeedbackModalOpen: false,
+  promptRefresh: false,
   notifications: [],
 });
 
@@ -50,6 +52,12 @@ function app(state: AppState = defaultAppState(), action: FSA): AppState {
       return {
         ...state,
         isFeedbackModalOpen: !state.isFeedbackModalOpen,
+      };
+
+    case PROMPT_REFRESH:
+      return {
+        ...state,
+        promptRefresh: true,
       };
     case OPEN_NOTIFICATION: {
       if (state.notifications.length) {

--- a/www/src/js/reducers/app.test.js
+++ b/www/src/js/reducers/app.test.js
@@ -20,6 +20,7 @@ const appInitialState: AppState = {
   activeLesson: null,
   isOnline: true,
   isFeedbackModalOpen: false,
+  promptRefresh: false,
   notifications: [],
 };
 const appHasSemesterTwoState: AppState = { ...appInitialState, activeSemester: anotherSemester };

--- a/www/src/js/types/reducers.js
+++ b/www/src/js/types/reducers.js
@@ -51,6 +51,7 @@ export type AppState = {
   +isOnline: boolean,
   +isFeedbackModalOpen: boolean,
   +notifications: NotificationData[],
+  +promptRefresh: boolean,
 };
 
 /* requests.js */

--- a/www/src/js/views/AppShell.jsx
+++ b/www/src/js/views/AppShell.jsx
@@ -113,15 +113,19 @@ export class AppShellComponent extends Component<Props> {
             )}
           </main>
         </div>
+
         <ErrorBoundary>
           <FeedbackModal />
         </ErrorBoundary>
+
         <ErrorBoundary>
           <Notification />
         </ErrorBoundary>
+
         <ErrorBoundary>
           <Footer />
         </ErrorBoundary>
+
         <ErrorBoundary>
           <KeyboardShortcuts />
         </ErrorBoundary>

--- a/www/src/js/views/components/Announcements.scss
+++ b/www/src/js/views/components/Announcements.scss
@@ -1,4 +1,4 @@
-@import "~styles/utils/modules-entry";
+@import '~styles/utils/modules-entry';
 
 .announcement {
   display: flex;
@@ -18,6 +18,10 @@
 
   p:last-child {
     margin-bottom: 0;
+  }
+
+  .actions {
+    margin-top: 0.5rem;
   }
 }
 

--- a/www/src/js/views/components/RefreshPrompt.jsx
+++ b/www/src/js/views/components/RefreshPrompt.jsx
@@ -1,5 +1,4 @@
 // @flow
-
 import React, { PureComponent } from 'react';
 import classnames from 'classnames';
 import { connect, type MapStateToProps } from 'react-redux';

--- a/www/src/js/views/components/RefreshPrompt.jsx
+++ b/www/src/js/views/components/RefreshPrompt.jsx
@@ -14,9 +14,9 @@ type Props = {
 
 class RefreshPrompt extends PureComponent<Props> {
   render() {
-    // if (!this.props.showPrompt) {
-    //   return null;
-    // }
+    if (!this.props.showPrompt) {
+      return null;
+    }
 
     return (
       <div className={classnames('alert alert-success', styles.announcement)}>

--- a/www/src/js/views/components/RefreshPrompt.jsx
+++ b/www/src/js/views/components/RefreshPrompt.jsx
@@ -22,7 +22,7 @@ class RefreshPrompt extends PureComponent<Props> {
         <Refresh className={styles.backgroundIcon} />
 
         <div className={classnames()}>
-          <h3>NUSMods has been updated</h3>
+          <h3>A new version of NUSMods is available</h3>
           <p>Please refresh the page to get the latest version.</p>
         </div>
 

--- a/www/src/js/views/components/RefreshPrompt.jsx
+++ b/www/src/js/views/components/RefreshPrompt.jsx
@@ -1,0 +1,55 @@
+// @flow
+
+import React, { PureComponent } from 'react';
+import classnames from 'classnames';
+import { connect, type MapStateToProps } from 'react-redux';
+import type { State } from 'reducers';
+import { getRegistration } from 'bootstrapping/service-worker';
+import { Refresh } from 'views/components/icons';
+import styles from './Announcements.scss';
+
+type Props = {
+  showPrompt: boolean,
+};
+
+class RefreshPrompt extends PureComponent<Props> {
+  render() {
+    // if (!this.props.showPrompt) {
+    //   return null;
+    // }
+
+    return (
+      <div className={classnames('alert alert-success', styles.announcement)}>
+        <Refresh className={styles.backgroundIcon} />
+
+        <div className={classnames()}>
+          <h3>NUSMods has been updated</h3>
+          <p>Please refresh the page to get the latest version.</p>
+        </div>
+
+        <button
+          className="btn btn-success"
+          type="button"
+          onClick={() => {
+            const registration = getRegistration();
+            if (!registration || !registration.waiting) {
+              // Just to ensure registration.waiting is available before
+              // calling postMessage()
+              return;
+            }
+
+            registration.waiting.postMessage('skipWaiting');
+          }}
+        >
+          Refresh page
+        </button>
+      </div>
+    );
+  }
+}
+
+const mapPropsToState: MapStateToProps<*, *, *> = (state: State) => ({
+  showPrompt: state.app.promptRefresh,
+});
+
+export default connect(mapPropsToState)(RefreshPrompt);

--- a/www/src/js/views/components/RefreshPrompt.jsx
+++ b/www/src/js/views/components/RefreshPrompt.jsx
@@ -21,7 +21,7 @@ class RefreshPrompt extends PureComponent<Props> {
       <div className={classnames('alert alert-success', styles.announcement)}>
         <Refresh className={styles.backgroundIcon} />
 
-        <div className={classnames()}>
+        <div>
           <h3>A new version of NUSMods is available</h3>
           <p>Please refresh the page to get the latest version.</p>
         </div>

--- a/www/src/js/views/components/icons/index.js
+++ b/www/src/js/views/components/icons/index.js
@@ -28,6 +28,7 @@ import MessageSquare from 'react-feather/dist/icons/message-square';
 import Mail from 'react-feather/dist/icons/mail';
 import MinusSquare from 'react-feather/dist/icons/minus-square';
 import PlusSquare from 'react-feather/dist/icons/plus-square';
+import Refresh from 'react-feather/dist/icons/refresh-cw';
 import Repeat from 'react-feather/dist/icons/repeat';
 import Settings from 'react-feather/dist/icons/settings';
 import Search from 'react-feather/dist/icons/search';
@@ -63,6 +64,7 @@ export {
   MessageSquare,
   Mail,
   LinkedIn,
+  Refresh,
   Repeat,
   MinusSquare,
   PlusSquare,

--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -27,6 +27,7 @@ import CorsStats from 'views/components/cors-stats/CorsStats';
 import CorsNotification from 'views/components/cors-info/CorsNotification';
 import Announcements from 'views/components/Announcements';
 import Title from 'views/components/Title';
+import RefreshPrompt from 'views/components/RefreshPrompt';
 
 import styles from './ModulePageContent.scss';
 
@@ -77,6 +78,8 @@ export class ModulePageContentComponent extends Component<Props, State> {
         <Title description={module.ModuleDescription}>{pageTitle}</Title>
 
         <Announcements />
+
+        <RefreshPrompt />
 
         <CorsNotification />
 

--- a/www/src/js/views/timetable/TimetableContainer.jsx
+++ b/www/src/js/views/timetable/TimetableContainer.jsx
@@ -126,7 +126,7 @@ export class TimetableContainerComponent extends PureComponent<Props, State> {
         <Repeat />
 
         <div className={classnames('row', styles.row)}>
-          <div className={classnames('col-md-auto', styles.text)}>
+          <div className={classnames('col')}>
             <h3>This timetable was shared with you</h3>
             <p>
               Clicking import will <strong>replace</strong> your saved timetable with the one below.

--- a/www/src/js/views/timetable/TimetableContainer.scss
+++ b/www/src/js/views/timetable/TimetableContainer.scss
@@ -23,13 +23,7 @@
     height: 8rem;
   }
 
-  .text {
-    flex: 0 1 auto;
-  }
-
   .actions {
-    text-align: right;
-
     :global(.btn) {
       margin-left: 0.5rem;
     }
@@ -37,7 +31,6 @@
 
   @include media-breakpoint-up(md) {
     .row {
-      flex-wrap: nowrap;
       align-items: center;
       justify-content: space-between;
     }

--- a/www/src/js/views/timetable/TimetableContent.jsx
+++ b/www/src/js/views/timetable/TimetableContent.jsx
@@ -36,6 +36,7 @@ import ModulesSelectContainer from 'views/timetable/ModulesSelectContainer';
 import CorsNotification from 'views/components/cors-info/CorsNotification';
 import Announcements from 'views/components/Announcements';
 import Title from 'views/components/Title';
+import RefreshPrompt from 'views/components/RefreshPrompt';
 import Timetable from './Timetable';
 import TimetableActions from './TimetableActions';
 import TimetableModulesTable from './TimetableModulesTable';
@@ -286,6 +287,8 @@ class TimetableContent extends Component<Props, State> {
         <CorsNotification />
 
         <Announcements />
+
+        <RefreshPrompt />
 
         <div>{this.props.header}</div>
 

--- a/www/static/service-worker-notifications.js
+++ b/www/static/service-worker-notifications.js
@@ -1,0 +1,17 @@
+// Code taken from https://developers.google.com/web/tools/workbox/guides/advanced-recipes
+self.addEventListener('message', (event) => {
+  if (!event.data) {
+    return;
+  }
+
+  switch (event.data) {
+    // When the user clicks on the update button, we skipWaiting and refresh the
+    // page
+    case 'skipWaiting':
+      self.skipWaiting();
+      break;
+    default:
+      // NOOP
+      break;
+  }
+});

--- a/www/webpack/webpack.parts.js
+++ b/www/webpack/webpack.parts.js
@@ -344,6 +344,12 @@ exports.workbox = () => ({
         },
       ],
 
+      // Exclude hot reload related code in development
+      exclude: [/\.hot-update\.js(on)?$/],
+
+      // Include additional service worker code
+      importScripts: ['service-worker-notifications.js'],
+
       // Always serve index.html since we're a SPA using HTML5 history
       navigateFallback: 'index.html',
 


### PR DESCRIPTION
Mostly following this recipe on Workbox's guide https://developers.google.com/web/tools/workbox/guides/advanced-recipes#offer_a_page_reload_for_users, which itself copies from https://redfin.engineering/how-to-fix-the-refresh-button-when-using-service-workers-a8e27af6df68. The code feels very verbose but the Redfin article mentions this is about as short as you can get. Note that this does not implement point 4 in the article, which I feel is more trouble than its worth. Hopefully when service worker gets more mature this will get better. 

## Changes 

- Split off service worker bootstrapping in to its own file
- Add a PROMPT_REFRESH action and a boolean state into app 
- When the state changes to true, the `<RefreshPrompt>` component will display a alert on the top of the page in the same places as `<Announcement>` asking the user to update the app 