### PR TITLE
Stop redux logger diffing large actions

### DIFF
--- a/www/src/js/bootstrapping/configure-store.js
+++ b/www/src/js/bootstrapping/configure-store.js
@@ -33,6 +33,9 @@ export default function configureStore(defaultState?: State) {
       collapsed: true,
       duration: true,
       diff: true,
+      // Avoid diffing actions that insert a lot of stuff into the state to prevent console from lagging
+      diffPredicate: (getState, action) =>
+        !action.type.startsWith('FETCH_MODULE_LIST') && !action.type.startsWith('persist/'),
     });
     middlewares.push(logger);
   }


### PR DESCRIPTION
On Firefox Redux Logger makes starting the app really slow because it tries to diff actions that insert lots of data into the store. This PR filters those out so that Firefox doesn't lag anymore when opening the app. 