### PR TITLE
Fix Safari 9 regression due to query-string

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -114,7 +114,7 @@
     "mousetrap": "1.6.1",
     "no-scroll": "2.1.0",
     "nusmoderator": "2.1.1",
-    "query-string": "6.0.0",
+    "query-string": "5.0.0",
     "raven-for-redux": "1.3.0",
     "raven-js": "3.24.0",
     "react": "16.3.2",

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -7186,12 +7186,13 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-query-string@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.0.0.tgz#8b8f39447b73e8290d6f5e3581779218e9171142"
+query-string@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.0.0.tgz#fbdf7004b4d2aff792f9871981b7a2794f555947"
   dependencies:
     decode-uri-component "^0.2.0"
-    strict-uri-encode "^2.0.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 query-string@^4.1.0:
   version "4.3.4"
@@ -8511,10 +8512,6 @@ stream-shift@^1.0.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-convert@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
query-string@6 does not support anything other than the latest version of evergreen browsers. Downgrading to v5 fixes our current issue with Safari 9. 

We should look into setting up some sort of automated smoke test. Maybe using Browserstack. 