### PR TITLE
Fix add module action crash when module cannot be loaded

### DIFF
--- a/www/src/js/actions/timetables.js
+++ b/www/src/js/actions/timetables.js
@@ -23,10 +23,20 @@ export function addModule(semester: Semester, moduleCode: ModuleCode) {
   return (dispatch: Function, getState: GetState) =>
     dispatch(fetchModule(moduleCode)).then(() => {
       const module: Module = getState().moduleBank.modules[moduleCode];
+
+      if (!module) {
+        // TODO: Replace with better UI implementation
+        if (window.confirm(`Cannot add ${moduleCode}. Press okay to retry`)) {
+          dispatch(addModule(semester, moduleCode));
+        }
+
+        return;
+      }
+
       const lessons = getModuleTimetable(module, semester);
       const moduleLessonConfig = randomModuleLessonConfig(lessons);
 
-      return dispatch({
+      dispatch({
         type: ADD_MODULE,
         payload: {
           semester,


### PR DESCRIPTION
Fixes #704 

The issue is caused by the module not being available in module bank when the fetch module promise resolves. This happens if the module fetch failed. The promise still resolves because of the requests middleware (aside - we should rework that). 

This PR adds a quick and dirty fix using `window.confirm`. This is needed because our current notification implementation doesn't allow additional action on the notification, and I want a retry button. The retry button just dispatches the same fetch module action again. 