### PR TITLE
Add release management via Sentry CLI

### DIFF
--- a/www/scripts/promote-staging.sh
+++ b/www/scripts/promote-staging.sh
@@ -74,4 +74,15 @@ echo
 echo "Promoting..."
 npm run rsync -- $FRONTEND_PROD_DIR
 npm run rsync:export -- $TIMETABLE_ONLY_PROD_DIR
+
+# Create release
+if [ -x "$(command -v sentry-cli)" ]; then
+  echo "Creating Sentry release"
+
+  sentry-cli releases new "$PROD_COMMIT"
+  sentry-cli releases set-commits "$PROD_COMMIT" --auto
+  sentry-cli releases files "$PROD_COMMIT" upload-sourcemaps $FRONTEND_STAGING_DIR
+  sentry-cli releases finalize "$PROD_COMMIT"
+fi
+
 echo "All done!"


### PR DESCRIPTION
To improve sourcemaps in Sentry reports we can [upload our sourcemaps directly to Sentry](https://docs.sentry.io/clients/javascript/sourcemaps/#raven-js-sourcemaps) instead of having the frontend. This PR adds that to our deploy script. I've already set up Sentry CLI on our server and configured it. 