### PR TITLE
Improve offline error handling

### DIFF
--- a/www/src/js/views/AppShell.jsx
+++ b/www/src/js/views/AppShell.jsx
@@ -24,6 +24,7 @@ import GlobalSearchContainer from 'views/layout/GlobalSearchContainer';
 import Notification from 'views/components/Notification';
 import ErrorBoundary from 'views/errors/ErrorBoundary';
 import ErrorPage from 'views/errors/ErrorPage';
+import ApiError from 'views/errors/ApiError';
 import { DARK_MODE } from 'types/settings';
 import LoadingSpinner from './components/LoadingSpinner';
 import FeedbackModal from './components/FeedbackModal';
@@ -61,11 +62,7 @@ export class AppShellComponent extends Component<Props, State> {
     const { timetables } = this.props;
 
     // Retrieve module list
-    // TODO: This always re-fetch the entire modules list. Consider a better strategy for this
-    this.props.fetchModuleList().catch((error) => {
-      Raven.captureException(error);
-      this.setState({ moduleListError: error });
-    });
+    this.fetchModuleList();
 
     // Fetch the module data of the existing modules in the timetable and ensure all
     // lessons are filled
@@ -74,6 +71,14 @@ export class AppShellComponent extends Component<Props, State> {
       this.fetchTimetableModules(timetable, semester);
     });
   }
+
+  fetchModuleList = () => {
+    // TODO: This always re-fetch the entire modules list. Consider a better strategy for this
+    this.props.fetchModuleList().catch((error) => {
+      Raven.captureException(error);
+      this.setState({ moduleListError: error });
+    });
+  };
 
   fetchTimetableModules = (timetable: SemTimetableConfig, semester: Semester) => {
     this.props
@@ -95,7 +100,7 @@ export class AppShellComponent extends Component<Props, State> {
     const isDarkMode = this.props.mode === DARK_MODE;
 
     if (!isModuleListReady && this.state.moduleListError) {
-      return <ErrorPage eventId={Raven.lastEventId()} />;
+      return <ApiError dataName="module information" retry={this.fetchModuleList} />;
     }
 
     return (

--- a/www/src/js/views/AppShell.jsx
+++ b/www/src/js/views/AppShell.jsx
@@ -55,6 +55,8 @@ type State = {
 };
 
 export class AppShellComponent extends Component<Props, State> {
+  state = {};
+
   componentDidMount() {
     const { timetables } = this.props;
 

--- a/www/src/js/views/errors/ApiError.jsx
+++ b/www/src/js/views/errors/ApiError.jsx
@@ -1,0 +1,69 @@
+// @flow
+import type { Node } from 'react';
+
+import React, { PureComponent } from 'react';
+import classnames from 'classnames';
+
+import Title from 'views/components/Title';
+import styles from './ErrorPage.scss';
+
+type Props = {
+  children?: Node,
+  retry?: () => void,
+  dataName?: string,
+};
+
+export default class ApiError extends PureComponent<Props> {
+  static defaultProps = {
+    showRefresh: true,
+  };
+
+  componentDidMount() {
+    if (!navigator.onLine) {
+      window.addEventListener('online', this.onlineListener);
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('online', this.onlineListener);
+  }
+
+  onlineListener = () => {
+    if (this.props.retry && navigator.onLine) {
+      this.props.retry();
+    }
+  };
+
+  render() {
+    const { retry, dataName } = this.props;
+    const message = dataName ? `We can't load ${dataName}` : "We can't connect to NUSMods";
+
+    return (
+      <div>
+        <Title>Oh no...</Title>
+
+        <div className={styles.container}>
+          <h1 className={classnames('h2', styles.header)}>
+            <span className={styles.expr}>Oh no...</span>
+            {message}
+          </h1>
+
+          <p>This could be because</p>
+
+          <ul>
+            <li>Your computer is offline</li>
+            <li>NUSMods is down :(</li>
+          </ul>
+
+          {retry && (
+            <div>
+              <button className="btn btn-primary btn-lg" onClick={retry}>
+                Try again
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/www/src/js/views/modules/ModulePageContainer.jsx
+++ b/www/src/js/views/modules/ModulePageContainer.jsx
@@ -13,7 +13,7 @@ import type { Module, ModuleCode } from 'types/modules';
 
 import { fetchModule } from 'actions/moduleBank';
 import { retry } from 'utils/promise';
-import ErrorPage from 'views/errors/ErrorPage';
+import ApiError from 'views/errors/ApiError';
 import ModuleNotFoundPage from 'views/errors/ModuleNotFoundPage';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import { modulePage } from 'views/routes/paths';
@@ -104,9 +104,9 @@ export class ModulePageContainerComponent extends PureComponent<Props, State> {
     }
 
     // If there is an error, but module already exists, we assume module has
-    // been loaded at some point, so we just show that
+    // been loaded at some point, so we just show that instead
     if (error && !module) {
-      return <ErrorPage eventId={Raven.lastEventId()} />;
+      return <ApiError dataName="module information" retry={() => this.fetchModule(moduleCode)} />;
     }
 
     if (module && match.url !== this.canonicalUrl()) {

--- a/www/src/js/views/modules/ModulePageContainer.test.jsx
+++ b/www/src/js/views/modules/ModulePageContainer.test.jsx
@@ -13,7 +13,7 @@ import cs1010s from '__mocks__/modules/CS1010S.json';
 import ModuleNotFoundPage from 'views/errors/ModuleNotFoundPage';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import { waitFor } from 'test-utils/async';
-import ErrorPage from 'views/errors/ErrorPage';
+import ApiError from 'views/errors/ApiError';
 import { ModulePageContainerComponent } from './ModulePageContainer';
 
 const CANONICAL = '/modules/CS1010S/programming-methodology';
@@ -71,6 +71,6 @@ test('should show error if module fetch failed', async () => {
     return component.type() !== LoadingSpinner;
   });
 
-  expect(component.type()).toEqual(ErrorPage);
+  expect(component.type()).toEqual(ApiError);
   expect(fetchModule).toBeCalledWith('CS1010S');
 });


### PR DESCRIPTION
Part of #521 

This PR finally adds proper error handling for REST API errors. The new `<ApiError>` component includes a retry option and some suggestions as to why the data did not load properly. The component itself auto-retries when the app transitions from offline to online, which should solve most offline errors. 

![peek 2018-08-15 15-56](https://user-images.githubusercontent.com/445650/44185349-56275100-a146-11e8-839d-2cd82fa36eee.gif)

The error handling situation is still a bit shaky with the initial module data load for modules already on the timetable, but otherwise this should fix most of the "page never stops loading" bugs. 

