### PR TITLE
Fix Sentry release version

### DIFF
--- a/www/scripts/promote-staging.sh
+++ b/www/scripts/promote-staging.sh
@@ -79,10 +79,13 @@ npm run rsync:export -- $TIMETABLE_ONLY_PROD_DIR
 if [ -x "$(command -v sentry-cli)" ]; then
   echo "Creating Sentry release"
 
-  sentry-cli releases new "$PROD_COMMIT"
-  sentry-cli releases set-commits "$PROD_COMMIT" --auto
-  sentry-cli releases files "$PROD_COMMIT" upload-sourcemaps $FRONTEND_STAGING_DIR
-  sentry-cli releases finalize "$PROD_COMMIT"
+  # Follow the format <YYYYMMDD>-<7-char commit hash>
+  PROD_VERSION="$(date +%Y%m%d)-${PROD_COMMIT}"
+
+  sentry-cli releases new "$PROD_VERSION"
+  sentry-cli releases set-commits "$PROD_VERSION" --auto
+  sentry-cli releases files "$PROD_VERSION" upload-sourcemaps $FRONTEND_STAGING_DIR
+  sentry-cli releases finalize "$PROD_VERSION"
 fi
 
 echo "All done!"


### PR DESCRIPTION
Fixes the updates to the release script done in #1089. Part of the problem was that the token used previously didn't have correct permissions. The old script also didn't produce the correct version string. 

```
$ sentry-cli releases new "$PROD_VERSION"
Created release 20180824-26b7abb.
$ sentry-cli releases set-commits "$PROD_VERSION" --auto
+--------------------------+--------------+
| Repository               | Revision     |
+--------------------------+--------------+
| nusmodifications/nusmods | 26b7abb29851 |
+--------------------------+--------------+
$ sentry-cli releases files "$PROD_VERSION" upload-sourcemaps dist
> Analyzing 13 sources
> Adding source map references
> Uploading source maps for release 20180824-26b7abb

Source Map Upload Report
  Scripts
    ~/precache-manifest.9e934a2c281d642e735e8f05f6e12b7e.js
    ~/service-worker-notifications.js
    ~/service-worker.js
  Minified Scripts
    ~/2bd1aaccce4a54916d87.js (sourcemap at 2bd1aaccce4a54916d87.js.map)
    ~/650b22f1a84ef76707cf.js (sourcemap at 650b22f1a84ef76707cf.js.map)
    ~/68fd41d084d9ba3adb13.js (sourcemap at 68fd41d084d9ba3adb13.js.map)
    ~/app.d37394545ec67ed6d728.js (sourcemap at app.d37394545ec67ed6d728.js.map)
    ~/vendor.81a78afc2e75c9aa61e8.js (sourcemap at vendor.81a78afc2e75c9aa61e8.js.map)
  Source Maps
    ~/2bd1aaccce4a54916d87.js.map
    ~/650b22f1a84ef76707cf.js.map
    ~/68fd41d084d9ba3adb13.js.map
    ~/app.d37394545ec67ed6d728.js.map
    ~/vendor.81a78afc2e75c9aa61e8.js.map
$ sentry-cli releases finalize "$PROD_VERSION"
Finalized release 20180824-26b7abb.
``` 