### PR TITLE
Allow for one more row in vertical mode

### DIFF
--- a/www/src/js/views/timetable/TimetableDay.jsx
+++ b/www/src/js/views/timetable/TimetableDay.jsx
@@ -24,7 +24,7 @@ type Props = {
 };
 
 // Height of timetable per hour in vertical mode
-const VERTICAL_HEIGHT = 2;
+const VERTICAL_HEIGHT = 2.4;
 
 function TimetableDay(props: Props) {
   const columns = props.endingIndex - props.startingIndex;


### PR DESCRIPTION
Because of #1058, on md and xs screens sometimes week text takes two lines instead of one. This PR fixes that for vertical mode. 