### PR TITLE
Fix CloseButton click event in ModuleSelect modal 

### DIFF
--- a/www/src/js/views/timetable/ModulesSelect.jsx
+++ b/www/src/js/views/timetable/ModulesSelect.jsx
@@ -46,9 +46,15 @@ class ModulesSelect extends Component<Props, State> {
   };
 
   onBlur = () => {
-    if (!this.state.inputValue && this.state.isModalOpen) {
-      this.closeSelect();
-    }
+    // A hack to force the onBlur event to be handled after other UI events.
+    // This allows the close button in modal mode to work properly, because
+    // otherwise the blur event will fire before the click event is handled,
+    // and the click event will fire on the wrong element
+    setTimeout(() => {
+      if (!this.state.inputValue && this.state.isModalOpen) {
+        this.closeSelect();
+      }
+    }, 0);
   };
 
   onInputChange = (event) => {
@@ -189,6 +195,8 @@ class ModulesSelect extends Component<Props, State> {
       return downshiftComponent;
     }
 
+    // On smaller screens we use a modal to open the dropdown menu as a
+    // fullscreen menu
     return (
       <div>
         <button
@@ -202,6 +210,7 @@ class ModulesSelect extends Component<Props, State> {
           isOpen={!disabled && isModalOpen}
           onRequestClose={this.closeSelect}
           className={styles.modal}
+          fullscreen
         >
           <CloseButton className={styles.close} onClick={this.closeSelect} />
           {downshiftComponent}

--- a/www/src/js/views/timetable/ModulesSelect.scss
+++ b/www/src/js/views/timetable/ModulesSelect.scss
@@ -1,4 +1,5 @@
 @import '~styles/utils/modules-entry';
+
 $input-height: 2.75rem;
 $module-list-height: 13.5rem;
 
@@ -22,10 +23,6 @@ $module-list-height: 13.5rem;
 }
 
 .modal {
-  .container {
-    height: 100%;
-  }
-
   .input {
     border-width: 0 0 1px;
     border-radius: 0;
@@ -39,21 +36,6 @@ $module-list-height: 13.5rem;
   z-index: 1;
   width: $input-height;
   height: $input-height;
-}
-
-// Override offsets in Modal.scss
-div > .modal {
-  height: 100%;
-
-  @include media-breakpoint-down(xs) {
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    max-width: 100%;
-    max-height: 100%;
-    padding: 0;
-  }
 }
 
 .selectList {


### PR DESCRIPTION
Closes #1097. 

The cause of this is the onBlur handler on the form input. When the close button is clicked, the blur event handler fires first, which causes the modal to close. *Then* when the click event fires, it fires on the element underneath the close button since the modal is now closed. 

The current fix is to add a 0ms timeout to the blur event handler, so the event is effectively pushed to fires after any UI events that's occurring at the same time. I don't really like it, so if you guys have any better suggestions I'm open to it. 