### PR TITLE
Create BingSiteAuth.xml

### DIFF
--- a/www/static/BingSiteAuth.xml
+++ b/www/static/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>F9BA2073E11605F48E6FAEED25980A72</user>
+</users>


### PR DESCRIPTION
Tried to search for NUS mods on DuckDuckGo, and to my shock and horror :scream: , NUSMods doesn't seem to be crawled - most likely because it is a SPA. Since DDG uses Bing data, we're going to need to add NUSMods sitemap to Bing, so I'm adding an auth page to our site, similar to that for Google. 