### PR TITLE
Turn off autocomplete for module and venue search box, fixes #672

### DIFF
--- a/www/src/js/views/components/SearchBox.jsx
+++ b/www/src/js/views/components/SearchBox.jsx
@@ -100,6 +100,7 @@ export default class SearchBox extends PureComponent<Props, State> {
             id="search-box"
             className="form-control form-control-lg"
             type="search"
+            autoComplete="off"
             ref={this.searchElement}
             value={this.state.searchTerm}
             onChange={this.onInput}


### PR DESCRIPTION
Fixes #672 by setting `autocomplete="off"` in the `SearchBox` component. 