### PR TITLE
Fix select font color under Safari Mobile

### DIFF
--- a/www/.stylelintrc.js
+++ b/www/.stylelintrc.js
@@ -3,6 +3,8 @@ module.exports = {
   plugins: ['stylelint-order'],
   defaultSeverity: process.env.NODE_ENV === 'production' ? 'error' : 'warning',
   rules: {
+    // Prettier is used for SCSS styling now, so these are unnecessary
+    'declaration-colon-newline-after': null,
     'at-rule-empty-line-before': null,
     'at-rule-no-unknown': null,
     // Disabled as it's returning many false positives.

--- a/www/src/styles/components/select.scss
+++ b/www/src/styles/components/select.scss
@@ -1,0 +1,14 @@
+// Mobile Safari doesn't allow styling <select> background unless we use
+// -webkit-appearance: none. That property removes all native styling, so
+// we need to put back the dropdown arrow, which is what the SVG background
+// is for
+body.mobile-safari {
+  select,
+  select:focus {
+    padding-right: 2rem;
+    background: transparent
+      url("data:image/svg+xml;utf8,<svg fill='rgb(170, 170, 170)' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>")
+      no-repeat top 4px right 4px;
+    -webkit-appearance: none;
+  }
+}

--- a/www/src/styles/components/select.scss
+++ b/www/src/styles/components/select.scss
@@ -8,7 +8,7 @@ body.mobile-safari {
     padding-right: 2rem;
     background: transparent
       url("data:image/svg+xml;utf8,<svg fill='rgb(170, 170, 170)' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>")
-      no-repeat top 4px right 4px;
+      no-repeat center right 4px;
     -webkit-appearance: none;
   }
 }

--- a/www/src/styles/main.scss
+++ b/www/src/styles/main.scss
@@ -29,6 +29,7 @@
 @import 'components/sentry';
 @import 'components/buttons';
 @import 'components/kbd';
+@import 'components/select';
 
 // Pages
 @import 'pages/module-finder';

--- a/www/src/styles/utils/css-variables.scss
+++ b/www/src/styles/utils/css-variables.scss
@@ -74,16 +74,3 @@ body.mode-dark {
     --workload-#{$name}-color: #{darken($color, 30)};
   }
 }
-
-body.mobile-safari {
-  & select,
-  & select:focus {
-    padding-right: 2rem;
-    color: $gray-light;
-    background: transparent;
-    background-image: url("data:image/svg+xml;utf8,<svg fill='rgb(170, 170, 170)' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
-    background-position: top 4px right 4px;
-    background-repeat: no-repeat;
-    -webkit-appearance: none;
-  }
-}


### PR DESCRIPTION
Fixes the issue with the previous PR #1189. I would have merged this into master already, but I want to double check, and the easiest way to get a preview build that my iPad can access is through Netlify 