### PR TITLE
Reload Disqus when night mode is activated/deactivated

### DIFF
--- a/www/src/js/types/views.js
+++ b/www/src/js/types/views.js
@@ -51,10 +51,10 @@ export type PageRangeDiff = {
 
 export type OnPageChange = (PageRangeDiff) => void;
 
-export type DisqusConfig = {
+export type DisqusConfig = {|
   identifier: string,
   url: string,
   title: string,
-};
+|};
 
 export type ModuleTableOrder = 'exam' | 'mc' | 'code';

--- a/www/src/js/views/components/disqus/DisqusComments.jsx
+++ b/www/src/js/views/components/disqus/DisqusComments.jsx
@@ -9,12 +9,13 @@ import type { State } from 'reducers';
 import config from 'config';
 import insertScript from 'utils/insertScript';
 
-type Props = DisqusConfig & {
+type Props = {|
+  ...DisqusConfig,
   // Disqus autodetects page background color so that its own font color has
   // enough contrast to be read, but only when the widget is loaded, so we use
   // this to force the widget after night mode is activated or deactivated
   mode: Mode,
-};
+|};
 
 const SCRIPT_ID = 'dsq-embed-scr';
 
@@ -25,6 +26,8 @@ class DisqusComments extends PureComponent<Props> {
 
   componentDidUpdate(prevProps: Props) {
     // Wait a bit for the page colors to change before reloading instance
+    // 2 second delay is found empirically, and is longer than necessary to
+    // account for lag is slower user agents
     if (prevProps.mode !== this.props.mode) {
       setTimeout(this.loadInstance, 2000);
     } else {

--- a/www/src/js/views/components/disqus/DisqusComments.jsx
+++ b/www/src/js/views/components/disqus/DisqusComments.jsx
@@ -2,23 +2,37 @@
 
 import type { DisqusConfig } from 'types/views';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+
+import type { Mode } from 'types/settings';
+import type { State } from 'reducers';
 import config from 'config';
 import insertScript from 'utils/insertScript';
 
-type Props = DisqusConfig;
+type Props = DisqusConfig & {
+  // Disqus autodetects page background color so that its own font color has
+  // enough contrast to be read, but only when the widget is loaded, so we use
+  // this to force the widget after night mode is activated or deactivated
+  mode: Mode,
+};
 
 const SCRIPT_ID = 'dsq-embed-scr';
 
-export default class DisqusComments extends PureComponent<Props> {
+class DisqusComments extends PureComponent<Props> {
   componentDidMount() {
     this.loadInstance();
   }
 
-  componentDidUpdate() {
-    this.loadInstance();
+  componentDidUpdate(prevProps: Props) {
+    // Wait a bit for the page colors to change before reloading instance
+    if (prevProps.mode !== this.props.mode) {
+      setTimeout(this.loadInstance, 2000);
+    } else {
+      this.loadInstance();
+    }
   }
 
-  loadInstance() {
+  loadInstance = () => {
     if (window.DISQUS) {
       // See https://help.disqus.com/customer/portal/articles/472107
       window.DISQUS.reset({
@@ -33,7 +47,7 @@ export default class DisqusComments extends PureComponent<Props> {
 
       insertScript(`https://${config.disqusShortname}.disqus.com/embed.js`, SCRIPT_ID, true);
     }
-  }
+  };
 
   getDisqusConfig() {
     // Disqus is configured using a function that modifies 'this', so we cannot use
@@ -52,3 +66,7 @@ export default class DisqusComments extends PureComponent<Props> {
     return <div id="disqus_thread" />;
   }
 }
+
+export default connect((state: State) => ({
+  mode: state.settings.mode,
+}))(DisqusComments);


### PR DESCRIPTION
Disqus autodetect page font color and sets its own font colors appropriately. However this fails if the page suddenly changes colors, which happens if the user switches on/off night mode. This PR adds a bit of logic that forces the comment widget to reload if that happens. Apparently this is the only reliable way I can find - even though this page https://help.disqus.com/installation/disqus-appearance-tweaks claims the script uses CSS font color to determine the widget theme, I can't get it to work. 

Instead, the component just uses a constant 2s delay, which is found through experimentation. A bit dirty, and may not work well in all cases, but it seems good enough for now. 