### PR TITLE
Find venue button uses the current time when clicked

### DIFF
--- a/www/src/js/views/venues/VenuesContainer.jsx
+++ b/www/src/js/views/venues/VenuesContainer.jsx
@@ -76,7 +76,10 @@ export class VenuesContainerComponent extends Component<Props, State> {
       loading: true,
       venues: null,
       searchTerm: params.q || '',
+      pristineSearchOptions: isAvailabilityEnabled,
     };
+
+    this.onFindFreeRoomsClicked = this.onFindFreeRoomsClicked.bind(this);
   }
 
   componentDidMount() {
@@ -95,6 +98,16 @@ export class VenuesContainerComponent extends Component<Props, State> {
     }
   }
 
+  onFindFreeRoomsClicked() {
+    const { pristineSearchOptions, searchOptions, isAvailabilityEnabled } = this.state;
+    const newSearchOptions = pristineSearchOptions ? defaultSearchOptions() : searchOptions;
+    const stateUpdate = {
+      isAvailabilityEnabled: !isAvailabilityEnabled,
+      searchOptions: newSearchOptions,
+    };
+    this.setState({ ...stateUpdate });
+  }
+
   onClearVenueSelect = () =>
     this.props.history.push({
       ...this.props.history.location,
@@ -109,7 +122,10 @@ export class VenuesContainerComponent extends Component<Props, State> {
 
   onAvailabilityUpdate = (searchOptions: VenueSearchOptions) => {
     if (!isEqual(searchOptions, this.state.searchOptions)) {
-      this.setState({ searchOptions });
+      this.setState({
+        searchOptions,
+        pristineSearchOptions: false, // user changed searchOptions
+      });
     }
   };
 
@@ -174,7 +190,7 @@ export class VenuesContainerComponent extends Component<Props, State> {
             styles.availabilityToggle,
             isAvailabilityEnabled ? 'btn-primary' : 'btn-outline-primary',
           )}
-          onClick={() => this.setState({ isAvailabilityEnabled: !isAvailabilityEnabled })}
+          onClick={this.onFindFreeRoomsClicked}
         >
           <Clock className="svg" /> Find free rooms
         </button>

--- a/www/src/js/views/venues/VenuesContainer.jsx
+++ b/www/src/js/views/venues/VenuesContainer.jsx
@@ -77,10 +77,8 @@ export class VenuesContainerComponent extends Component<Props, State> {
       loading: true,
       venues: null,
       searchTerm: params.q || '',
-      pristineSearchOptions: isAvailabilityEnabled,
+      pristineSearchOptions: !isAvailabilityEnabled,
     };
-
-    this.onFindFreeRoomsClicked = this.onFindFreeRoomsClicked.bind(this);
   }
 
   componentDidMount() {
@@ -99,7 +97,7 @@ export class VenuesContainerComponent extends Component<Props, State> {
     }
   }
 
-  onFindFreeRoomsClicked() {
+  onFindFreeRoomsClicked = () => {
     const { pristineSearchOptions, searchOptions, isAvailabilityEnabled } = this.state;
     const newSearchOptions = pristineSearchOptions ? defaultSearchOptions() : searchOptions;
     const stateUpdate = {
@@ -107,7 +105,7 @@ export class VenuesContainerComponent extends Component<Props, State> {
       searchOptions: newSearchOptions,
     };
     this.setState({ ...stateUpdate });
-  }
+  };
 
   onClearVenueSelect = () =>
     this.props.history.push({

--- a/www/src/js/views/venues/VenuesContainer.jsx
+++ b/www/src/js/views/venues/VenuesContainer.jsx
@@ -99,10 +99,16 @@ export class VenuesContainerComponent extends Component<Props, State> {
 
   onFindFreeRoomsClicked = () => {
     const { pristineSearchOptions, isAvailabilityEnabled } = this.state;
-    const stateUpdate = { isAvailabilityEnabled: !isAvailabilityEnabled };
+    const stateUpdate: $Shape<State> = { isAvailabilityEnabled: !isAvailabilityEnabled };
+
+    // Only reset search options if the user has never changed it, and if the
+    // search box is being opened. By resetting the option when the box is opened,
+    // the time when the box is opened will be used, instead of the time when the
+    // page is loaded
     if (pristineSearchOptions && !isAvailabilityEnabled) {
       stateUpdate.searchOptions = defaultSearchOptions();
     }
+
     this.setState(stateUpdate);
   };
 

--- a/www/src/js/views/venues/VenuesContainer.jsx
+++ b/www/src/js/views/venues/VenuesContainer.jsx
@@ -98,12 +98,11 @@ export class VenuesContainerComponent extends Component<Props, State> {
   }
 
   onFindFreeRoomsClicked = () => {
-    const { pristineSearchOptions, searchOptions, isAvailabilityEnabled } = this.state;
-    const newSearchOptions = pristineSearchOptions ? defaultSearchOptions() : searchOptions;
-    const stateUpdate = {
-      isAvailabilityEnabled: !isAvailabilityEnabled,
-      searchOptions: newSearchOptions,
-    };
+    const { pristineSearchOptions, isAvailabilityEnabled } = this.state;
+    const stateUpdate = { isAvailabilityEnabled: !isAvailabilityEnabled };
+    if (pristineSearchOptions && !isAvailabilityEnabled) {
+      stateUpdate.searchOptions = defaultSearchOptions();
+    }
     this.setState(stateUpdate);
   };
 

--- a/www/src/js/views/venues/VenuesContainer.jsx
+++ b/www/src/js/views/venues/VenuesContainer.jsx
@@ -104,7 +104,7 @@ export class VenuesContainerComponent extends Component<Props, State> {
       isAvailabilityEnabled: !isAvailabilityEnabled,
       searchOptions: newSearchOptions,
     };
-    this.setState({ ...stateUpdate });
+    this.setState(stateUpdate);
   };
 
   onClearVenueSelect = () =>

--- a/www/src/js/views/venues/VenuesContainer.jsx
+++ b/www/src/js/views/venues/VenuesContainer.jsx
@@ -50,6 +50,7 @@ type State = {|
   searchTerm: string,
   isAvailabilityEnabled: boolean,
   searchOptions: VenueSearchOptions,
+  pristineSearchOptions: boolean,
 |};
 
 const pageHead = <Title>Venues</Title>;


### PR DESCRIPTION
### Few things about my PR

- I chose to implement my function as a separate named function 'cause I believe it would have been _too long_ to be a arrow function
- ~I chose to implement a proper property function instead of an arrow function because me and some [other people](https://medium.com/@charpeni/arrow-functions-in-class-properties-might-not-be-as-great-as-we-think-3b3551c440b1) believe it is _better_~ apparently I can't bind class methods so I declared it as an arrow function instead.

### User flows
- User enters the page `/venues` with no parameters 
    -> clicks the "Find free rooms" button right away: search options set to current time (time he clicked the button)
    -> waits a few hours then clicks "Find free rooms": search options set to current time (time he clicked the button
    -> clicks the "Find free rooms" button right away waits a few hours then clicks it again: both calls are made with the search options set to the time the user clicked the button

If the user changes manually the search options, from that moment on, the search options will always be set to those chosen by the user. So unless he changes the options manually or refreshes the page back to `venues` he won't lose his precious parameters.
- User enters the page `/venues?day=0&duration=1&time=12` with parameters already set

whenever he clicks on the "Find free rooms" button the search options are going to be set to the parameters unless he manually changes the options when the box is open

Hopefully I did not confuse the reviewer with these "use cases". Anyway, I'm available for changes and clarifications.

this PR takes care of #1219 