### PR TITLE
Enable Mamoto analytics

### DIFF
--- a/www/src/js/bootstrapping/mamoto.js
+++ b/www/src/js/bootstrapping/mamoto.js
@@ -1,0 +1,34 @@
+// @flow
+
+import type { RouterHistory } from 'react-router-dom';
+import insertScript from 'utils/insertScript';
+import type { Tracker } from 'types/views';
+
+let tracker: ?Tracker; // eslint-disable-line import/no-mutable-exports
+
+// Code mostly adopted from https://github.com/AmazingDreams/vue-matomo
+function configureMamoto(history: RouterHistory) {
+  const siteId = '1';
+  const host = 'https://analytics.nusmods.com';
+  const scriptSrc = `${host}/piwik.js`;
+
+  insertScript(scriptSrc, { defer: true, async: true }).then(() => {
+    // Save a non-null instance of the tracker
+    const mamoto: Tracker = window.Piwik.getTracker(`${host}/piwik.php`, siteId);
+    tracker = mamoto;
+
+    // Track initial page view
+    mamoto.trackPageView();
+
+    history.listen((location, action) => {
+      if (action === 'PUSH') {
+        // Wait a bit for the page title to update
+        setTimeout(() => {
+          mamoto.trackPageView();
+        }, 100);
+      }
+    });
+  });
+}
+
+export { tracker, configureMamoto };

--- a/www/src/js/types/views.js
+++ b/www/src/js/types/views.js
@@ -58,3 +58,64 @@ export type DisqusConfig = {|
 |};
 
 export type ModuleTableOrder = 'exam' | 'mc' | 'code';
+
+// Incomplete typing of Mamoto's API. If you need something not here, feel free
+// to declare the typing here.
+// Full list: https://developer.matomo.org/api-reference/tracking-javascript
+export type Tracker = {
+  /**
+   * Using the Tracker Object
+   */
+  // Logs an event with an event category (Videos, Music, Games...),
+  // an event action (Play, Pause, Duration, Add Playlist, Downloaded, Clicked...),
+  // and an optional event name and optional numeric value.
+  trackEvent: (category: string, action: string, name?: string, value?: number) => void,
+
+  // Logs a visit to this page
+  trackPageView: (pageTitle?: string) => void,
+
+  // Log an internal site search for a specific keyword, in an optional category,
+  // specifying the optional count of search results in the page.
+  trackSiteSearch: (keyword: string, category?: string, resultsCount?: number) => void,
+
+  // Manually log a conversion for the numeric goal ID, with an optional numeric
+  // custom revenue customRevenue.
+  trackGoal: (idGoal: string, customRevenue?: number) => void,
+
+  // Manually log a click from your own code. url is the full URL which is to be
+  // tracked as a click. linkType can either be 'link' for an outlink or 'download' for a download.
+  trackLink: (url: string, linkType: 'link' | 'download') => void,
+
+  trackAllContentImpressions: () => void,
+  trackVisibleContentImpressions: (checkOnScroll: boolean, timeIntervalInMs: number) => void,
+
+  // Scans the given DOM node and its children for content blocks and tracks an
+  // impression for them if no impression was already tracked for it.
+  trackContentImpressionsWithinNode: (domNode: Element) => void,
+
+  enableHeartBeatTimer: (delayInSeconds: number) => void,
+  enableCrossDomainLinking: () => void,
+  setCrossDomainLinkingTimeout: (timeout: number) => void,
+
+  /**
+   * Managing Consent
+   */
+  // By default the Matomo tracker assumes consent to tracking. To change this behavior
+  // so nothing is tracked until a user consents, you must call requireConsent.
+  requireConsent: () => void,
+
+  // Marks that the current user has consented. The consent is one-time only, so in a
+  // subsequent browser session, the user will have to consent again. To remember consent,
+  // see the method below: rememberConsentGiven.
+  setConsentGiven: () => void,
+
+  // Marks that the current user has consented, and remembers this consent through a
+  // browser cookie. The next time the user visits the site, Matomo will remember that
+  // they consented, and track them. If you call this method, you do not need to
+  // call setConsentGiven.
+  rememberConsentGiven: (hoursToExpire: number) => void,
+
+  // Removes a user's consent, both if the consent was one-time only and if the consent was
+  // remembered. After calling this method, the user will have to consent again in order to be tracked.
+  forgetConsentGiven: () => void,
+};

--- a/www/src/js/utils/insertScript.js
+++ b/www/src/js/utils/insertScript.js
@@ -1,12 +1,25 @@
 // @flow
 
-export default function insertScript(scriptSrc: string, scriptId: string, scriptAsync: boolean) {
-  const script = window.document.createElement('script');
-  script.src = scriptSrc;
-  script.id = scriptId;
-  script.async = scriptAsync;
+type ScriptOptions = {
+  id?: string,
+  async?: boolean,
+  defer?: boolean,
+};
 
-  if (window.document.body) {
-    window.document.body.appendChild(script);
-  }
+export default function insertScript(src: string, options: ScriptOptions = {}): Promise<*> {
+  return new Promise((resolve, reject) => {
+    const script = window.document.createElement('script');
+    script.src = src;
+
+    Object.keys(options).forEach((option) => {
+      script[option] = options[option];
+    });
+
+    script.onload = resolve;
+    script.onerror = reject;
+
+    if (window.document.body) {
+      window.document.body.appendChild(script);
+    }
+  });
 }

--- a/www/src/js/utils/insertScript.test.js
+++ b/www/src/js/utils/insertScript.test.js
@@ -9,9 +9,9 @@ describe(insertScript, () => {
 
     window.document.body.appendChild = jest.fn();
 
-    insertScript('https://example.com/random.js', 'NUSMods', true);
-    insertScript('https://example.com/random.js', 'NUSMods', true);
-    insertScript('https://example.com/random.js', 'NUSMods', true);
+    insertScript('https://example.com/random.js');
+    insertScript('https://example.com/random.js', { async: true });
+    insertScript('https://example.com/random.js', { id: 'nusmods', defer: true });
 
     expect(window.document.createElement).toHaveBeenCalledTimes(3);
     expect(window.document.body.appendChild).toHaveBeenCalledTimes(3);

--- a/www/src/js/views/AppShell.jsx
+++ b/www/src/js/views/AppShell.jsx
@@ -26,6 +26,7 @@ import Notification from 'views/components/notfications/Notification';
 import ErrorBoundary from 'views/errors/ErrorBoundary';
 import ErrorPage from 'views/errors/ErrorPage';
 import ApiError from 'views/errors/ApiError';
+import { configureMamoto } from 'bootstrapping/mamoto';
 import { DARK_MODE } from 'types/settings';
 import LoadingSpinner from './components/LoadingSpinner';
 import FeedbackModal from './components/FeedbackModal';
@@ -71,6 +72,9 @@ export class AppShellComponent extends Component<Props, State> {
       const semester = Number(semesterString);
       this.fetchTimetableModules(timetable, semester);
     });
+
+    // Enable Mamoto analytics
+    configureMamoto(this.props.history);
   }
 
   isMobileIos = isMobileIos();


### PR DESCRIPTION
Part of #1074 

Mamoto (formerly Piwik) is a self-hosted analytics service that is more privacy friendly, allowing us better control over user data while also making it more open. The service is currently running at https://analytics.nusmods.com/. 

This PR adds Mamoto tracking, and we'll see if it works as expected. If it does, we'll probably keep GA for one release, then remove it in the next to ensure we're not missing anything. 