### PR TITLE
Prevent "/" character from being entered into search bar when shortcut is used

### DIFF
--- a/www/src/js/views/components/KeyboardShortcuts.jsx
+++ b/www/src/js/views/components/KeyboardShortcuts.jsx
@@ -66,9 +66,12 @@ export class KeyboardShortcutsComponent extends PureComponent<Props, State> {
       history.push('/settings');
     });
 
-    this.bind('/', NAVIGATION, 'Open global search', () => {
+    this.bind('/', NAVIGATION, 'Open global search', (e) => {
       if (ComponentMap.globalSearchInput) {
         ComponentMap.globalSearchInput.focus();
+
+        // Prevents the '/' character from being entered into the global search bar
+        e.preventDefault();
       }
     });
 
@@ -116,7 +119,7 @@ export class KeyboardShortcutsComponent extends PureComponent<Props, State> {
 
   closeModal = () => this.setState({ helpShown: false });
 
-  bind(key: Shortcut, section: Section, description: string, action: () => void) {
+  bind(key: Shortcut, section: Section, description: string, action: (e: Event) => void) {
     this.shortcuts.push({ key, description, section });
 
     Mousetrap.bind(key, action);


### PR DESCRIPTION
When using the "/" shortcut, the "/" character is entered into the search box. This PR uses `e.preventDefault()` to stop that from happening. 