### PR TITLE
Fix only 30 contributors displaying on the contributors page

### DIFF
--- a/www/src/js/views/static/ContributorsContainer.jsx
+++ b/www/src/js/views/static/ContributorsContainer.jsx
@@ -8,7 +8,8 @@ import ExternalLink from 'views/components/ExternalLink';
 
 import StaticPage from './StaticPage';
 
-const CONTRIBUTORS_URL = 'https://api.github.com/repos/NUSModifications/NUSMods/contributors?per_page=100';
+const CONTRIBUTORS_URL =
+  'https://api.github.com/repos/NUSModifications/NUSMods/contributors?per_page=100';
 
 type Props = {};
 

--- a/www/src/js/views/static/ContributorsContainer.jsx
+++ b/www/src/js/views/static/ContributorsContainer.jsx
@@ -8,7 +8,7 @@ import ExternalLink from 'views/components/ExternalLink';
 
 import StaticPage from './StaticPage';
 
-const CONTRIBUTORS_URL = 'https://api.github.com/repos/NUSModifications/NUSMods/contributors';
+const CONTRIBUTORS_URL = 'https://api.github.com/repos/NUSModifications/NUSMods/contributors?per_page=100';
 
 type Props = {};
 


### PR DESCRIPTION
Added "?per_page=100" to CONTRIBUTORS_URL so it returns more than the first 30 contributors.

Fixes #1237 