### PR TITLE
Fix module page state and scroll to top behavior 

### DIFF
--- a/www/src/js/views/modules/ModulePageContainer.jsx
+++ b/www/src/js/views/modules/ModulePageContainer.jsx
@@ -121,7 +121,10 @@ export class ModulePageContainerComponent extends PureComponent<Props, State> {
     }
 
     if (module && ModulePageContent) {
-      return <ModulePageContent moduleCode={moduleCode} />;
+      // Unique key forces component to remount whenever the user moves to
+      // a new module. This allows the internal state (eg. currently selected
+      // timetable semester) of <ModulePageContent> to be consistent
+      return <ModulePageContent key={moduleCode} moduleCode={moduleCode} />;
     }
 
     return <LoadingSpinner />;

--- a/www/src/js/views/modules/ModulePageContent.jsx
+++ b/www/src/js/views/modules/ModulePageContent.jsx
@@ -10,7 +10,7 @@ import type { Module } from 'types/modules';
 import config from 'config';
 import { formatExamDate, getSemestersOffered } from 'utils/modules';
 import { intersperse } from 'utils/array';
-import { BULLET, scrollToHash } from 'utils/react';
+import { BULLET } from 'utils/react';
 import { NAVTAB_HEIGHT } from 'views/layout/Navtabs';
 import ModuleTree from 'views/modules/ModuleTree';
 import LinkModuleCodes from 'views/components/LinkModuleCodes';
@@ -28,6 +28,7 @@ import CorsNotification from 'views/components/cors-info/CorsNotification';
 import Announcements from 'views/components/notfications/Announcements';
 import Title from 'views/components/Title';
 import RefreshPrompt from 'views/components/notfications/RefreshPrompt';
+import ScrollToTop from 'views/components/ScrollToTop';
 
 import styles from './ModulePageContent.scss';
 
@@ -54,10 +55,6 @@ export class ModulePageContentComponent extends Component<Props, State> {
     isMenuOpen: false,
   };
 
-  componentDidMount() {
-    scrollToHash();
-  }
-
   toggleMenu = (isMenuOpen: boolean) => this.setState({ isMenuOpen });
 
   render() {
@@ -82,6 +79,8 @@ export class ModulePageContentComponent extends Component<Props, State> {
         <RefreshPrompt />
 
         <CorsNotification />
+
+        <ScrollToTop onComponentDidMount scrollToHash />
 
         <div className="row">
           <div className="col-md-9">


### PR DESCRIPTION
This bugfix uses [this technique](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key) to force a full remount whenever module code changes. This resolves several subtle issue with the page and its subcomponents not resetting correctly when the module code changes. This seems simpler than using `getDerivedStateFromProps`, as recommended in the post. 

Also fix a minor bug with the scroll to top behavior of the page, again taking advantage of the full remount to make `<ScrollToTop>` work. 