### PR TITLE
Validate shared module codes before trying to fetch them

### DIFF
--- a/www/src/js/actions/timetables.js
+++ b/www/src/js/actions/timetables.js
@@ -162,10 +162,13 @@ export function validateTimetable(semester: Semester) {
 }
 
 export function fetchTimetableModules(timetables: SemTimetableConfig[]) {
-  return (dispatch: Function) => {
+  return (dispatch: Function, getState: GetState) => {
     const moduleCodes = new Set(flatMap(timetables, Object.keys));
+    const validModuleCodes = getState().moduleBank.moduleCodes;
     return Promise.all(
-      Array.from(moduleCodes).map((moduleCode) => dispatch(fetchModule(moduleCode))),
+      Array.from(moduleCodes)
+        .filter((moduleCode) => validModuleCodes[moduleCode])
+        .map((moduleCode) => dispatch(fetchModule(moduleCode))),
     );
   };
 }


### PR DESCRIPTION
Resolves #1175

This makes sure we only fetch valid modules. But there's an issue: if there are any foreign query params, the TimetableContainer doesn't stop showing the loading spinner, even after we have fetched the valid modules.