### PR TITLE
Fix timetable cell linked hover on touch devices

### DIFF
--- a/www/src/js/views/timetable/TimetableCell.jsx
+++ b/www/src/js/views/timetable/TimetableCell.jsx
@@ -50,8 +50,10 @@ function TimetableCell(props: Props) {
         hover,
       })}
       style={props.style}
-      onMouseEnter={() => onHover && onHover(getHoverLesson(lesson))}
-      onMouseLeave={() => onHover && onHover(null)}
+      onMouseEnter={() => onHover?.(getHoverLesson(lesson))}
+      onTouchStart={() => onHover?.(getHoverLesson(lesson))}
+      onMouseLeave={() => onHover?.(null)}
+      onTouchEnd={() => onHover?.(null)}
       {...conditionalProps}
     >
       <div className={styles.cellContainer}>


### PR DESCRIPTION
On touch devices, linked lessons don't have their hover styles applied correctly because we only use `onMouseEnter/Leave`. This PR fixes that by adding `onTouchStart/End` too 