### PR TITLE
[#1289] Add support for detecting and matching OS dark mode

### DIFF
--- a/www/src/js/actions/settings.js
+++ b/www/src/js/actions/settings.js
@@ -43,6 +43,13 @@ export function toggleMode(): FSA {
     payload: null,
   };
 }
+export const ENABLE_OS_MODE: string = 'ENABLE_OS_MODE';
+export function enableOsMode(mode: Mode): FSA {
+  return {
+    type: ENABLE_OS_MODE,
+    payload: mode,
+  };
+}
 
 export const DISMISS_CORS_NOTIFICATION = 'DISMISS_CORS_NOTIFICATION';
 export function dismissCorsNotification(round: string): FSA {

--- a/www/src/js/actions/settings.js
+++ b/www/src/js/actions/settings.js
@@ -43,6 +43,15 @@ export function toggleMode(): FSA {
     payload: null,
   };
 }
+
+export const TOGGLE_MODE_OS: string = 'TOGGLE_MODE_OS';
+export function toggleModeOs(mode: Mode): FSA {
+  return {
+    type: TOGGLE_MODE_OS,
+    payload: mode,
+  };
+}
+
 export const ENABLE_OS_MODE: string = 'ENABLE_OS_MODE';
 export function enableOsMode(mode: Mode): FSA {
   return {

--- a/www/src/js/actions/settings.js
+++ b/www/src/js/actions/settings.js
@@ -37,10 +37,10 @@ export function selectMode(mode: Mode): FSA {
 }
 
 export const TOGGLE_MODE: string = 'TOGGLE_MODE';
-export function toggleMode(): FSA {
+export function toggleMode(mode: Mode): FSA {
   return {
     type: TOGGLE_MODE,
-    payload: null,
+    payload: mode || null,
   };
 }
 

--- a/www/src/js/reducers/settings.js
+++ b/www/src/js/reducers/settings.js
@@ -16,10 +16,11 @@ import {
   TOGGLE_CORS_NOTIFICATION_GLOBALLY,
   SET_MODULE_TABLE_SORT,
   TOGGLE_BETA_TESTING_STATUS,
+  ENABLE_OS_MODE,
 } from 'actions/settings';
 import { SET_EXPORTED_DATA } from 'actions/export';
 import { DIMENSIONS, withTracker } from 'bootstrapping/mamoto';
-import { LIGHT_MODE, DARK_MODE } from 'types/settings';
+import { LIGHT_MODE, DARK_MODE, OS_MODE } from 'types/settings';
 import config from 'config';
 
 export const defaultCorsNotificationState = {
@@ -29,6 +30,7 @@ export const defaultCorsNotificationState = {
 };
 
 const defaultSettingsState: SettingsState = {
+  osEnabled: false,
   newStudent: false,
   faculty: '',
   mode: LIGHT_MODE,
@@ -67,7 +69,12 @@ function settings(state: SettingsState = defaultSettingsState, action: FSA): Set
           enabled: { $set: action.payload.enabled },
         },
       });
-
+    case ENABLE_OS_MODE:
+      return {
+        ...state,
+        mode: action.payload,
+        osEnabled: true,
+      };
     case DISMISS_CORS_NOTIFICATION:
       return update(state, {
         corsNotification: {

--- a/www/src/js/reducers/settings.js
+++ b/www/src/js/reducers/settings.js
@@ -11,6 +11,7 @@ import {
   SELECT_FACULTY,
   SELECT_MODE,
   TOGGLE_MODE,
+  TOGGLE_MODE_OS,
   DISMISS_CORS_NOTIFICATION,
   ENABLE_CORS_NOTIFICATION,
   TOGGLE_CORS_NOTIFICATION_GLOBALLY,
@@ -56,13 +57,20 @@ function settings(state: SettingsState = defaultSettingsState, action: FSA): Set
       return {
         ...state,
         mode: action.payload,
+        osEnabled: false,
       };
     case TOGGLE_MODE:
       return {
         ...state,
-        mode: state.mode === LIGHT_MODE ? DARK_MODE : LIGHT_MODE,
+        mode: state.osEnabled || state.mode === LIGHT_MODE ? DARK_MODE : LIGHT_MODE,
+        osEnabled: false,
       };
-
+    case TOGGLE_MODE_OS:
+      return {
+        ...state,
+        mode: !state.osEnabled && state.mode === LIGHT_MODE ? action.payload : LIGHT_MODE,
+        osEnabled: !state.osEnabled && state.mode === LIGHT_MODE,
+      };
     case TOGGLE_CORS_NOTIFICATION_GLOBALLY:
       return update(state, {
         corsNotification: {
@@ -72,8 +80,8 @@ function settings(state: SettingsState = defaultSettingsState, action: FSA): Set
     case ENABLE_OS_MODE:
       return {
         ...state,
-        mode: action.payload,
         osEnabled: true,
+        mode: action.payload,
       };
     case DISMISS_CORS_NOTIFICATION:
       return update(state, {

--- a/www/src/js/reducers/settings.js
+++ b/www/src/js/reducers/settings.js
@@ -21,7 +21,7 @@ import {
 } from 'actions/settings';
 import { SET_EXPORTED_DATA } from 'actions/export';
 import { DIMENSIONS, withTracker } from 'bootstrapping/mamoto';
-import { LIGHT_MODE, DARK_MODE } from 'types/settings';
+import { LIGHT_MODE, DARK_MODE, OS_MODE } from 'types/settings';
 import config from 'config';
 
 export const defaultCorsNotificationState = {
@@ -31,9 +31,9 @@ export const defaultCorsNotificationState = {
 };
 
 const defaultSettingsState: SettingsState = {
-  osEnabled: false,
   newStudent: false,
   faculty: '',
+  userPreference: LIGHT_MODE,
   mode: LIGHT_MODE,
   hiddenInTimetable: [],
   corsNotification: defaultCorsNotificationState,
@@ -57,19 +57,19 @@ function settings(state: SettingsState = defaultSettingsState, action: FSA): Set
       return {
         ...state,
         mode: action.payload,
-        osEnabled: false,
+        userPreference: action.payload,
       };
     case TOGGLE_MODE:
       return {
         ...state,
-        mode: state.osEnabled || state.mode === LIGHT_MODE ? DARK_MODE : LIGHT_MODE,
-        osEnabled: false,
+        userPreference: state.userPreference === DARK_MODE ? LIGHT_MODE : DARK_MODE,
+        mode: state.userPreference === DARK_MODE ? LIGHT_MODE : DARK_MODE,
       };
     case TOGGLE_MODE_OS:
       return {
         ...state,
-        mode: !state.osEnabled && state.mode === LIGHT_MODE ? action.payload : LIGHT_MODE,
-        osEnabled: !state.osEnabled && state.mode === LIGHT_MODE,
+        mode: action.payload,
+        userPreference: OS_MODE,
       };
     case TOGGLE_CORS_NOTIFICATION_GLOBALLY:
       return update(state, {
@@ -80,7 +80,7 @@ function settings(state: SettingsState = defaultSettingsState, action: FSA): Set
     case ENABLE_OS_MODE:
       return {
         ...state,
-        osEnabled: true,
+        userPreference: OS_MODE,
         mode: action.payload,
       };
     case DISMISS_CORS_NOTIFICATION:

--- a/www/src/js/reducers/settings.js
+++ b/www/src/js/reducers/settings.js
@@ -20,7 +20,7 @@ import {
 } from 'actions/settings';
 import { SET_EXPORTED_DATA } from 'actions/export';
 import { DIMENSIONS, withTracker } from 'bootstrapping/mamoto';
-import { LIGHT_MODE, DARK_MODE, OS_MODE } from 'types/settings';
+import { LIGHT_MODE, DARK_MODE } from 'types/settings';
 import config from 'config';
 
 export const defaultCorsNotificationState = {

--- a/www/src/js/reducers/settings.test.js
+++ b/www/src/js/reducers/settings.test.js
@@ -20,6 +20,7 @@ const initialState: SettingsState = {
   },
   moduleTableOrder: 'exam',
   beta: false,
+  osEnabled: false,
 };
 const settingsWithNewStudent: SettingsState = { ...initialState, newStudent: true };
 const faculty = 'School of Computing';

--- a/www/src/js/types/reducers.js
+++ b/www/src/js/types/reducers.js
@@ -96,6 +96,7 @@ export type SettingsState = {
   +corsNotification: CorsNotificationSettings,
   +moduleTableOrder: ModuleTableOrder,
   +beta?: boolean,
+  +osEnabled: boolean,
 };
 
 /* timetables.js */

--- a/www/src/js/types/settings.js
+++ b/www/src/js/types/settings.js
@@ -6,6 +6,7 @@ export type Theme = {|
   +name: string,
 |};
 
-export type Mode = 'LIGHT' | 'DARK';
+export type Mode = 'LIGHT' | 'DARK' | 'OS';
 export const LIGHT_MODE: Mode = 'LIGHT';
 export const DARK_MODE: Mode = 'DARK';
+export const OS_MODE: Mode = 'OS';

--- a/www/src/js/views/AppShell.jsx
+++ b/www/src/js/views/AppShell.jsx
@@ -45,7 +45,6 @@ type Props = {
   theme: string,
   mode: Mode,
   activeSemester: Semester,
-  osEnabled: boolean,
 
   // From Redux actions
   fetchModuleList: () => Promise<*>,
@@ -66,12 +65,25 @@ export class AppShellComponent extends Component<Props, State> {
   componentDidMount() {
     const { timetables } = this.props;
     // Checks initial load
-    if (this.checkFirstLoad()) this.enableOSMode();
-    const mqlDark = matchMedia('(prefers-color-scheme: dark)');
-    mqlDark.addListener((e) => {
-      if (e.matches && this.props.osEnabled) {
+    if (window.localStorage.length === 0) {
+      // Enables OS MODE on initial load if Browser Supports.
+      const mqlLight = matchMedia('(prefers-color-scheme: light)');
+      const mqlDark = matchMedia('(prefers-color-scheme: dark)');
+      if (mqlLight.matches) {
+        this.props.enableOsMode('LIGHT');
+      } else if (mqlDark.matches) {
         this.props.enableOsMode('DARK');
-      } else if (!e.matches && this.props.osEnabled) {
+      }
+    }
+    const mqlDark = matchMedia('(prefers-color-scheme: dark)');
+    const mqlLight = matchMedia('(prefers-color-scheme: light)');
+    mqlDark.addListener((e) => {
+      if (e.matches) {
+        this.props.enableOsMode('DARK');
+      }
+    });
+    mqlLight.addListener((e) => {
+      if (e.matches) {
         this.props.enableOsMode('LIGHT');
       }
     });
@@ -112,18 +124,6 @@ export class AppShellComponent extends Component<Props, State> {
           },
         });
       });
-  };
-  checkFirstLoad = () => localStorage.getItem('persist:settings') == null;
-
-  enableOSMode = () => {
-    // Enables OS MODE on initial load if Browser Supports.
-    const mqlLight = matchMedia('(prefers-color-scheme: light)');
-    const mqlDark = matchMedia('(prefers-color-scheme: dark)');
-    if (mqlLight.matches) {
-      this.props.enableOsMode('LIGHT');
-    } else if (mqlDark.matches) {
-      this.props.enableOsMode('DARK');
-    }
   };
 
   render() {
@@ -195,7 +195,7 @@ const mapStateToProps = (state: StoreState) => ({
   timetables: state.timetables.lessons,
   theme: state.theme.id,
   mode: state.settings.mode,
-  osEnabled: state.settings.osEnabled,
+  userPreference: state.settings.userPreference,
   activeSemester: state.app.activeSemester,
 });
 

--- a/www/src/js/views/AppShell.jsx
+++ b/www/src/js/views/AppShell.jsx
@@ -45,6 +45,7 @@ type Props = {
   theme: string,
   mode: Mode,
   activeSemester: Semester,
+  osEnabled: boolean,
 
   // From Redux actions
   fetchModuleList: () => Promise<*>,
@@ -52,6 +53,7 @@ type Props = {
   setTimetable: (Semester, SemTimetableConfig) => void,
   validateTimetable: (Semester) => void,
   openNotification: (string, ?NotificationOptions) => void,
+  enableOsMode: (Mode) => void,
 };
 
 type State = {

--- a/www/src/js/views/AppShell.jsx
+++ b/www/src/js/views/AppShell.jsx
@@ -66,7 +66,6 @@ export class AppShellComponent extends Component<Props, State> {
     // Checks initial load
     if (this.checkFirstLoad()) this.enableOSMode();
     const mqlDark = matchMedia('(prefers-color-scheme: dark)');
-    console.log(this.props.osEnabled);
     mqlDark.addListener((e) => {
       if (e.matches && this.props.osEnabled) {
         this.props.selectMode('DARK');

--- a/www/src/js/views/AppShell.jsx
+++ b/www/src/js/views/AppShell.jsx
@@ -65,18 +65,16 @@ export class AppShellComponent extends Component<Props, State> {
   componentDidMount() {
     const { timetables } = this.props;
     // Checks initial load
+    const mqlLight = matchMedia('(prefers-color-scheme: light)');
+    const mqlDark = matchMedia('(prefers-color-scheme: dark)');
     if (window.localStorage.length === 0) {
       // Enables OS MODE on initial load if Browser Supports.
-      const mqlLight = matchMedia('(prefers-color-scheme: light)');
-      const mqlDark = matchMedia('(prefers-color-scheme: dark)');
       if (mqlLight.matches) {
         this.props.enableOsMode('LIGHT');
       } else if (mqlDark.matches) {
         this.props.enableOsMode('DARK');
       }
     }
-    const mqlDark = matchMedia('(prefers-color-scheme: dark)');
-    const mqlLight = matchMedia('(prefers-color-scheme: light)');
     mqlDark.addListener((e) => {
       if (e.matches) {
         this.props.enableOsMode('DARK');

--- a/www/src/js/views/AppShell.jsx
+++ b/www/src/js/views/AppShell.jsx
@@ -68,9 +68,9 @@ export class AppShellComponent extends Component<Props, State> {
     const mqlDark = matchMedia('(prefers-color-scheme: dark)');
     mqlDark.addListener((e) => {
       if (e.matches && this.props.osEnabled) {
-        this.props.selectMode('DARK');
+        this.props.enableOsMode('DARK');
       } else if (!e.matches && this.props.osEnabled) {
-        this.props.selectMode('LIGHT');
+        this.props.enableOsMode('LIGHT');
       }
     });
     // Retrieve module list

--- a/www/src/js/views/AppShell.jsx
+++ b/www/src/js/views/AppShell.jsx
@@ -15,6 +15,7 @@ import classnames from 'classnames';
 import { each } from 'lodash';
 
 import weekText from 'utils/weekText';
+import { enableOsMode, selectMode } from 'actions/settings';
 import { isMobileIos } from 'utils/css';
 import { openNotification } from 'actions/app';
 import { fetchModuleList } from 'actions/moduleBank';
@@ -62,7 +63,17 @@ export class AppShellComponent extends Component<Props, State> {
 
   componentDidMount() {
     const { timetables } = this.props;
-
+    // Checks initial load
+    if (this.checkFirstLoad()) this.enableOSMode();
+    const mqlDark = matchMedia('(prefers-color-scheme: dark)');
+    console.log(this.props.osEnabled);
+    mqlDark.addListener((e) => {
+      if (e.matches && this.props.osEnabled) {
+        this.props.selectMode('DARK');
+      } else if (!e.matches && this.props.osEnabled) {
+        this.props.selectMode('LIGHT');
+      }
+    });
     // Retrieve module list
     this.fetchModuleList();
 
@@ -100,6 +111,18 @@ export class AppShellComponent extends Component<Props, State> {
           },
         });
       });
+  };
+  checkFirstLoad = () => localStorage.getItem('persist:settings') == null;
+
+  enableOSMode = () => {
+    // Enables OS MODE on initial load if Browser Supports.
+    const mqlLight = matchMedia('(prefers-color-scheme: light)');
+    const mqlDark = matchMedia('(prefers-color-scheme: dark)');
+    if (mqlLight.matches) {
+      this.props.enableOsMode('LIGHT');
+    } else if (mqlDark.matches) {
+      this.props.enableOsMode('DARK');
+    }
   };
 
   render() {
@@ -171,6 +194,7 @@ const mapStateToProps = (state: StoreState) => ({
   timetables: state.timetables.lessons,
   theme: state.theme.id,
   mode: state.settings.mode,
+  osEnabled: state.settings.osEnabled,
   activeSemester: state.app.activeSemester,
 });
 
@@ -182,6 +206,8 @@ const connectedAppShell = connect(
     setTimetable,
     validateTimetable,
     openNotification,
+    enableOsMode,
+    selectMode,
   },
 )(AppShellComponent);
 

--- a/www/src/js/views/components/KeyboardShortcuts.jsx
+++ b/www/src/js/views/components/KeyboardShortcuts.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import Mousetrap from 'mousetrap';
 import { groupBy, map } from 'lodash';
 
-import { DARK_MODE } from 'types/settings';
+import { LIGHT_MODE, DARK_MODE } from 'types/settings';
 import type { Mode, ThemeId } from 'types/settings';
 import themes from 'data/themes.json';
 import { cycleTheme, toggleTimetableOrientation } from 'actions/theme';
@@ -21,6 +21,7 @@ type Props = ContextRouter & {
   dispatch: Dispatch<*>,
   theme: ThemeId,
   mode: Mode,
+  userPreference: Mode,
   osEnabled: boolean,
 };
 
@@ -97,18 +98,30 @@ export class KeyboardShortcutsComponent extends PureComponent<Props, State> {
     this.bind('x', APPEARANCE, 'Toggle Night Mode', () => {
       const mqlLight = matchMedia('(prefers-color-scheme: light)');
       const mqlDark = matchMedia('(prefers-color-scheme: dark)');
-      if (mqlLight.matches && !this.props.osEnabled) {
+      const userPreferLightMode = this.props.userPreference === LIGHT_MODE;
+
+      if (mqlLight.matches && userPreferLightMode) {
         this.props.dispatch(toggleModeOs('LIGHT'));
-      } else if (mqlDark.matches && !this.props.osEnabled) {
+        dispatch(
+          openNotification(`OS mode enabled`, {
+            overwritable: true,
+          }),
+        );
+      } else if (mqlDark.matches && userPreferLightMode) {
         this.props.dispatch(toggleModeOs('DARK'));
+        dispatch(
+          openNotification(`OS mode enabled`, {
+            overwritable: true,
+          }),
+        );
       } else {
         this.props.dispatch(toggleMode());
+        dispatch(
+          openNotification(`Night mode ${this.props.mode === DARK_MODE ? 'on' : 'off'}`, {
+            overwritable: true,
+          }),
+        );
       }
-      dispatch(
-        openNotification(`Night mode ${this.props.mode === DARK_MODE ? 'on' : 'off'}`, {
-          overwritable: true,
-        }),
-      );
     });
 
     // Cycle through themes
@@ -192,6 +205,7 @@ export class KeyboardShortcutsComponent extends PureComponent<Props, State> {
 
 const KeyboardShortcutsConnected = connect((state) => ({
   mode: state.settings.mode,
+  userPreference: state.settings.userPreference,
   theme: state.theme.id,
   osEnabled: state.settings.osEnabled,
 }))(KeyboardShortcutsComponent);

--- a/www/src/js/views/components/KeyboardShortcuts.jsx
+++ b/www/src/js/views/components/KeyboardShortcuts.jsx
@@ -11,7 +11,7 @@ import type { Mode, ThemeId } from 'types/settings';
 import themes from 'data/themes.json';
 import { cycleTheme, toggleTimetableOrientation } from 'actions/theme';
 import { openNotification } from 'actions/app';
-import { toggleMode } from 'actions/settings';
+import { toggleMode, toggleModeOs } from 'actions/settings';
 import { intersperse } from 'utils/array';
 import ComponentMap from 'utils/ComponentMap';
 import Modal from './Modal';
@@ -21,6 +21,7 @@ type Props = ContextRouter & {
   dispatch: Dispatch<*>,
   theme: ThemeId,
   mode: Mode,
+  osEnabled: boolean,
 };
 
 type State = {
@@ -94,8 +95,15 @@ export class KeyboardShortcutsComponent extends PureComponent<Props, State> {
 
     // Toggle night mode
     this.bind('x', APPEARANCE, 'Toggle Night Mode', () => {
-      this.props.dispatch(toggleMode());
-
+      const mqlLight = matchMedia('(prefers-color-scheme: light)');
+      const mqlDark = matchMedia('(prefers-color-scheme: dark)');
+      if (mqlLight.matches && !this.props.osEnabled) {
+        this.props.dispatch(toggleModeOs('LIGHT'));
+      } else if (mqlDark.matches && !this.props.osEnabled) {
+        this.props.dispatch(toggleModeOs('DARK'));
+      } else {
+        this.props.dispatch(toggleMode());
+      }
       dispatch(
         openNotification(`Night mode ${this.props.mode === DARK_MODE ? 'on' : 'off'}`, {
           overwritable: true,
@@ -185,6 +193,7 @@ export class KeyboardShortcutsComponent extends PureComponent<Props, State> {
 const KeyboardShortcutsConnected = connect((state) => ({
   mode: state.settings.mode,
   theme: state.theme.id,
+  osEnabled: state.settings.osEnabled,
 }))(KeyboardShortcutsComponent);
 
 export default withRouter(KeyboardShortcutsConnected);

--- a/www/src/js/views/settings/ModeSelect.jsx
+++ b/www/src/js/views/settings/ModeSelect.jsx
@@ -9,6 +9,7 @@ type Props = {
   mode: Mode,
   onSelectMode: Function,
   enableOsMode: Function,
+  osEnabled: boolean,
 };
 type ModeOption = { value: Mode, label: string };
 
@@ -22,27 +23,27 @@ const MODES: Array<ModeOption> = [
     value: LIGHT_MODE,
   },
   {
-    label: 'OS',
+    label: 'OS DEFAULT',
     value: true,
   },
 ];
 
 export default function ModeSelect(props: Props) {
-  const { enableOsMode, mode, onSelectMode } = props;
+  const { osEnabled, enableOsMode, mode, onSelectMode } = props;
   const mqlLight = matchMedia('(prefers-color-scheme: light)');
   const mqlDark = matchMedia('(prefers-color-scheme: dark)');
   const browserSupport = mqlLight.matches || mqlDark.matches;
   return (
     <div className="btn-group" role="group">
-      {MODES.filter(({ label }) => label !== 'OS' || browserSupport).map(
+      {MODES.filter(({ label }) => label !== 'OS DEFAULT' || browserSupport).map(
         ({ value, label }) =>
-          label !== 'OS' ? (
+          label !== 'OS DEFAULT' ? (
             <button
               type="button"
               key={value}
               className={classnames('btn', {
-                'btn-primary': mode === value,
-                'btn-outline-primary': mode !== value,
+                'btn-primary': !osEnabled && mode === value,
+                'btn-outline-primary': osEnabled || mode !== value,
               })}
               onClick={() => onSelectMode(value)}
             >
@@ -53,12 +54,12 @@ export default function ModeSelect(props: Props) {
               type="button"
               key={value}
               className={classnames('btn', {
-                'btn-primary': mode === value,
-                'btn-outline-primary': mode !== value,
+                'btn-primary': osEnabled,
+                'btn-outline-primary': !osEnabled,
               })}
               onClick={() => {
                 if (mqlLight.matches) enableOsMode('LIGHT');
-                else enableOsMode('DARK');
+                else if (mqlDark.matches) enableOsMode('DARK');
               }}
             >
               {label}

--- a/www/src/js/views/settings/ModeSelect.jsx
+++ b/www/src/js/views/settings/ModeSelect.jsx
@@ -3,7 +3,7 @@ import type { Mode } from 'types/settings';
 
 import React from 'react';
 import classnames from 'classnames';
-import { LIGHT_MODE, DARK_MODE } from 'types/settings';
+import { LIGHT_MODE, DARK_MODE, OS_MODE } from 'types/settings';
 
 type Props = {
   mode: Mode,
@@ -24,7 +24,7 @@ const MODES: Array<ModeOption> = [
   },
   {
     label: 'OS DEFAULT',
-    value: true,
+    value: OS_MODE,
   },
 ];
 

--- a/www/src/js/views/settings/ModeSelect.jsx
+++ b/www/src/js/views/settings/ModeSelect.jsx
@@ -8,6 +8,7 @@ import { LIGHT_MODE, DARK_MODE } from 'types/settings';
 type Props = {
   mode: Mode,
   onSelectMode: Function,
+  enableOsMode: Function,
 };
 type ModeOption = { value: Mode, label: string };
 
@@ -20,26 +21,50 @@ const MODES: Array<ModeOption> = [
     label: 'Off',
     value: LIGHT_MODE,
   },
+  {
+    label: 'OS',
+    value: true,
+  },
 ];
 
 export default function ModeSelect(props: Props) {
-  const { mode, onSelectMode } = props;
-
+  const { enableOsMode, mode, onSelectMode } = props;
+  const mqlLight = matchMedia('(prefers-color-scheme: light)');
+  const mqlDark = matchMedia('(prefers-color-scheme: dark)');
+  const browserSupport = mqlLight.matches || mqlDark.matches;
   return (
     <div className="btn-group" role="group">
-      {MODES.map(({ value, label }) => (
-        <button
-          type="button"
-          key={value}
-          className={classnames('btn', {
-            'btn-primary': mode === value,
-            'btn-outline-primary': mode !== value,
-          })}
-          onClick={() => onSelectMode(value)}
-        >
-          {label}
-        </button>
-      ))}
+      {MODES.filter(({ label }) => label !== 'OS' || browserSupport).map(
+        ({ value, label }) =>
+          label !== 'OS' ? (
+            <button
+              type="button"
+              key={value}
+              className={classnames('btn', {
+                'btn-primary': mode === value,
+                'btn-outline-primary': mode !== value,
+              })}
+              onClick={() => onSelectMode(value)}
+            >
+              {label}
+            </button>
+          ) : (
+            <button
+              type="button"
+              key={value}
+              className={classnames('btn', {
+                'btn-primary': mode === value,
+                'btn-outline-primary': mode !== value,
+              })}
+              onClick={() => {
+                if (mqlLight.matches) enableOsMode('LIGHT');
+                else enableOsMode('DARK');
+              }}
+            >
+              {label}
+            </button>
+          ),
+      )}
     </div>
   );
 }

--- a/www/src/js/views/settings/ModeSelect.jsx
+++ b/www/src/js/views/settings/ModeSelect.jsx
@@ -9,7 +9,7 @@ type Props = {
   mode: Mode,
   onSelectMode: Function,
   enableOsMode: Function,
-  osEnabled: boolean,
+  userPreference: Mode,
 };
 type ModeOption = { value: Mode, label: string };
 
@@ -23,27 +23,27 @@ const MODES: Array<ModeOption> = [
     value: LIGHT_MODE,
   },
   {
-    label: 'OS DEFAULT',
+    label: 'OS mode',
     value: OS_MODE,
   },
 ];
 
 export default function ModeSelect(props: Props) {
-  const { osEnabled, enableOsMode, mode, onSelectMode } = props;
+  const { enableOsMode, userPreference, onSelectMode } = props;
   const mqlLight = matchMedia('(prefers-color-scheme: light)');
   const mqlDark = matchMedia('(prefers-color-scheme: dark)');
   const browserSupport = mqlLight.matches || mqlDark.matches;
   return (
     <div className="btn-group" role="group">
-      {MODES.filter(({ label }) => label !== 'OS DEFAULT' || browserSupport).map(
+      {MODES.filter(({ label }) => label !== 'OS mode' || browserSupport).map(
         ({ value, label }) =>
-          label !== 'OS DEFAULT' ? (
+          label !== 'OS mode' ? (
             <button
               type="button"
               key={value}
               className={classnames('btn', {
-                'btn-primary': !osEnabled && mode === value,
-                'btn-outline-primary': osEnabled || mode !== value,
+                'btn-primary': userPreference === value,
+                'btn-outline-primary': userPreference !== value,
               })}
               onClick={() => onSelectMode(value)}
             >
@@ -54,8 +54,8 @@ export default function ModeSelect(props: Props) {
               type="button"
               key={value}
               className={classnames('btn', {
-                'btn-primary': osEnabled,
-                'btn-outline-primary': !osEnabled,
+                'btn-primary': userPreference === value,
+                'btn-outline-primary': userPreference !== value,
               })}
               onClick={() => {
                 if (mqlLight.matches) enableOsMode('LIGHT');

--- a/www/src/js/views/settings/SettingsContainer.jsx
+++ b/www/src/js/views/settings/SettingsContainer.jsx
@@ -19,6 +19,7 @@ import {
   enableCorsNotification,
   toggleCorsNotificationGlobally,
   toggleBetaTesting,
+  enableOsMode,
 } from 'actions/settings';
 // import FacultySelect from 'views/components/FacultySelect';
 // import NewStudentSelect from 'views/components/NewStudentSelect';
@@ -46,9 +47,11 @@ type Props = {
   faculty: Faculty,
   currentThemeId: string,
   mode: Mode,
+  osEnabled: boolean,
   corsNotification: CorsNotificationSettings,
   betaTester: boolean,
 
+  enableOsMode: Function,
   selectTheme: Function,
   selectNewStudent: Function,
   selectFaculty: Function,
@@ -76,7 +79,11 @@ class SettingsContainer extends Component<Props> {
             </p>
           </div>
           <div className={classnames('col-sm-4 offset-sm-1', styles.toggle)}>
-            <ModeSelect mode={this.props.mode} onSelectMode={this.props.selectMode} />
+            <ModeSelect
+              mode={this.props.mode}
+              onSelectMode={this.props.selectMode}
+              enableOsMode={this.props.enableOsMode}
+            />
           </div>
         </div>
         <hr />
@@ -236,6 +243,7 @@ const mapStateToProps = (state: StoreState) => ({
 const connectedSettings = connect(
   mapStateToProps,
   {
+    enableOsMode,
     selectTheme,
     selectNewStudent,
     selectFaculty,

--- a/www/src/js/views/settings/SettingsContainer.jsx
+++ b/www/src/js/views/settings/SettingsContainer.jsx
@@ -83,6 +83,7 @@ class SettingsContainer extends Component<Props> {
               mode={this.props.mode}
               onSelectMode={this.props.selectMode}
               enableOsMode={this.props.enableOsMode}
+              osEnabled={this.props.osEnabled}
             />
           </div>
         </div>
@@ -235,6 +236,7 @@ const mapStateToProps = (state: StoreState) => ({
   newStudent: state.settings.newStudent,
   faculty: state.settings.faculty,
   mode: state.settings.mode,
+  osEnabled: state.settings.osEnabled,
   corsNotification: state.settings.corsNotification,
   currentThemeId: state.theme.id,
   betaTester: state.settings.beta || false,

--- a/www/src/js/views/settings/SettingsContainer.jsx
+++ b/www/src/js/views/settings/SettingsContainer.jsx
@@ -47,6 +47,7 @@ type Props = {
   faculty: Faculty,
   currentThemeId: string,
   mode: Mode,
+  userPreference: Mode,
   osEnabled: boolean,
   corsNotification: CorsNotificationSettings,
   betaTester: boolean,
@@ -81,6 +82,7 @@ class SettingsContainer extends Component<Props> {
           <div className={classnames('col-sm-4 offset-sm-1', styles.toggle)}>
             <ModeSelect
               mode={this.props.mode}
+              userPreference={this.props.userPreference}
               onSelectMode={this.props.selectMode}
               enableOsMode={this.props.enableOsMode}
               osEnabled={this.props.osEnabled}
@@ -236,7 +238,7 @@ const mapStateToProps = (state: StoreState) => ({
   newStudent: state.settings.newStudent,
   faculty: state.settings.faculty,
   mode: state.settings.mode,
-  osEnabled: state.settings.osEnabled,
+  userPreference: state.settings.userPreference,
   corsNotification: state.settings.corsNotification,
   currentThemeId: state.theme.id,
   betaTester: state.settings.beta || false,


### PR DESCRIPTION
Fixes #1289 
Browser support to detect MOJAVE's light/dark preference.
Allows Toggling between NightMode Settings.