### PR TITLE
Fix location map height when the map is expanded

### DIFF
--- a/www/src/js/views/components/map/LocationMap.jsx
+++ b/www/src/js/views/components/map/LocationMap.jsx
@@ -44,9 +44,12 @@ export default class LocationMap extends PureComponent<Props, State> {
     const googleMapQuery = encodeURIComponent(position.join(','));
     const { isExpanded } = this.state;
 
+    // The map uses position: fixed when expanded so we don't need inline height
+    const style = isExpanded ? {} : { height };
+
     return (
       <div
-        style={{ height }}
+        style={style}
         className={classnames(styles.mapWrapper, className, { [styles.expanded]: isExpanded })}
       >
         <ExternalLink


### PR DESCRIPTION
When the map on the Today page is expanded the expand toggle is pushed below the screen due to poor interaction between the `position: fixed` added by expanded mode and the inline height prop passed in from the parent. 

This PR fixes that by not including the inline height when the map is expanded, since the height is implicitly calculated in `position: fixed`