### PR TITLE
Fix test errors caused by SVG mock

### DIFF
--- a/www/__mocks__/svgMock.jsx
+++ b/www/__mocks__/svgMock.jsx
@@ -1,0 +1,3 @@
+const React = require('react');
+
+module.exports = () => <svg />;

--- a/www/jest.config.js
+++ b/www/jest.config.js
@@ -23,8 +23,12 @@ module.exports = {
   ],
   setupFiles: ['<rootDir>/scripts/test.js'],
   moduleNameMapper: {
-    // Mock non js files for jest to process
-    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
+    // Mock non JS files as strings
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
+    // Mock SVG as React component
+    '\\.svg\\?url': '<rootDir>/__mocks__/fileMock.js',
+    '\\.svg': '<rootDir>/__mocks__/svgMock.jsx',
+    // Mock SCSS and CSS modules as objects
     '\\.(css|scss)$': 'identity-obj-proxy',
   },
   // Allow us to directly use enzyme wrappers for snapshotting


### PR DESCRIPTION
Fix a minor issue caused by #1466 because Jest does not properly mock the SVG file