### PR TITLE
Make the localStorage shim compliant with the Storage interface

### DIFF
--- a/www/src/js/storage/localStorage.test.ts
+++ b/www/src/js/storage/localStorage.test.ts
@@ -1,6 +1,6 @@
 import getLocalStorage, { createLocalStorageShim, canUseBrowserLocalStorage } from './localStorage';
 
-describe('#createLocalStorageShim', () => {
+describe(createLocalStorageShim, () => {
   test('should store and return data', () => {
     const shim = createLocalStorageShim();
     const toStore = JSON.stringify({ key: 'value', key2: 2 });
@@ -24,7 +24,7 @@ describe('#createLocalStorageShim', () => {
     expect(shim.privData).toEqual({});
   });
 
-  test('should return undefined when getting nonexistent data', () => {
+  test('should return null when getting nonexistent data', () => {
     const shim = createLocalStorageShim();
     expect(shim.getItem('key')).toBeNull();
   });
@@ -58,11 +58,12 @@ describe('#canUseBrowserLocalStorage', () => {
   test('should return true if localStorage is localStorage-like object', () => {
     // @ts-ignore
     window.localStorage = createLocalStorageShim();
+
     expect(canUseBrowserLocalStorage()).toEqual(true);
   });
 });
 
-describe('#getLocalStorage', () => {
+describe(getLocalStorage, () => {
   test("should return the actual browser's localStorage if the browser can use localStorage", () => {
     expect(canUseBrowserLocalStorage()).toEqual(true);
     expect(getLocalStorage()).toBe(window.localStorage);
@@ -71,6 +72,7 @@ describe('#getLocalStorage', () => {
   test('should return a shim if browser cannot use localStorage', () => {
     // @ts-ignore
     delete window.localStorage;
+
     expect(canUseBrowserLocalStorage()).toEqual(false);
     expect(getLocalStorage()).toMatchObject(
       expect.objectContaining({

--- a/www/src/js/storage/localStorage.test.ts
+++ b/www/src/js/storage/localStorage.test.ts
@@ -24,20 +24,9 @@ describe('#createLocalStorageShim', () => {
     expect(shim.privData).toEqual({});
   });
 
-  test('should not throw when setting null/undefined', () => {
-    const shim = createLocalStorageShim();
-    // @ts-ignore
-    expect(() => shim.setItem('key', null)).not.toThrow();
-    // @ts-ignore
-    expect(() => shim.setItem('key', undefined)).not.toThrow();
-  });
-
   test('should return undefined when getting nonexistent data', () => {
     const shim = createLocalStorageShim();
-    expect(shim.getItem('key')).toBeUndefined();
-    // @ts-ignore
-    shim.setItem('key', undefined);
-    expect(shim.getItem('key')).toBeUndefined();
+    expect(shim.getItem('key')).toBeNull();
   });
 
   test('should not throw when removing nonexistent key', () => {

--- a/www/src/js/storage/localStorage.ts
+++ b/www/src/js/storage/localStorage.ts
@@ -23,15 +23,14 @@ export function createLocalStorageShim(): Storage {
     },
 
     setItem(key: string, val: string) {
-      storage.privData[String(key)] = JSON.stringify(val);
+      storage.privData[key] = val;
     },
 
     getItem(key: string) {
-      const storedValue = storage.privData[String(key)];
-      return storedValue && JSON.parse(storedValue);
+      return storage.privData[key] || null;
     },
 
-    removeItem: (key: string) => delete storage.privData[String(key)],
+    removeItem: (key: string) => delete storage.privData[key],
   };
 
   return storage;


### PR DESCRIPTION
Our local storage shim does not actually comply with the interface because it tries to be generous and stringify inputs. This is actually unnecessary, and this PR fixes that. 