### PR TITLE
Improve typing and reduce lint errors 

### DIFF
--- a/www/src/js/apis/export.ts
+++ b/www/src/js/apis/export.ts
@@ -1,6 +1,8 @@
+import qs from 'query-string';
+
 import { State } from 'reducers';
 import { Semester } from 'types/modules';
-import { extractStateForExport, serializeExportState } from 'utils/export';
+import { extractStateForExport } from 'utils/export';
 
 export type ExportOptions = {
   pixelRatio?: number;
@@ -9,7 +11,10 @@ export type ExportOptions = {
 const baseUrl = '/export';
 
 function serializeState(semester: Semester, state: State, options: ExportOptions = {}) {
-  return serializeExportState(extractStateForExport(semester, state), options);
+  return qs.stringify({
+    data: JSON.stringify(extractStateForExport(semester, state)),
+    ...options,
+  });
 }
 
 export default {

--- a/www/src/js/bootstrapping/configure-store.ts
+++ b/www/src/js/bootstrapping/configure-store.ts
@@ -7,7 +7,8 @@ import rootReducer, { State } from 'reducers';
 import requestsMiddleware from 'middlewares/requests-middleware';
 import ravenMiddleware from 'middlewares/raven-middleware';
 import { setAutoFreeze } from 'immer';
-import { FSA, GetState } from '../types/redux';
+
+import { FSA, GetState } from 'types/redux';
 
 // Extend immutability-helper with autovivification commands. This allows immutability-helper
 // to automatically create objects if it doesn't exist before

--- a/www/src/js/config/config.test.ts
+++ b/www/src/js/config/config.test.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
+import { Semesters } from 'types/modules';
 import { roundEnd } from 'utils/cors';
 import academicCalendar from 'data/academic-calendar.json';
 import config from './index';
-import { Semesters } from '../types/modules';
 
 function isSorted(arr: any[]) {
   return arr.slice(1).every((item, index) => item >= arr[index]);

--- a/www/src/js/data/venues.ts
+++ b/www/src/js/data/venues.ts
@@ -1,0 +1,5 @@
+import venuesJSON from './venues.json';
+import { VenueLocationMap } from '../types/venues';
+
+const venues = venuesJSON as VenueLocationMap;
+export default venues;

--- a/www/src/js/data/venues.ts
+++ b/www/src/js/data/venues.ts
@@ -1,5 +1,5 @@
+import { VenueLocationMap } from 'types/venues';
 import venuesJSON from './venues.json';
-import { VenueLocationMap } from '../types/venues';
 
 const venues = venuesJSON as VenueLocationMap;
 export default venues;

--- a/www/src/js/reducers/theme.ts
+++ b/www/src/js/reducers/theme.ts
@@ -1,5 +1,5 @@
 import { FSA } from 'types/redux';
-import { ColorMapping, ThemeState, VERTICAL, HORIZONTAL } from 'types/reducers';
+import { ThemeState, VERTICAL, HORIZONTAL } from 'types/reducers';
 import { Theme } from 'types/settings';
 
 import { SET_EXPORTED_DATA } from 'actions/export';

--- a/www/src/js/selectors/timetables.ts
+++ b/www/src/js/selectors/timetables.ts
@@ -1,8 +1,8 @@
 import { ModuleCode } from 'types/modules';
 import config from 'config';
+import { State } from 'reducers';
 import { isOngoing, isSuccess } from 'selectors/requests';
 import { fetchArchiveRequest } from 'actions/moduleBank';
-import { State } from '../reducers';
 
 export function isArchiveLoading(state: State, moduleCode: ModuleCode) {
   return config.archiveYears.some((year) =>

--- a/www/src/js/storage/index.ts
+++ b/www/src/js/storage/index.ts
@@ -2,6 +2,8 @@ import { isString } from 'lodash';
 import { captureException } from 'utils/error';
 import getLocalStorage from './localStorage';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 // Simple wrapper around localStorage to automagically parse and stringify payloads.
 function setItem(key: string, value: any) {
   try {
@@ -22,9 +24,7 @@ function setItem(key: string, value: any) {
       // Ignore error
     }
 
-    captureException(e, {
-      usedSpace,
-    });
+    captureException(e, { usedSpace });
   }
 }
 

--- a/www/src/js/types/utils.ts
+++ b/www/src/js/types/utils.ts
@@ -1,4 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+export const EMPTY_ARRAY: ReadonlyArray<any> = [];
 
 export const notFalsy = (Boolean as any) as <T>(x: T | false) => x is T;
 export const notNull = <T>(x: T | null | undefined): x is T => x != null;

--- a/www/src/js/types/utils.ts
+++ b/www/src/js/types/utils.ts
@@ -1,3 +1,8 @@
+/**
+ * Various utility types and type utilities for making working with TypeScript
+ * easier
+ */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;

--- a/www/src/js/types/vendor/leaflet-gesture-handling.d.ts
+++ b/www/src/js/types/vendor/leaflet-gesture-handling.d.ts
@@ -1,11 +1,9 @@
 // Extend React Leaflet with init hooks from plugins
-// TODO: This doesn't actually work - figure out why
-import { MapOptions } from 'react-leaflet';
+import { Map } from 'react-leaflet';
+import GestureHandling from 'leaflet-gesture-handling';
 
 declare module 'react-leaflet' {
-  import GestureHandling from 'leaflet-gesture-handling';
-
-  interface MapOptions {
-    gestureHandling: GestureHandling;
+  interface Map {
+    gestureHandling?: GestureHandling;
   }
 }

--- a/www/src/js/types/views.ts
+++ b/www/src/js/types/views.ts
@@ -39,8 +39,10 @@ export type SearchItem =
 /* browse/ModuleFinderContainer */
 export type FilterGroupId = string;
 
-export type OnFilterChange = (filterGroup: FilterGroup<any>) => any;
-export type FilterGroups = { [filterGroupId: string]: FilterGroup<any> };
+export type AnyGroup = FilterGroup<any>;
+
+export type OnFilterChange = (filterGroup: AnyGroup) => unknown;
+export type FilterGroups = { [filterGroupId: string]: AnyGroup };
 export type DepartmentFaculty = { [department: string]: Faculty };
 
 export type PageRange = {

--- a/www/src/js/utils/colors.test.ts
+++ b/www/src/js/utils/colors.test.ts
@@ -2,9 +2,9 @@ import { range, without, uniq } from 'lodash';
 
 import { ColorIndex, ColorMapping } from 'types/reducers';
 import { Lesson } from 'types/modules';
+import { SemTimetableConfig } from 'types/timetables';
 
 import { NUM_DIFFERENT_COLORS, getNewColor, colorLessonsByKey, fillColorMapping } from './colors';
-import { SemTimetableConfig } from '../types/timetables';
 
 describe(getNewColor, () => {
   test('it should get color without randomization', () => {

--- a/www/src/js/utils/colors.ts
+++ b/www/src/js/utils/colors.ts
@@ -6,30 +6,29 @@ import { ModuleCode } from 'types/modules';
 
 export const NUM_DIFFERENT_COLORS = 8;
 
+function generateInitialColors(): ColorIndex[] {
+  return range(NUM_DIFFERENT_COLORS);
+}
+
 // Returns a new index that is not present in the current color index.
 // If there are more than NUM_DIFFERENT_COLORS modules already present,
 // will try to balance the color distribution if randomize === true.
-export function getNewColor(
-  currentColorIndices: ColorIndex[],
-  randomize: boolean = true,
-): ColorIndex {
-  function generateInitialIndices(): ColorIndex[] {
-    return range(NUM_DIFFERENT_COLORS);
-  }
-
-  let availableColorIndices = generateInitialIndices();
-  currentColorIndices.forEach((index: ColorIndex) => {
-    availableColorIndices = without(availableColorIndices, index);
-    if (availableColorIndices.length === 0) {
-      availableColorIndices = generateInitialIndices();
+export function getNewColor(currentColors: ColorIndex[], randomize: boolean = true): ColorIndex {
+  let availableColors = generateInitialColors();
+  currentColors.forEach((index: ColorIndex) => {
+    availableColors = without(availableColors, index);
+    if (availableColors.length === 0) {
+      availableColors = generateInitialColors();
     }
   });
 
   if (randomize) {
-    return sample(availableColorIndices)!;
+    // Safe to assert non null because the previous step ensures availableColorIndices is never empty
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return sample(availableColors)!;
   }
 
-  return availableColorIndices[0];
+  return availableColors[0];
 }
 
 // Color lessons by a certain property of every lesson

--- a/www/src/js/utils/export.ts
+++ b/www/src/js/utils/export.ts
@@ -1,4 +1,3 @@
-import qs from 'query-string';
 import { Semester } from 'types/modules';
 import { State } from 'reducers';
 import { ExportData } from 'types/export';
@@ -18,11 +17,4 @@ export function extractStateForExport(semester: Semester, state: State): ExportD
       mode: state.settings.mode,
     },
   };
-}
-
-export function serializeExportState(data: ExportData, options: any): string {
-  return qs.stringify({
-    data: JSON.stringify(data),
-    ...options,
-  });
 }

--- a/www/src/js/utils/filters/FilterGroup.ts
+++ b/www/src/js/utils/filters/FilterGroup.ts
@@ -3,10 +3,10 @@ import update from 'immutability-helper';
 
 import { Module, ModuleCode } from 'types/modules';
 import { FilterGroupId } from 'types/views';
+import { notNull } from 'types/utils';
 
 import { intersection, union } from 'utils/set';
 import ModuleFilter from './ModuleFilter';
-import { notNull } from '../../types/utils';
 
 export const ID_DELIMITER = ',';
 

--- a/www/src/js/utils/react.tsx
+++ b/www/src/js/utils/react.tsx
@@ -63,13 +63,13 @@ export function noBreak(text: string): string {
   return text.replace(/ /g, NBSP);
 }
 
-export function defer(task: () => any) {
+export function defer(task: () => unknown) {
   window.requestAnimationFrame(() => {
     window.requestAnimationFrame(task);
   });
 }
 
-export function wrapComponentName(Component: React.ComponentType<any>, wrapper: string): string {
+export function wrapComponentName(Component: React.ComponentType, wrapper: string): string {
   return `${wrapper}(${Component.displayName || Component.name || 'Component'})`;
 }
 

--- a/www/src/js/utils/react.tsx
+++ b/www/src/js/utils/react.tsx
@@ -70,8 +70,10 @@ export function defer(task: () => unknown) {
 }
 
 // We really don't care about the props here
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function wrapComponentName(Component: React.ComponentType<any>, wrapper: string): string {
+export function wrapComponentName<T extends {}>(
+  Component: React.ComponentType<T>,
+  wrapper: string,
+): string {
   return `${wrapper}(${Component.displayName || Component.name || 'Component'})`;
 }
 

--- a/www/src/js/utils/react.tsx
+++ b/www/src/js/utils/react.tsx
@@ -69,7 +69,9 @@ export function defer(task: () => unknown) {
   });
 }
 
-export function wrapComponentName(Component: React.ComponentType, wrapper: string): string {
+// We really don't care about the props here
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function wrapComponentName(Component: React.ComponentType<any>, wrapper: string): string {
   return `${wrapper}(${Component.displayName || Component.name || 'Component'})`;
 }
 

--- a/www/src/js/views/AppShell.tsx
+++ b/www/src/js/views/AppShell.tsx
@@ -50,7 +50,7 @@ type Props = RouteComponentProps & {
 };
 
 type State = {
-  moduleListError?: any;
+  moduleListError?: Error;
 };
 
 export class AppShellComponent extends React.Component<Props, State> {

--- a/www/src/js/views/components/RandomKawaii.tsx
+++ b/www/src/js/views/components/RandomKawaii.tsx
@@ -27,8 +27,10 @@ class RandomKawaii extends React.PureComponent<Props> {
   constructor(props: Props) {
     super(props);
 
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
     this.kawaii = sample(icons)!;
     this.defaultMood = sample(defaultMoods)!;
+    /* eslint-enable */
   }
 
   render() {

--- a/www/src/js/views/components/disqus/DisqusComments.tsx
+++ b/www/src/js/views/components/disqus/DisqusComments.tsx
@@ -63,6 +63,8 @@ class DisqusComments extends React.PureComponent<Props> {
     // this if we need to use them inside the function
     const { identifier, url, title } = this.props;
 
+    // Can't be arsed to type this bullshit
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return function configDisqus(this: any) {
       this.page.identifier = identifier;
       this.page.url = url;

--- a/www/src/js/views/components/filters/ChecklistFilters.tsx
+++ b/www/src/js/views/components/filters/ChecklistFilters.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { values } from 'lodash';
 
-import { OnFilterChange } from 'types/views';
+import { AnyGroup, OnFilterChange } from 'types/views';
 
 import FilterGroup from 'utils/filters/FilterGroup';
 import styles from './styles.scss';
@@ -9,8 +9,8 @@ import Checklist from './Checklist';
 
 type Props = {
   onFilterChange: OnFilterChange;
-  groups: FilterGroup<any>[];
-  group: FilterGroup<any>;
+  groups: AnyGroup[];
+  group: AnyGroup;
 };
 
 export default function ChecklistFilters(props: Props) {

--- a/www/src/js/views/components/filters/DropdownListFilters.tsx
+++ b/www/src/js/views/components/filters/DropdownListFilters.tsx
@@ -3,7 +3,7 @@ import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
 import classnames from 'classnames';
 import { each, values, uniq, omit } from 'lodash';
 
-import { OnFilterChange } from 'types/views';
+import { AnyGroup, OnFilterChange } from 'types/views';
 
 import { Search, ChevronDown } from 'views/components/icons';
 import makeResponsive from 'views/hocs/makeResponsive';
@@ -16,8 +16,8 @@ import Checklist from './Checklist';
 
 type Props = {
   onFilterChange: OnFilterChange;
-  groups: FilterGroup<any>[];
-  group: FilterGroup<any>;
+  groups: AnyGroup[];
+  group: AnyGroup;
   matchBreakpoint: boolean;
 };
 
@@ -47,7 +47,9 @@ export class DropdownListFiltersComponent extends React.PureComponent<Props, Sta
 
     const { group, onFilterChange } = this.props;
     onFilterChange(group.toggle(selectedItem));
-    this.setState({ searchedFilters: uniq([...this.state.searchedFilters, selectedItem]) });
+    this.setState((state) => ({
+      searchedFilters: uniq([...state.searchedFilters, selectedItem]),
+    }));
   };
 
   onOuterClick = () => {

--- a/www/src/js/views/components/map/BusStops.tsx
+++ b/www/src/js/views/components/map/BusStops.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { DivIcon, DragEndEvent } from 'leaflet';
 import { Marker, Popup } from 'react-leaflet';
 import classnames from 'classnames';
 import produce from 'immer';
@@ -8,7 +9,6 @@ import { BusTiming } from 'types/views';
 
 import busStopJSON from 'data/bus-stops.json';
 import { allowBusStopEditing } from 'utils/debug';
-import { DivIcon } from 'leaflet';
 import { nextBus } from 'apis/nextbus';
 import styles from './BusStops.scss';
 import { ArrivalTimes } from './ArrivalTimes';
@@ -61,7 +61,7 @@ export default class BusStops extends React.PureComponent<Props, State> {
 
   // Only used for map editing
   // TODO: Find out how to properly type Leaflet events
-  onDragEnd = (evt: any) => {
+  onDragEnd = (evt: DragEndEvent) => {
     if (!allowBusStopEditing()) return;
 
     const { target } = evt;

--- a/www/src/js/views/components/map/ExpandMap.tsx
+++ b/www/src/js/views/components/map/ExpandMap.tsx
@@ -28,12 +28,13 @@ class ExpandMap extends React.PureComponent<Props> {
       // This is a little hacky because we are changing the behavior of the outer map
       // component from inside it. Also the gestureHandling prop cannot be added to the
       // outer Map component, otherwise the disable() below won't work
-      if (this.props.isExpanded) {
-        // @ts-ignore TODO: Find a way to patch this type in
-        map.gestureHandling.disable();
-      } else {
-        // @ts-ignore TODO: Find a way to patch this type in
-        map.gestureHandling.enable();
+      const { gestureHandling } = map;
+      if (gestureHandling) {
+        if (this.props.isExpanded) {
+          gestureHandling.disable();
+        } else {
+          gestureHandling.enable();
+        }
       }
     }
   }

--- a/www/src/js/views/contribute/ContributeContainer/ContributeContainer.tsx
+++ b/www/src/js/views/contribute/ContributeContainer/ContributeContainer.tsx
@@ -17,6 +17,7 @@ import { FeedbackButtons } from 'views/components/FeedbackModal';
 import { getModuleCondensed } from 'selectors/moduleBank';
 import { currentTests } from 'views/settings/BetaToggle';
 import { State as StoreState } from 'reducers';
+import { notNull } from 'types/utils';
 
 import ReviewIcon from 'img/icons/review.svg';
 import WrenchIcon from 'img/icons/wrench.svg';
@@ -30,7 +31,6 @@ import VenueIcon from 'img/icons/compass.svg';
 import UnmappedVenues from '../UnmappedVenues';
 import ContributorList from '../ContributorList';
 import styles from './ContributeContainer.scss';
-import { notNull } from '../../../types/utils';
 
 type Props = {
   modules: ModuleCondensed[];

--- a/www/src/js/views/contribute/ContributorList.tsx
+++ b/www/src/js/views/contribute/ContributorList.tsx
@@ -43,7 +43,11 @@ type Props = {
   size?: number;
 };
 
-const ContributorList = Loadable.Map<Props, any>({
+type Export = {
+  contributors: Contributor[];
+};
+
+const ContributorList = Loadable.Map<Props, Export>({
   loader: {
     contributors: () => getContributors(),
   },
@@ -60,7 +64,7 @@ const ContributorList = Loadable.Map<Props, any>({
 
   // This is not a proper render function, so prop validation doesn't work
   /* eslint-disable react/prop-types */
-  render(loaded, props: Props) {
+  render(loaded, props) {
     let { contributors } = loaded;
     if (props.size) contributors = contributors.slice(0, props.size);
 

--- a/www/src/js/views/contribute/UnmappedVenues.tsx
+++ b/www/src/js/views/contribute/UnmappedVenues.tsx
@@ -1,11 +1,11 @@
-import { VenueList as Venues, VenueLocationMap } from 'types/venues';
-import { State as StoreState } from 'reducers';
-
 import * as React from 'react';
 import Loadable, { LoadingComponentProps } from 'react-loadable';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { partition } from 'lodash';
+
+import { VenueList as Venues, VenueLocationMap } from 'types/venues';
+import { State as StoreState } from 'reducers';
 
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import VenueList from 'views/venues/VenueList';
@@ -104,6 +104,7 @@ export const AsyncUnmappedVenues = Loadable.Map({
     if (props.error) {
       return <ApiError dataName="venue locations" retry={props.retry} />;
     }
+
     if (props.pastDelay) {
       return <LoadingSpinner />;
     }

--- a/www/src/js/views/errors/ErrorBoundary.test.tsx
+++ b/www/src/js/views/errors/ErrorBoundary.test.tsx
@@ -14,9 +14,12 @@ jest.mock(
     },
 );
 
-const error = new Error('Test error'); // To be used to compare with error caught by ErrorBoundary
+// To be used to compare with error caught by ErrorBoundary
+const error = new Error('Test error');
+
 // Stateless React component which throws error
-function ThrowsError(prop: any): null {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function ThrowsError(props: any): null {
   throw error;
 }
 

--- a/www/src/js/views/errors/ErrorBoundary.tsx
+++ b/www/src/js/views/errors/ErrorBoundary.tsx
@@ -21,7 +21,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     error: null,
   };
 
-  componentDidCatch(error: Error, info: any) {
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
     this.setState({ error });
 
     if (this.props.captureError) {

--- a/www/src/js/views/errors/ModuleNotFoundPage.tsx
+++ b/www/src/js/views/errors/ModuleNotFoundPage.tsx
@@ -22,7 +22,7 @@ type OwnProps = {
 type Props = OwnProps & {
   isLoading: boolean;
   availableArchive: string[];
-  fetchModuleArchive: (str: string) => Promise<any>;
+  fetchModuleArchive: (str: string) => Promise<unknown>;
 };
 
 export class ModuleNotFoundPageComponent extends React.PureComponent<Props> {

--- a/www/src/js/views/errors/ModuleNotFoundPage.tsx
+++ b/www/src/js/views/errors/ModuleNotFoundPage.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import classnames from 'classnames';
 import * as Sentry from '@sentry/browser';
 
+import { State } from 'reducers';
 import { ModuleCode } from 'types/modules';
 import RandomKawaii from 'views/components/RandomKawaii';
 import Title from 'views/components/Title';
@@ -13,7 +14,6 @@ import LoadingSpinner from 'views/components/LoadingSpinner';
 import { availableArchive, isArchiveLoading } from 'selectors/timetables';
 import { moduleArchive } from 'views/routes/paths';
 import styles from './ErrorPage.scss';
-import { State } from '../../reducers';
 
 type OwnProps = {
   moduleCode: ModuleCode;

--- a/www/src/js/views/modules/ModuleFinderContainer.tsx
+++ b/www/src/js/views/modules/ModuleFinderContainer.tsx
@@ -6,7 +6,7 @@ import update from 'immutability-helper';
 import { each, mapValues, values } from 'lodash';
 
 import { Module, Semester, Semesters } from 'types/modules';
-import { PageRange, PageRangeDiff } from 'types/views';
+import { AnyGroup, FilterGroups, PageRange, PageRangeDiff } from 'types/views';
 import { State as StoreState } from 'reducers';
 
 import ModuleFinderList from 'views/modules/ModuleFinderList';
@@ -54,7 +54,7 @@ export type State = {
   loading: boolean;
   page: PageRange;
   modules: Module[];
-  filterGroups: { [filterGroupId: string]: FilterGroup<any> };
+  filterGroups: FilterGroups;
   isMenuOpen: boolean;
   error: Error | null;
 };
@@ -135,7 +135,7 @@ export class ModuleFinderContainerComponent extends React.Component<Props, State
     }
   }
 
-  onFilterChange = (newGroup: FilterGroup<any>, resetScroll: boolean = true) => {
+  onFilterChange = (newGroup: AnyGroup, resetScroll: boolean = true) => {
     this.setState(
       (state) =>
         update(state, {
@@ -258,7 +258,7 @@ export class ModuleFinderContainerComponent extends React.Component<Props, State
 
   toggleMenu = (isMenuOpen: boolean) => this.setState({ isMenuOpen });
 
-  filterGroups(): FilterGroup<any>[] {
+  filterGroups(): AnyGroup[] {
     return values(this.state.filterGroups);
   }
 

--- a/www/src/js/views/modules/ModuleFinderContainer.tsx
+++ b/www/src/js/views/modules/ModuleFinderContainer.tsx
@@ -56,7 +56,7 @@ export type State = {
   modules: Module[];
   filterGroups: { [filterGroupId: string]: FilterGroup<any> };
   isMenuOpen: boolean;
-  error?: any;
+  error: Error | null;
 };
 
 // Threshold to enable instant search based on the amount of time it takes to
@@ -104,6 +104,7 @@ export class ModuleFinderContainerComponent extends React.Component<Props, State
       loading: true,
       modules: [],
       isMenuOpen: false,
+      error: null,
     };
   }
 

--- a/www/src/js/views/tetris/TetrisContainer.tsx
+++ b/www/src/js/views/tetris/TetrisContainer.tsx
@@ -35,7 +35,8 @@ class TetrisContainer extends React.PureComponent<Props, State> {
 /**
  * Lazy load the TetrisGame component and pass it down to TetrisContainer
  */
-export default Loadable.Map<{}, any>({
+type Export = { TetrisGame: { default: React.ComponentType<TetrisGameProps> } };
+export default Loadable.Map<{}, Export>({
   loader: {
     TetrisGame: () => import(/* webpackChunkName: "tetris" */ './TetrisGame'),
   },

--- a/www/src/js/views/tetris/overlays/HighScoreForm.tsx
+++ b/www/src/js/views/tetris/overlays/HighScoreForm.tsx
@@ -81,7 +81,8 @@ export default class HighScoreForm extends React.PureComponent<Props, State> {
     const sortedEntries = sortBy(entriesWithNewScore, ([entryScore]) => entryScore).reverse();
 
     // If your score comes in later than the other high scores, then sorry!
-    if (sortedEntries.length > HIGH_SCORE_COUNT && !last(sortedEntries)![1]) {
+    const lastEntry = last(sortedEntries);
+    if (sortedEntries.length > HIGH_SCORE_COUNT && lastEntry && !lastEntry[1]) {
       return null;
     }
 

--- a/www/src/js/views/today/EventMap/EventMap.tsx
+++ b/www/src/js/views/today/EventMap/EventMap.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-/** @var { VenueLocationMap } */
-import venueLocationJSON from 'data/venues.json';
-import { Venue, VenueLocation, VenueLocationMap } from 'types/venues';
+import venueLocations from 'data/venues';
+
+import { Venue, VenueLocation } from 'types/venues';
 import LocationMap from 'views/components/map/LocationMap';
 import { Map } from 'views/components/icons';
 import styles from './EventMap.scss';
-
-const venueLocations = venueLocationJSON as VenueLocationMap;
 
 export type Props = {
   readonly venue: Venue | null;

--- a/www/src/js/views/today/EventMap/index.tsx
+++ b/www/src/js/views/today/EventMap/index.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import Loadable, { LoadingComponentProps } from 'react-loadable';
+
 import { retryImport } from 'utils/error';
 import ApiError from 'views/errors/ApiError';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import { Props } from './EventMap';
 
-export default Loadable<Props, any>({
+export default Loadable<Props, {}>({
   loader: () => retryImport(() => import(/* webpackChunkName: "venue" */ './EventMap')),
   loading: (props: LoadingComponentProps) => {
     if (props.error) {

--- a/www/src/js/views/today/EventMapInline/EventMapInline.tsx
+++ b/www/src/js/views/today/EventMapInline/EventMapInline.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import classnames from 'classnames';
-/** @var { VenueLocationMap } */
-import venueLocationJSON from 'data/venues.json';
-import { LatLngTuple, Venue, VenueLocation, VenueLocationMap } from 'types/venues';
+import venueLocations from 'data/venues';
+
+import { LatLngTuple, Venue, VenueLocation } from 'types/venues';
 import LocationMap from 'views/components/map/LocationMap';
 import styles from './EventMapInline.scss';
-
-const venueLocations = venueLocationJSON as VenueLocationMap;
 
 export type Props = {
   readonly isOpen: boolean;

--- a/www/src/js/views/today/EventMapInline/index.tsx
+++ b/www/src/js/views/today/EventMapInline/index.tsx
@@ -1,7 +1,7 @@
 import Loadable from 'react-loadable';
 import { Props } from './EventMapInline';
 
-export default Loadable<Props, any>({
+export default Loadable<Props, {}>({
   loader: () => import(/* webpackChunkName: "venue" */ './EventMapInline'),
   loading: () => null,
 });

--- a/www/src/js/views/today/TodayContainer/TodayContainer.tsx
+++ b/www/src/js/views/today/TodayContainer/TodayContainer.tsx
@@ -29,6 +29,7 @@ import makeResponsive from 'views/hocs/makeResponsive';
 import NoFooter from 'views/layout/NoFooter';
 import { formatTime, getCurrentHours, getCurrentMinutes, getDayIndex } from 'utils/timify';
 import { breakpointUp } from 'utils/css';
+import { EMPTY_ARRAY } from 'types/utils';
 
 import DayEvents from '../DayEvents';
 import DayHeader from '../DayHeader';
@@ -67,8 +68,6 @@ type DayGroup = {
   type: EmptyGroupType;
   dates: Date[];
 };
-
-const EMPTY_ARRAY: any[] = [];
 
 // Number of days to display
 const DAYS = 7;

--- a/www/src/js/views/today/TodayContainer/index.tsx
+++ b/www/src/js/views/today/TodayContainer/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-
 import Loadable, { LoadingComponentProps } from 'react-loadable';
+
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import ApiError from 'views/errors/ApiError';
 import { retryImport } from 'utils/error';

--- a/www/src/js/views/venues/VenueLocation/FeedbackModal.tsx
+++ b/www/src/js/views/venues/VenueLocation/FeedbackModal.tsx
@@ -1,10 +1,12 @@
-import { VenueLocation } from 'types/venues';
 import * as React from 'react';
 import classnames from 'classnames';
+
+import { VenueLocation } from 'types/venues';
 import Modal from 'views/components/Modal';
 import CloseButton from 'views/components/CloseButton';
 import ExternalLink from 'views/components/ExternalLink';
 import { MapPin, Map as MapIcon } from 'views/components/icons';
+
 import ImproveVenueForm from './ImproveVenueForm';
 import styles from './VenueLocation.scss';
 

--- a/www/src/js/views/venues/VenueLocation/VenueLocation.tsx
+++ b/www/src/js/views/venues/VenueLocation/VenueLocation.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import classnames from 'classnames';
 
-import { LatLngTuple, VenueLocation as VenueLocationItem, VenueLocationMap } from 'types/venues';
+import { LatLngTuple, VenueLocation as VenueLocationItem } from 'types/venues';
 import { Omit } from 'types/utils';
 import Modal from 'views/components/Modal';
 import LocationMap from 'views/components/map/LocationMap';
 import CloseButton from 'views/components/CloseButton';
 import { floorName } from 'utils/venues';
-/** @var { VenueLocationMap } */
-import venueLocationJSON from 'data/venues.json';
+import venueLocations from 'data/venues';
 
 import VenueContext from '../VenueContext';
 import FeedbackModal from './FeedbackModal';
@@ -27,9 +26,6 @@ type Props = OwnProps & {
 type State = {
   readonly isFeedbackModalOpen: boolean;
 };
-
-// Typecast to make TypeScript happy
-const venueLocations = venueLocationJSON as VenueLocationMap;
 
 class VenueLocation extends React.PureComponent<Props, State> {
   state: State = {

--- a/www/src/js/views/venues/VenueLocation/index.tsx
+++ b/www/src/js/views/venues/VenueLocation/index.tsx
@@ -5,7 +5,7 @@ import { retryImport } from 'utils/error';
 import ApiError from 'views/errors/ApiError';
 import { OwnProps } from './VenueLocation';
 
-const AsyncVenueLocation = Loadable<OwnProps, any>({
+const AsyncVenueLocation = Loadable<OwnProps, {}>({
   loader: () => retryImport(() => import(/* webpackChunkName: "venue" */ './VenueLocation')),
   loading: (props: LoadingComponentProps) => {
     if (props.error) {


### PR DESCRIPTION
A lot of cleaning up the usage of `any` in the code. 

- Replace with finer type where possible 
- Replace with `unknown` when the type doesn't really matter 
- Add comment and `eslint-ignore` where it would be too troublesome/verbose to type 

Also cleaned up some other lint errors, some of which are not fixed because they are fixed in other PRs