### PR TITLE
Highlight search period

### DIFF
--- a/www/src/js/views/venues/VenueDetails.tsx
+++ b/www/src/js/views/venues/VenueDetails.tsx
@@ -18,6 +18,7 @@ import { breakpointDown } from 'utils/css';
 import VenueLocation from './VenueLocation';
 
 import styles from './VenueDetails.scss';
+import { convertIndexToTime, SCHOOLDAYS } from "../../utils/timify";
 
 type Props = RouteComponentProps & {
   readonly venue: Venue;
@@ -37,8 +38,31 @@ export class VenueDetailsComponent extends React.PureComponent<Props> {
     ).map((venueLesson) => ({ ...venueLesson, ModuleTitle: '', isModifiable: true }));
 
     const coloredLessons = colorLessonsByKey(lessons, 'ModuleCode');
+    if (this.props.searchedPeriod !== undefined) {
+      coloredLessons.push(this.makeSearchedPeriodLesson());
+    }
     // @ts-ignore TODO: Fix this typing
     return arrangeLessonsForWeek(coloredLessons);
+  }
+
+  makeSearchedPeriodLesson() {
+    const day = SCHOOLDAYS[this.props.searchedPeriod.day];
+    console.log(this.props.searchedPeriod.time + this.props.searchedPeriod.duration);
+    const startTime = convertIndexToTime(this.props.searchedPeriod.time * 2);
+    const endTime = convertIndexToTime(2 * (this.props.searchedPeriod.time + this.props.searchedPeriod.duration));
+
+    let freeTimePeriod: VenueLesson = {
+      ClassNo: 'SEARCHED TIME PERIOD',
+      DayText: day,
+      EndTime: endTime,
+      LessonType: '',
+      ModuleCode: '',
+      StartTime: startTime,
+      WeekText: '',
+    };
+    let freeTimePeriodLesson = { ...freeTimePeriod, ModuleTitle: '', isModifiable: false, colorIndex: 3 };
+    console.log(freeTimePeriodLesson);
+    return freeTimePeriodLesson;
   }
 
   render() {

--- a/www/src/js/views/venues/VenueDetails.tsx
+++ b/www/src/js/views/venues/VenueDetails.tsx
@@ -18,7 +18,7 @@ import { breakpointDown } from 'utils/css';
 import VenueLocation from './VenueLocation';
 
 import styles from './VenueDetails.scss';
-import { convertIndexToTime, SCHOOLDAYS } from "../../utils/timify";
+import { convertIndexToTime, SCHOOLDAYS } from '../../utils/timify';
 
 type Props = RouteComponentProps & {
   readonly venue: Venue;
@@ -47,11 +47,12 @@ export class VenueDetailsComponent extends React.PureComponent<Props> {
 
   makeSearchedPeriodLesson() {
     const day = SCHOOLDAYS[this.props.searchedPeriod.day];
-    console.log(this.props.searchedPeriod.time + this.props.searchedPeriod.duration);
     const startTime = convertIndexToTime(this.props.searchedPeriod.time * 2);
-    const endTime = convertIndexToTime(2 * (this.props.searchedPeriod.time + this.props.searchedPeriod.duration));
+    const endTime = convertIndexToTime(
+      2 * (this.props.searchedPeriod.time + this.props.searchedPeriod.duration),
+    );
 
-    let freeTimePeriod: VenueLesson = {
+    const freeTimePeriod: VenueLesson = {
       ClassNo: 'SEARCHED TIME PERIOD',
       DayText: day,
       EndTime: endTime,
@@ -60,8 +61,13 @@ export class VenueDetailsComponent extends React.PureComponent<Props> {
       StartTime: startTime,
       WeekText: '',
     };
-    let freeTimePeriodLesson = { ...freeTimePeriod, ModuleTitle: '', isModifiable: false, colorIndex: 3 };
-    console.log(freeTimePeriodLesson);
+    // Lesson representing the searched free time period
+    const freeTimePeriodLesson = {
+      ...freeTimePeriod,
+      ModuleTitle: '',
+      isModifiable: false,
+      colorIndex: 3,
+    };
     return freeTimePeriodLesson;
   }
 

--- a/www/src/js/views/venues/VenueDetails.tsx
+++ b/www/src/js/views/venues/VenueDetails.tsx
@@ -3,7 +3,7 @@ import { Link, withRouter, RouteComponentProps } from 'react-router-dom';
 import classnames from 'classnames';
 import { flatMap } from 'lodash';
 
-import { DayAvailability, Venue, VenueLesson } from 'types/venues';
+import { DayAvailability, Venue, VenueLesson, VenueSearchOptions } from 'types/venues';
 import { Lesson } from 'types/modules';
 
 import { colorLessonsByKey } from 'utils/colors';
@@ -24,6 +24,7 @@ type Props = RouteComponentProps & {
   readonly previous?: Venue | null;
   readonly next?: Venue | null;
   readonly availability: DayAvailability[];
+  readonly searchedPeriod: VenueSearchOptions;
 
   readonly matchBreakpoint: boolean;
 };
@@ -42,7 +43,6 @@ export class VenueDetailsComponent extends React.PureComponent<Props> {
 
   render() {
     const { venue, previous, next, matchBreakpoint, history } = this.props;
-
     return (
       <>
         <Title description={`NUS classroom timetable for ${venue}`}>{`${venue} - Venues`}</Title>

--- a/www/src/js/views/venues/VenuesContainer.tsx
+++ b/www/src/js/views/venues/VenuesContainer.tsx
@@ -251,14 +251,15 @@ export class VenuesContainerComponent extends React.Component<Props, State> {
       const venueDetail = venues.find(([venue]) => venue.toLowerCase() === lowercaseSelectedVenue);
       if (!venueDetail) return null;
       const [venue, availability] = venueDetail;
-      return <VenueDetails venue={venue} availability={availability} />;
+      return <VenueDetails venue={venue} availability={availability} searchedPeriod={this.state.searchOptions} />;
     }
 
     const [venue, availability] = matchedVenues[venueIndex];
     const [previous] = get(matchedVenues, String(venueIndex - 1), []);
     const [next] = get(matchedVenues, String(venueIndex + 1), []);
     return (
-      <VenueDetails venue={venue} availability={availability} next={next} previous={previous} />
+      <VenueDetails venue={venue} availability={availability} next={next} previous={previous}
+                    searchedPeriod={this.state.searchOptions} />
     );
   }
 

--- a/www/src/js/views/venues/VenuesContainer.tsx
+++ b/www/src/js/views/venues/VenuesContainer.tsx
@@ -251,15 +251,26 @@ export class VenuesContainerComponent extends React.Component<Props, State> {
       const venueDetail = venues.find(([venue]) => venue.toLowerCase() === lowercaseSelectedVenue);
       if (!venueDetail) return null;
       const [venue, availability] = venueDetail;
-      return <VenueDetails venue={venue} availability={availability} searchedPeriod={this.state.searchOptions} />;
+      return (
+        <VenueDetails
+          venue={venue}
+          availability={availability}
+          searchedPeriod={this.state.searchOptions}
+        />
+      );
     }
 
     const [venue, availability] = matchedVenues[venueIndex];
     const [previous] = get(matchedVenues, String(venueIndex - 1), []);
     const [next] = get(matchedVenues, String(venueIndex + 1), []);
     return (
-      <VenueDetails venue={venue} availability={availability} next={next} previous={previous}
-                    searchedPeriod={this.state.searchOptions} />
+      <VenueDetails
+        venue={venue}
+        availability={availability}
+        next={next}
+        previous={previous}
+        searchedPeriod={this.state.searchOptions}
+      />
     );
   }
 


### PR DESCRIPTION
Part of #538 

Highlight period of time searched for when availability search is on.

Sample output:
<img width="960" alt="2019-02-17_21h28_14" src="https://user-images.githubusercontent.com/29021586/52913651-f8dda980-32fa-11e9-9922-e8156aea1026.png">

There is an issue with the output when changing the search start time. The searchedPeriod duration (and TimeTable component ) is not updated and so, it ends up looking like this.
<img width="960" alt="2019-02-17_21h24_55" src="https://user-images.githubusercontent.com/29021586/52913601-7bb23480-32fa-11e9-8be9-0c2e42985cf3.png">
.
