### PR TITLE
Switch to Typescript FSA

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -164,7 +164,9 @@
     "redux": "4.0.1",
     "redux-persist": "5.9.1",
     "redux-thunk": "2.2.0",
-    "reselect": "4.0.0"
+    "reselect": "4.0.0",
+    "typescript-fsa": "3.0.0-beta-2",
+    "typescript-fsa-redux-thunk": "^1.0.1"
   },
   "browserslist": [
     "last 2 versions",

--- a/www/src/js/actions/planner.ts
+++ b/www/src/js/actions/planner.ts
@@ -1,81 +1,30 @@
+import actionCreatorFactory from 'typescript-fsa';
+
 import { ModuleCode, Semester } from 'types/modules';
-import { FSA } from 'types/redux';
 import { CustomModule } from 'types/reducers';
 
-export const SET_PLANNER_MIN_YEAR = 'SET_PLANNER_MIN_YEAR';
-export function setPlannerMinYear(year: string) {
-  return {
-    type: SET_PLANNER_MIN_YEAR,
-    payload: year,
-  };
-}
+const actionCreator = actionCreatorFactory('PLANNER');
 
-export const SET_PLANNER_MAX_YEAR = 'SET_PLANNER_MAX_YEAR';
-export function setPlannerMaxYear(year: string) {
-  return {
-    type: SET_PLANNER_MAX_YEAR,
-    payload: year,
-  };
-}
+export const setMinYear = actionCreator<string>('SET_MIN_YEAR');
+export const setMaxYear = actionCreator<string>('SET_MAX_YEAR');
+export const setIBLOCs = actionCreator<boolean>('SET_IBLOCS');
 
-export const SET_PLANNER_IBLOCS = 'SET_PLANNER_IBLOCS';
-export function setPlannerIBLOCs(iblocs: boolean) {
-  return {
-    type: SET_PLANNER_IBLOCS,
-    payload: iblocs,
-  };
-}
+export type AddModulePayload = {
+  moduleCode: ModuleCode;
+  year: string;
+  semester: Semester;
+  index?: number;
+};
 
-export const ADD_PLANNER_MODULE = 'ADD_PLANNER_MODULE';
-export function addPlannerModule(
-  moduleCode: ModuleCode,
-  year: string,
-  semester: Semester,
-  index: number | null = null,
-): FSA {
-  return {
-    type: ADD_PLANNER_MODULE,
-    payload: {
-      year,
-      semester,
-      moduleCode,
-      index,
-    },
-  };
-}
+export type MoveModulePayload = AddModulePayload;
 
-export const MOVE_PLANNER_MODULE = 'MOVE_PLANNER_MODULE';
-export function movePlannerModule(
-  moduleCode: ModuleCode,
-  year: string,
-  semester: Semester,
-  index: number | null = null,
-): FSA {
-  return {
-    type: MOVE_PLANNER_MODULE,
-    payload: {
-      year,
-      semester,
-      moduleCode,
-      index,
-    },
-  };
-}
+export const addModule = actionCreator<AddModulePayload>('ADD_MODULE');
+export const moveModule = actionCreator<MoveModulePayload>('MOVE_MODULE');
 
-export const REMOVE_PLANNER_MODULE = 'REMOVE_PLANNER_MODULE';
-export function removePlannerModule(moduleCode: ModuleCode): FSA {
-  return {
-    type: REMOVE_PLANNER_MODULE,
-    payload: {
-      moduleCode,
-    },
-  };
-}
+export type RemoveModulePayload = { moduleCode: ModuleCode };
+export const removeModule = actionCreator<RemoveModulePayload>('REMOVE_MODULE');
 
-export const ADD_CUSTOM_PLANNER_DATA = 'ADD_CUSTOM_PLANNER_DATA';
-export function addCustomModule(moduleCode: ModuleCode, data: CustomModule): FSA {
-  return {
-    type: ADD_CUSTOM_PLANNER_DATA,
-    payload: { moduleCode, data },
-  };
-}
+export const addCustomModule = actionCreator<{
+  moduleCode: ModuleCode;
+  data: CustomModule;
+}>('ADD_CUSTOM_DATA');

--- a/www/src/js/reducers/planner.test.ts
+++ b/www/src/js/reducers/planner.test.ts
@@ -1,16 +1,10 @@
 import {
-  ADD_PLANNER_MODULE,
-  MOVE_PLANNER_MODULE,
-  REMOVE_PLANNER_MODULE,
-  SET_PLANNER_MIN_YEAR,
-  SET_PLANNER_MAX_YEAR,
-  SET_PLANNER_IBLOCS,
-  addPlannerModule,
-  movePlannerModule,
-  removePlannerModule,
-  setPlannerMinYear,
-  setPlannerMaxYear,
-  setPlannerIBLOCs,
+  addModule,
+  moveModule,
+  removeModule,
+  setMinYear,
+  setMaxYear,
+  setIBLOCs,
 } from 'actions/planner';
 import { PlannerState } from 'types/reducers';
 import reducer from './planner';
@@ -25,9 +19,9 @@ const defaultState: PlannerState = {
 
 /* eslint-disable no-useless-computed-key */
 
-describe(SET_PLANNER_MIN_YEAR, () => {
+describe(setMinYear, () => {
   test('should set min year', () => {
-    expect(reducer(defaultState, setPlannerMinYear('2016/2017'))).toEqual({
+    expect(reducer(defaultState, setMinYear('2016/2017'))).toEqual({
       ...defaultState,
       minYear: '2016/2017',
       maxYear: '2018/2019',
@@ -35,7 +29,7 @@ describe(SET_PLANNER_MIN_YEAR, () => {
   });
 
   test('should set max year if min year is past it', () => {
-    expect(reducer(defaultState, setPlannerMinYear('2019/2020'))).toEqual({
+    expect(reducer(defaultState, setMinYear('2019/2020'))).toEqual({
       ...defaultState,
       minYear: '2019/2020',
       maxYear: '2019/2020',
@@ -43,9 +37,9 @@ describe(SET_PLANNER_MIN_YEAR, () => {
   });
 });
 
-describe(SET_PLANNER_MAX_YEAR, () => {
+describe(setMaxYear, () => {
   test('should set max year', () => {
-    expect(reducer(defaultState, setPlannerMaxYear('2020/2021'))).toEqual({
+    expect(reducer(defaultState, setMaxYear('2020/2021'))).toEqual({
       ...defaultState,
       minYear: '2017/2018',
       maxYear: '2020/2021',
@@ -53,7 +47,7 @@ describe(SET_PLANNER_MAX_YEAR, () => {
   });
 
   test('should set min year if max year is past it', () => {
-    expect(reducer(defaultState, setPlannerMaxYear('2016/2017'))).toEqual({
+    expect(reducer(defaultState, setMaxYear('2016/2017'))).toEqual({
       ...defaultState,
       minYear: '2016/2017',
       maxYear: '2016/2017',
@@ -61,35 +55,41 @@ describe(SET_PLANNER_MAX_YEAR, () => {
   });
 });
 
-describe(SET_PLANNER_IBLOCS, () => {
+describe(setIBLOCs, () => {
   test('should set iblocs status', () => {
-    expect(reducer(defaultState, setPlannerIBLOCs(true))).toEqual({
+    expect(reducer(defaultState, setIBLOCs(true))).toEqual({
       ...defaultState,
       iblocs: true,
     });
   });
 });
 
-describe(ADD_PLANNER_MODULE, () => {
+describe(addModule, () => {
   const initial: PlannerState = {
     ...defaultState,
     modules: { CS1010S: ['2018/2019', 1, 0] },
   };
 
   test('should add module to semester and year', () => {
-    expect(reducer(initial, addPlannerModule('CS2030', '2018/2019', 2)).modules).toEqual({
+    expect(
+      reducer(initial, addModule({ moduleCode: 'CS2030', year: '2018/2019', semester: 2 })).modules,
+    ).toEqual({
       CS1010S: ['2018/2019', 1, 0],
       CS2030: ['2018/2019', 2, 0],
     });
 
     // Add module code in uppercase
-    expect(reducer(initial, addPlannerModule('cs2030', '2018/2019', 2)).modules).toEqual({
+    expect(
+      reducer(initial, addModule({ moduleCode: 'cs2030', year: '2018/2019', semester: 2 })).modules,
+    ).toEqual({
       CS1010S: ['2018/2019', 1, 0],
       CS2030: ['2018/2019', 2, 0],
     });
 
     // Inserts new module in correct position
-    expect(reducer(initial, addPlannerModule('CS2030', '2018/2019', 1)).modules).toEqual({
+    expect(
+      reducer(initial, addModule({ moduleCode: 'CS2030', year: '2018/2019', semester: 1 })).modules,
+    ).toEqual({
       CS1010S: ['2018/2019', 1, 0],
       CS2030: ['2018/2019', 1, 1],
     });
@@ -97,17 +97,23 @@ describe(ADD_PLANNER_MODULE, () => {
 
   test('should not add duplicate modules', () => {
     expect(
-      Object.keys(reducer(initial, addPlannerModule('CS1010S', '2018/2019', 1)).modules),
+      Object.keys(
+        reducer(initial, addModule({ moduleCode: 'CS1010S', year: '2018/2019', semester: 1 }))
+          .modules,
+      ),
     ).toHaveLength(1);
 
     // Also deduplicate lowercase module codes
     expect(
-      Object.keys(reducer(initial, addPlannerModule('cs1010s', '2018/2019', 1)).modules),
+      Object.keys(
+        reducer(initial, addModule({ moduleCode: 'cs1010s', year: '2018/2019', semester: 1 }))
+          .modules,
+      ),
     ).toHaveLength(1);
   });
 });
 
-describe(MOVE_PLANNER_MODULE, () => {
+describe(moveModule, () => {
   const initial: PlannerState = {
     ...defaultState,
 
@@ -119,7 +125,12 @@ describe(MOVE_PLANNER_MODULE, () => {
   };
 
   test('should move modules between same semester', () => {
-    expect(reducer(initial, movePlannerModule('CS2105', '2018/2019', 2, 0)).modules).toEqual({
+    expect(
+      reducer(
+        initial,
+        moveModule({ moduleCode: 'CS2105', year: '2018/2019', semester: 2, index: 0 }),
+      ).modules,
+    ).toEqual({
       CS1010S: ['2018/2019', 1, 0],
       CS2030: ['2018/2019', 2, 1],
       CS2105: ['2018/2019', 2, 0],
@@ -135,7 +146,7 @@ describe(MOVE_PLANNER_MODULE, () => {
             CS2105: ['2018/2019', 2, 2],
           },
         },
-        movePlannerModule('CS2105', '2018/2019', 2, 1),
+        moveModule({ moduleCode: 'CS2105', year: '2018/2019', semester: 2, index: 1 }),
       ).modules,
     ).toEqual({
       CS1010S: ['2018/2019', 2, 0],
@@ -146,19 +157,34 @@ describe(MOVE_PLANNER_MODULE, () => {
 
   test('should move module to other acad year or semester', () => {
     // Move CS2105 from sem 2 to 1
-    expect(reducer(initial, movePlannerModule('CS2105', '2018/2019', 1, 0)).modules).toEqual({
+    expect(
+      reducer(
+        initial,
+        moveModule({ moduleCode: 'CS2105', year: '2018/2019', semester: 1, index: 0 }),
+      ).modules,
+    ).toEqual({
       CS1010S: ['2018/2019', 1, 1],
       CS2030: ['2018/2019', 2, 0],
       CS2105: ['2018/2019', 1, 0],
     });
 
-    expect(reducer(initial, movePlannerModule('CS1010S', '2017/2018', 2, 0)).modules).toEqual({
+    expect(
+      reducer(
+        initial,
+        moveModule({ moduleCode: 'CS1010S', year: '2017/2018', semester: 2, index: 0 }),
+      ).modules,
+    ).toEqual({
       CS1010S: ['2017/2018', 2, 0],
       CS2030: ['2018/2019', 2, 0],
       CS2105: ['2018/2019', 2, 1],
     });
 
-    expect(reducer(initial, movePlannerModule('CS1010S', '2018/2019', 2, 1)).modules).toEqual({
+    expect(
+      reducer(
+        initial,
+        moveModule({ moduleCode: 'CS1010S', year: '2018/2019', semester: 2, index: 1 }),
+      ).modules,
+    ).toEqual({
       CS1010S: ['2018/2019', 2, 1],
       CS2030: ['2018/2019', 2, 0],
       CS2105: ['2018/2019', 2, 2],
@@ -166,7 +192,7 @@ describe(MOVE_PLANNER_MODULE, () => {
   });
 });
 
-describe(REMOVE_PLANNER_MODULE, () => {
+describe(removeModule, () => {
   const initial: PlannerState = {
     ...defaultState,
 
@@ -174,6 +200,6 @@ describe(REMOVE_PLANNER_MODULE, () => {
   };
 
   test('should remove the specified module', () => {
-    expect(reducer(initial, removePlannerModule('CS1010S')).modules).toEqual({});
+    expect(reducer(initial, removeModule({ moduleCode: 'CS1010S' })).modules).toEqual({});
   });
 });

--- a/www/src/js/reducers/planner.ts
+++ b/www/src/js/reducers/planner.ts
@@ -1,17 +1,18 @@
 import produce from 'immer';
 import { pull, max, min } from 'lodash';
+import { isType } from 'typescript-fsa';
+import { Action } from 'redux';
 
 import { PlannerState } from 'types/reducers';
-import { FSA } from 'types/redux';
 import { ModuleCode } from 'types/modules';
 import {
-  ADD_PLANNER_MODULE,
-  MOVE_PLANNER_MODULE,
-  REMOVE_PLANNER_MODULE,
-  SET_PLANNER_IBLOCS,
-  SET_PLANNER_MAX_YEAR,
-  SET_PLANNER_MIN_YEAR,
-  ADD_CUSTOM_PLANNER_DATA,
+  setMinYear,
+  setMaxYear,
+  setIBLOCs,
+  addModule,
+  moveModule,
+  removeModule,
+  addCustomModule,
 } from 'actions/planner';
 import { filterModuleForSemester } from 'selectors/planner';
 import config from 'config';
@@ -27,86 +28,84 @@ const defaultPlannerState: PlannerState = {
 
 export default function planner(
   state: PlannerState = defaultPlannerState,
-  action: FSA,
+  action: Action,
 ): PlannerState {
-  switch (action.type) {
-    case SET_PLANNER_MIN_YEAR:
-      return {
-        ...state,
-        minYear: action.payload,
-        maxYear: max([action.payload, state.maxYear]),
-      };
+  if (isType(action, setMinYear)) {
+    return {
+      ...state,
+      minYear: action.payload,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      maxYear: max([action.payload, state.maxYear])!,
+    };
+  }
 
-    case SET_PLANNER_MAX_YEAR:
-      return {
-        ...state,
-        maxYear: action.payload,
-        minYear: min([action.payload, state.minYear]),
-      };
+  if (isType(action, setMaxYear)) {
+    return {
+      ...state,
+      maxYear: action.payload,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      minYear: min([action.payload, state.minYear])!,
+    };
+  }
 
-    case SET_PLANNER_IBLOCS:
-      return { ...state, iblocs: action.payload };
+  if (isType(action, setIBLOCs)) {
+    return { ...state, iblocs: action.payload };
+  }
 
-    // Adding and updating planner modules currently do the exact same thing.
-    // We assume the user knows when evoking MOVE that the module is in the
-    // planner already
-    case ADD_PLANNER_MODULE:
-    case MOVE_PLANNER_MODULE: {
-      const { year, semester, index } = action.payload;
-      const moduleCode = action.payload.moduleCode.toUpperCase();
+  if (isType(action, removeModule)) {
+    return produce(state, (draft) => {
+      delete draft.modules[action.payload.moduleCode];
+    });
+  }
 
-      // Insert the module into its new location and update the location of
-      // all other modules on the list
-      const newModuleOrder = pull(
-        filterModuleForSemester(state.modules, year, semester),
-        moduleCode,
-      );
+  if (isType(action, addCustomModule)) {
+    return produce(state, (draft) => {
+      draft.custom[action.payload.moduleCode] = action.payload.data;
+    });
+  }
 
-      // If index is not specified we assume the module is to be pushed to the
-      // end of the index
-      if (index == null) {
-        newModuleOrder.push(moduleCode);
-      } else {
-        newModuleOrder.splice(index, 0, moduleCode);
-      }
+  if (isType(action, addModule) || isType(action, moveModule)) {
+    const { year, semester, index = null } = action.payload;
 
-      // If the module is moved from another year / semester, then we also need
-      // to update the index of the old module list
-      let oldModuleOrder: ModuleCode[] = [];
-      if (state.modules[moduleCode]) {
-        const [oldYear, oldSemester] = state.modules[moduleCode];
-        if (oldYear !== year || oldSemester !== semester) {
-          oldModuleOrder = pull(
-            filterModuleForSemester(state.modules, oldYear, oldSemester),
-            moduleCode,
-          );
-        }
-      }
+    const moduleCode = action.payload.moduleCode.toUpperCase();
 
-      return produce(state, (draft) => {
-        draft.modules[moduleCode] = [year, semester, index];
+    // Insert the module into its new location and update the location of
+    // all other modules on the list
+    const newModuleOrder = pull(filterModuleForSemester(state.modules, year, semester), moduleCode);
 
-        newModuleOrder.forEach((newModuleCode, order) => {
-          draft.modules[newModuleCode][2] = order;
-        });
-
-        oldModuleOrder.forEach((oldModuleCode, order) => {
-          draft.modules[oldModuleCode][2] = order;
-        });
-      });
+    // If index is not specified we assume the module is to be pushed to the
+    // end of the index
+    if (index == null) {
+      newModuleOrder.push(moduleCode);
+    } else {
+      newModuleOrder.splice(index, 0, moduleCode);
     }
 
-    case REMOVE_PLANNER_MODULE:
-      return produce(state, (draft) => {
-        delete draft.modules[action.payload.moduleCode];
+    // If the module is moved from another year / semester, then we also need
+    // to update the index of the old module list
+    let oldModuleOrder: ModuleCode[] = [];
+    if (state.modules[moduleCode]) {
+      const [oldYear, oldSemester] = state.modules[moduleCode];
+      if (oldYear !== year || oldSemester !== semester) {
+        oldModuleOrder = pull(
+          filterModuleForSemester(state.modules, oldYear, oldSemester),
+          moduleCode,
+        );
+      }
+    }
+
+    return produce(state, (draft) => {
+      draft.modules[moduleCode] = [year, semester, index || newModuleOrder.length - 1];
+
+      newModuleOrder.forEach((newModuleCode, order) => {
+        draft.modules[newModuleCode][2] = order;
       });
 
-    case ADD_CUSTOM_PLANNER_DATA:
-      return produce(state, (draft) => {
-        draft.custom[action.payload.moduleCode] = action.payload.data;
+      oldModuleOrder.forEach((oldModuleCode, order) => {
+        draft.modules[oldModuleCode][2] = order;
       });
-
-    default:
-      return state;
+    });
   }
+
+  return state;
 }

--- a/www/src/js/views/planner/PlannerSettings.tsx
+++ b/www/src/js/views/planner/PlannerSettings.tsx
@@ -6,7 +6,7 @@ import config from 'config';
 import { State } from 'reducers';
 import { getYearsBetween, offsetAcadYear } from 'utils/modules';
 import { acadYearLabel } from 'utils/planner';
-import { setPlannerIBLOCs, setPlannerMaxYear, setPlannerMinYear } from 'actions/planner';
+import { setIBLOCs, setMaxYear, setMinYear } from 'actions/planner';
 import ExternalLink from 'views/components/ExternalLink';
 import Toggle from 'views/components/Toggle';
 import styles from './PlannerSettings.scss';
@@ -133,9 +133,9 @@ const PlannerSettings = connect(
     iblocs: state.planner.iblocs,
   }),
   {
-    setMaxYear: setPlannerMaxYear,
-    setMinYear: setPlannerMinYear,
-    setIBLOCs: setPlannerIBLOCs,
+    setMaxYear,
+    setMinYear,
+    setIBLOCs,
   },
 )(PlannerSettingsComponent);
 

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -7529,6 +7529,11 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lodash-es@^4.2.1:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
+  integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
+
 lodash-webpack-plugin@0.11.5:
   version "0.11.5"
   resolved "https://registry.yarnpkg.com/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.5.tgz#c4bd064b4f561c3f823fa5982bdeb12c475390b9"
@@ -7760,7 +7765,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.11, lodash@^4.17.11:
+lodash@4.17.11, lodash@^4.17.11, lodash@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -10686,6 +10691,11 @@ redux-thunk@2.2.0:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
   integrity sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU=
 
+redux-thunk@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
 redux@4.0.1, redux@^4.0.0, redux@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
@@ -10693,6 +10703,16 @@ redux@4.0.1, redux@^4.0.0, redux@^4.0.1:
   dependencies:
     loose-envify "^1.4.0"
     symbol-observable "^1.2.0"
+
+redux@^3.7.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  integrity sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
 
 regenerate-unicode-properties@^7.0.0:
   version "7.0.0"
@@ -12182,7 +12202,7 @@ svgo@^1.1.1:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-observable@^1.2.0:
+symbol-observable@^1.0.3, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -12525,7 +12545,7 @@ trough@^1.0.0:
   dependencies:
     glob "^6.0.4"
 
-tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
@@ -12578,6 +12598,26 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript-fsa-redux-thunk@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/typescript-fsa-redux-thunk/-/typescript-fsa-redux-thunk-1.0.1.tgz#ca7cfa0dd582960cec00c622efdbc787b3c58d4b"
+  integrity sha512-+im3ewRmuuJK5ygLFpFkqT/mHrcI9PaGk8IKnuZ5kHIyk6jTtBSXPBbBg7yB/x8mXIcAU1zMBcsiNJBw4WaTuA==
+  dependencies:
+    redux "^3.7.0"
+    redux-thunk "^2.2.0"
+    tslib "^1.7.1"
+    typescript-fsa "^2.3.0"
+
+typescript-fsa@3.0.0-beta-2:
+  version "3.0.0-beta-2"
+  resolved "https://registry.yarnpkg.com/typescript-fsa/-/typescript-fsa-3.0.0-beta-2.tgz#1cc1d0c014c025fd51cba097776033ac4b6b753c"
+  integrity sha512-qXkHih2XAtpxqd3AEVgFtCDwvBlAMl2miVy1TmS+wXgiRlVw7orf2qIh3C8faANhD34n75Ui8x5ydQ40uzuskA==
+
+typescript-fsa@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/typescript-fsa/-/typescript-fsa-2.5.0.tgz#1baec01b5e8f5f34c322679d1327016e9e294faf"
+  integrity sha1-G67AG16PXzTDImedEycBbp4pT68=
 
 typescript@3.3.3:
   version "3.3.3"


### PR DESCRIPTION
Experimenting with TypeScript FSA. This gives us proper typing on the `payload` prop in the reducer automatically if we use their helpers. 

The downside is that we can't use `switch`, which makes the code a bit uglier. The bigger issue is that the action must always take one parameter which is the shape of the payload. This is problematic because we're breaking abstraction as the action now can't serve as a clean interface between the view and the model (reducers), since changes to the action's internal implementation (payload shape) now leaks into the views. 

On the other hand most of our action creators are simply binding parameters to payload, so it might not be too big an issue? 

Alternatively we can consider [`typesafe-actions`](https://github.com/piotrwitek/typesafe-actions#typesafe-actions) which does offer a `map` method which allows us to map the params to the payload, at the expense of more boilerplate. 