### PR TITLE
Add tooltips for navtab labels 

### DIFF
--- a/www/src/js/utils/css.ts
+++ b/www/src/js/utils/css.ts
@@ -5,13 +5,16 @@ import bowser from 'bowser';
 
 export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
-const breakpoints: { [breakpoint: string]: number } = {
+const breakpoints: { [breakpoint in Breakpoint]: number } = {
   xs: 0,
   sm: 576,
   md: 768,
   lg: 992,
   xl: 1200,
 };
+
+// Safari and Non-Safari browsers in iOS
+export const isMobileIos = () => bowser.ios;
 
 function nextBreakpoint(size: Breakpoint): number | null | undefined {
   const breakpointEntries = entries(breakpoints);
@@ -21,16 +24,28 @@ function nextBreakpoint(size: Breakpoint): number | null | undefined {
   return breakpointEntries[nextBreakpointIndex][1];
 }
 
+/**
+ * Matches breakpoints equal to and below the given size; equal to the
+ * breakpoint-down SCSS mixin
+ */
 export function breakpointDown(size: Breakpoint): QueryObject {
   const nextSize = nextBreakpoint(size);
   if (nextSize == null) return { all: true };
   return { maxWidth: nextSize - 1 };
 }
 
+/**
+ * Matches breakpoints strictly above the given size; equal to the
+ * breakpoint-up SCSS mixin
+ */
 export function breakpointUp(size: Breakpoint): QueryObject {
   return { minWidth: breakpoints[size] };
 }
 
+/**
+ * Matches user-agents which declare themselves to be touchscreens
+ * or devices without a precise pointing device
+ */
 export function touchScreenOnly(): QueryObject {
   return { pointer: 'coarse' };
 }
@@ -43,6 +58,3 @@ export function supportsCSSVariables() {
   // Safari does not support supports('--var', 'red')
   return CSS.supports && CSS.supports('(--var: red)');
 }
-
-// Safari and Non-Safari browsers in iOS
-export const isMobileIos = (): boolean => bowser.ios;

--- a/www/src/js/views/components/Tooltip/Tooltip.tsx
+++ b/www/src/js/views/components/Tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
-import * as React from 'react';
+import React from 'react';
 import Tippy, { TippyProps } from '@tippy.js/react';
-import bowser from 'bowser';
+import { isMobileIos } from 'utils/css';
+
 import 'styles/tippy/tippy.css';
 
 export type Props = TippyProps & {};
@@ -10,7 +11,7 @@ function Tooltip(props: Props) {
 
   // HACK: Emulate Android tooltip behavior (hold to show tooltip, tap to
   // activate click) on iOS
-  if (tippyProps.touchHold && bowser.ios) {
+  if (tippyProps.touchHold && isMobileIos()) {
     tippyProps.trigger = 'focus';
   }
 

--- a/www/src/js/views/layout/NavtabLink.tsx
+++ b/www/src/js/views/layout/NavtabLink.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { NavLink, NavLinkProps } from 'react-router-dom';
+
+import Tooltip from 'views/components/Tooltip/Tooltip';
+import styles from './Navtabs.scss';
+
+type Props = NavLinkProps & {
+  label: string;
+  hideLabel: boolean;
+  onHover?: () => void;
+};
+
+/**
+ * Represents a single item on the navtabs list
+ */
+function NavtabLink({ children, label, hideLabel, onHover, ...otherProps }: Props) {
+  return (
+    <Tooltip isEnabled={hideLabel} content={label} placement="bottom" touchHold>
+      <NavLink onMouseOver={onHover} onFocus={onHover} {...otherProps}>
+        {children}
+        {!hideLabel && <div className={styles.title}>{label}</div>}
+      </NavLink>
+    </Tooltip>
+  );
+}
+
+export default NavtabLink;

--- a/www/src/js/views/layout/Navtabs.scss
+++ b/www/src/js/views/layout/Navtabs.scss
@@ -93,12 +93,7 @@
 }
 
 .title {
-  display: none;
   font-size: 0.7rem;
-
-  @include media-breakpoint-up(md) {
-    display: block;
-  }
 
   @include media-breakpoint-up(xl) {
     margin-left: 0.4rem;
@@ -106,21 +101,18 @@
   }
 }
 
-.hiddenOnMobile {
-  @include media-breakpoint-down(sm) {
-    display: none;
-  }
-}
-
 .divider {
   $size: 70%;
   $margin: 0.3rem;
 
-  composes: hiddenOnMobile;
   opacity: 0.6;
   flex: 0 0 1px;
   margin: $margin ((100% - $size) / 2) 0;
   background: var(--gray-lighter);
+
+  @include media-breakpoint-down(sm) {
+    display: none;
+  }
 
   @include media-breakpoint-up(xl) {
     margin: $margin 1rem $margin 1.4rem;

--- a/www/src/js/views/layout/Navtabs.test.tsx
+++ b/www/src/js/views/layout/Navtabs.test.tsx
@@ -11,6 +11,7 @@ describe(NavtabsComponent, () => {
         activeSemester={1}
         beta={false}
         promptRefresh={false}
+        matchBreakpoint={false}
         {...createHistory()}
       />,
     );

--- a/www/src/js/views/layout/__snapshots__/Navtabs.test.tsx.snap
+++ b/www/src/js/views/layout/__snapshots__/Navtabs.test.tsx.snap
@@ -4,90 +4,63 @@ exports[`NavtabsComponent renders into nav element 1`] = `
 <nav
   className="nav"
 >
-  <NavLink
+  <NavtabLink
     activeClassName="linkActive"
-    aria-current="page"
     className="link"
+    label="Timetable"
     to="/timetable/sem-1"
   >
     <Calendar
       color="currentColor"
       size="24"
     />
-    <span
-      className="title"
-    >
-      Timetable
-    </span>
-  </NavLink>
-  <NavLink
+  </NavtabLink>
+  <NavtabLink
     activeClassName="linkActive"
-    aria-current="page"
     className="link"
+    label="Modules"
     to="/modules"
   >
     <BookOpen
       color="currentColor"
       size="24"
     />
-    <span
-      className="title"
-    >
-      Modules
-    </span>
-  </NavLink>
-  <NavLink
+  </NavtabLink>
+  <NavtabLink
     activeClassName="linkActive"
-    aria-current="page"
     className="link"
-    onFocus={[Function]}
-    onMouseOver={[Function]}
+    label="Venues"
+    onHover={[Function]}
     to="/venues"
   >
     <Map
       color="currentColor"
       size="24"
     />
-    <span
-      className="title"
-    >
-      Venues
-    </span>
-  </NavLink>
-  <NavLink
+  </NavtabLink>
+  <NavtabLink
     activeClassName="linkActive"
-    aria-current="page"
     className="link"
+    label="Settings"
     to="/settings"
   >
     <Settings
       color="currentColor"
       size="24"
     />
-    <span
-      className="title"
-    >
-      Settings
-    </span>
-  </NavLink>
-  <NavLink
+  </NavtabLink>
+  <NavtabLink
     activeClassName="linkActive"
-    aria-current="page"
-    className="link hiddenOnMobile"
-    onFocus={[Function]}
-    onMouseOver={[Function]}
+    className="link"
+    label="Contribute"
+    onHover={[Function]}
     to="/contribute"
   >
     <Star
       color="currentColor"
       size="24"
     />
-    <span
-      className="title"
-    >
-      Contribute
-    </span>
-  </NavLink>
+  </NavtabLink>
   <div
     className="divider"
   />

--- a/www/src/js/views/layout/__snapshots__/Navtabs.test.tsx.snap
+++ b/www/src/js/views/layout/__snapshots__/Navtabs.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`NavtabsComponent renders into nav element 1`] = `
   <NavtabLink
     activeClassName="linkActive"
     className="link"
+    hideLabel={false}
     label="Timetable"
     to="/timetable/sem-1"
   >
@@ -18,6 +19,7 @@ exports[`NavtabsComponent renders into nav element 1`] = `
   <NavtabLink
     activeClassName="linkActive"
     className="link"
+    hideLabel={false}
     label="Modules"
     to="/modules"
   >
@@ -29,6 +31,7 @@ exports[`NavtabsComponent renders into nav element 1`] = `
   <NavtabLink
     activeClassName="linkActive"
     className="link"
+    hideLabel={false}
     label="Venues"
     onHover={[Function]}
     to="/venues"
@@ -41,6 +44,7 @@ exports[`NavtabsComponent renders into nav element 1`] = `
   <NavtabLink
     activeClassName="linkActive"
     className="link"
+    hideLabel={false}
     label="Settings"
     to="/settings"
   >
@@ -52,6 +56,7 @@ exports[`NavtabsComponent renders into nav element 1`] = `
   <NavtabLink
     activeClassName="linkActive"
     className="link"
+    hideLabel={false}
     label="Contribute"
     onHover={[Function]}
     to="/contribute"

--- a/www/src/js/views/venues/VenueLocation/ImproveVenueForm.tsx
+++ b/www/src/js/views/venues/VenueLocation/ImproveVenueForm.tsx
@@ -3,11 +3,11 @@ import { LatLng } from 'leaflet';
 import { Map, Marker, TileLayer, Viewport } from 'react-leaflet';
 import classnames from 'classnames';
 import axios from 'axios';
-import bowser from 'bowser';
 import produce from 'immer';
 
 import { LatLngTuple, Venue, VenueLocation } from 'types/venues';
 import config from 'config';
+import { isMobileIos } from 'utils/css';
 import { MapPin, ThumbsUp } from 'views/components/icons';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import { markerIcon } from 'views/components/map/icons';
@@ -174,7 +174,7 @@ export default class ImproveVenueForm extends React.PureComponent<Props, State> 
     // HACK: There's an iOS bug that clips the expanded map around the modal,
     // making it impossible to exit the expanded state. While we find a better
     // solution for now we'll just hide the button
-    const showExpandMapBtn = !bowser.ios;
+    const showExpandMapBtn = !isMobileIos();
 
     return (
       <form className="form-row" onSubmit={this.onSubmit}>


### PR DESCRIPTION
With this PR, on mobile devices users can now long press the navtabs to see the label which is currently only shown on desktop / tablet sizes 