### PR TITLE
Add purgeOnError option for Workbox and remove ModuleConcatenationPlugin

### DIFF
--- a/www/webpack/webpack.config.prod.js
+++ b/www/webpack/webpack.config.prod.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const merge = require('webpack-merge');
-const webpack = require('webpack');
 const TerserJsPlugin = require('terser-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -66,7 +65,6 @@ const productionConfig = merge([
     },
     plugins: [
       // SEE: https://medium.com/webpack/brief-introduction-to-scope-hoisting-in-webpack-8435084c171f
-      new webpack.optimize.ModuleConcatenationPlugin(),
       new HtmlWebpackPlugin({
         template: path.join(parts.PATHS.app, 'index.html'),
         minify: {

--- a/www/webpack/webpack.parts.js
+++ b/www/webpack/webpack.parts.js
@@ -275,6 +275,7 @@ exports.workbox = () => ({
             },
             expiration: {
               maxAgeSeconds: ONE_MONTH,
+              purgeOnQuotaError: true,
             },
           },
         },
@@ -291,6 +292,7 @@ exports.workbox = () => ({
             expiration: {
               maxEntries: 500,
               maxAgeSeconds: ONE_MONTH,
+              purgeOnQuotaError: true,
             },
           },
         },


### PR DESCRIPTION
- Remove ModuleConcatenationPlugin because the plugin is deprecated in favor of the `optimizations.concatenateModule` option, which is already enabled by default in production so we don't need this 
- Add `purgeOnQuotaError: true` to our Workbox cache to avoid `QuotaExceededError` - https://sentry.io/share/issue/557b1984ac044a798562d0c169cb17e9/