### PR TITLE
Fix different module data between semesters warning using deep-diff

### DIFF
--- a/scrapers/nus-v2/package.json
+++ b/scrapers/nus-v2/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/bunyan": "1.8.5",
+    "@types/deep-diff": "1.0.0",
     "@types/fs-extra": "5.0.5",
     "@types/jest": "23.3.13",
     "@types/joi": "14.3.1",
@@ -51,6 +52,7 @@
     "bunyan": "1.8.12",
     "chevrotain": "4.2.0",
     "date-fns": "2.0.0-alpha.27",
+    "deep-diff": "1.0.2",
     "fs-extra": "7.0.1",
     "joi": "14.3.1",
     "lodash": "4.17.11",

--- a/scrapers/nus-v2/src/tasks/CollateModules.test.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.test.ts
@@ -1,5 +1,5 @@
 import { mapValues } from 'lodash';
-import { combineModules, mergeAliases } from './CollateModules';
+import { combineModules, mergeAliases, moduleDataCheck } from './CollateModules';
 import { mockLogger } from '../utils/test-utils';
 
 describe(combineModules, () => {
@@ -14,9 +14,8 @@ describe(combineModules, () => {
       faculty: 'Business',
       department: 'Accounting',
       title: 'Accounting Information Systems',
-      workload: '0-3-0-4-3',
+      workload: [0, 3, 0, 4, 3],
       prerequisite: 'FNA1002 or ACC1002',
-      corequisite: '',
       moduleCredit: '4',
       moduleCode: 'ACC1006',
     };
@@ -91,6 +90,72 @@ describe(combineModules, () => {
         semesterData: [semesterOneData, semesterTwoData],
       },
     ]);
+  });
+});
+
+describe(moduleDataCheck, () => {
+  const semesterModule = {
+    acadYear: '2018/2019',
+    description: 'This course aims to help students understand the role of information...',
+    preclusion: 'Students who have passed FNA1006',
+    faculty: 'Business',
+    department: 'Accounting',
+    title: 'Accounting Information Systems',
+    workload: [0, 3, 0, 4, 3],
+    prerequisite: 'FNA1002 or ACC1002',
+    moduleCredit: '4',
+    moduleCode: 'ACC1006',
+  };
+
+  const module = {
+    ...semesterModule,
+    aliases: ['ACC1006X'],
+    semesterData: [
+      {
+        semester: 1,
+        timetable: [
+          {
+            classNo: 'A1',
+            startTime: '1400',
+            endTime: '1700',
+            weeks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+            venue: 'UTSRC-LT51',
+            day: 'Thursday',
+            lessonType: 'Sectional Teaching',
+          },
+        ],
+        examDate: '2018-12-06T13:00:00.000+08:00',
+        examDuration: 120,
+      },
+    ],
+  };
+
+  test('should return null if the two are the same', () => {
+    expect(moduleDataCheck(module, semesterModule)).toBeNull();
+  });
+
+  test('should return keys that are different', () => {
+    expect(
+      moduleDataCheck(
+        {
+          ...module,
+          // Change workload
+          workload: [0, 3, 1, 3, 3],
+          // Add corequisite
+          corequisite: 'ACC1006C',
+        },
+        semesterModule,
+      ),
+    ).toEqual({
+      left: {
+        workload: [0, 3, 1, 3, 3],
+        corequisite: 'ACC1006C',
+      },
+      right: {
+        workload: [0, 3, 0, 4, 3],
+        corequisite: undefined,
+      },
+    });
   });
 });
 

--- a/scrapers/nus-v2/yarn.lock
+++ b/scrapers/nus-v2/yarn.lock
@@ -197,6 +197,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/deep-diff@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/deep-diff/-/deep-diff-1.0.0.tgz#7eba3202a99b3a207f758f351f7f86387269fc40"
+  integrity sha512-ENsJcujGbCU/oXhDfQ12mSo/mCBWodT2tpARZKmatoSrf8+cGRCPi0KVj3I0FORhYZfLXkewXu7AoIWqiBLkNw==
+
 "@types/fs-extra@5.0.5":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.5.tgz#080d90a792f3fa2c5559eb44bd8ef840aae9104b"
@@ -919,6 +924,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+deep-diff@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-1.0.2.tgz#afd3d1f749115be965e89c63edc7abb1506b9c26"
+  integrity sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==
 
 deep-extend@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Fixed a bug caused by #1614 because I missed a key when updating the code. Switched to using deep-diff (https://github.com/flitbit/diff) instead of manually picking the keys for better type safety and smaller, more readable logs since we now only log keys that differ so we won't have to scan through the keys that are the same. 