### PR TITLE
Add module attributes to API

### DIFF
--- a/scrapers/nus-v2/.eslintrc.js
+++ b/scrapers/nus-v2/.eslintrc.js
@@ -79,6 +79,8 @@ module.exports = {
       },
     ],
 
+    'no-continue': 'off',
+
     'import/no-extraneous-dependencies': ['error', { devDependencies: ['**/*.test.ts', 'src/utils/test-utils.ts'] }],
 
     // Rule is buggy when used with TypeScript

--- a/scrapers/nus-v2/src/tasks/CollateModules.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.ts
@@ -133,6 +133,7 @@ const getModuleInformation = ({
   prerequisite,
   preclusion,
   semesterData,
+  attributes,
 }: ModuleWithoutTree): ModuleInformation => ({
   moduleCode,
   title,
@@ -143,6 +144,7 @@ const getModuleInformation = ({
   workload,
   prerequisite,
   preclusion,
+  attributes,
   semesterData: semesterData.map(({ semester, examDate, examDuration }) => ({
     semester,
     examDate,

--- a/scrapers/nus-v2/src/types/api.ts
+++ b/scrapers/nus-v2/src/types/api.ts
@@ -32,14 +32,32 @@ export type ModuleAcademicGroup = Readonly<{
   Description: string;
 }>;
 
+// Possible CourseAttribute values. CourseAttributeValue is usually 'YES' or 'NO'.
+// YEAR - Year-Long Module
+// UROP - Undergraduate Research Opportunities Programme
+// SSGF - SkillsFuture Funded
+// SFS - SkillsFuture Series
+// PRQY - Has NUS Prereq and can SU
+// PRQN - Has NUS Prereq and cannot SU
+// NPRY - Without NUS Prereq and can SU
+// NPRN - Without NUS Prereq & cannot SU
+// LABB - LAB Based
+// ISM - Independent Study Module
+// HFYP - Honours/Final Year Project (value is 'HT', not 'YES' like the other attributes)
+// GRDY - GD modules eligible for SU
+export type ModuleAttributeEntry = Readonly<{
+  CourseAttributeValue: string;
+  CourseAttribute: string;
+}>;
+
 export type ModuleInfo = Readonly<{
   Term: string;
   AcademicOrganisation: ModuleAcademicOrganisation;
   AcademicGroup: ModuleAcademicGroup;
   WorkLoadHours: string;
   EffectiveDate: string;
-  CourseId: string;
-  CourseOfferNumber: string;
+  CourseId: string; // Internal ID used to connect dual-coded modules
+  CourseOfferNumber: string; // Usually 1, can be 2 or more for dual-coded modules
   Preclusion: string;
 
   PrintCatalog: 'Y' | 'N';
@@ -47,15 +65,13 @@ export type ModuleInfo = Readonly<{
 
   CourseTitle: string;
   CoRequisite: string;
-  CatalogNumber: string;
   Description: string;
   ModularCredit: string;
   PreRequisite: string;
-  Subject: string;
+  Subject: string; // The letter prefix part of the module code
+  CatalogNumber: string; // The number and suffix part of the module code
 
-  // I'm not sure what this is used for
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ModuleAttributes: any;
+  ModuleAttributes?: ModuleAttributeEntry[];
 }>;
 
 export type TimetableLesson = Readonly<{

--- a/scrapers/nus-v2/src/types/modules.ts
+++ b/scrapers/nus-v2/src/types/modules.ts
@@ -149,6 +149,7 @@ export type ModuleInformation = Readonly<{
   department: Department;
   faculty: Faculty;
   workload?: Workload;
+  attributes?: NUSModuleAttributes;
 
   // Requsites
   prerequisite?: string;

--- a/scrapers/nus-v2/src/types/modules.ts
+++ b/scrapers/nus-v2/src/types/modules.ts
@@ -82,6 +82,17 @@ export type SemesterData = {
   examDuration?: number;
 };
 
+export type NUSModuleAttributes = Partial<{
+  year: boolean; // Year long
+  su: boolean; // Can S/U
+  ssgf: boolean; // SkillsFuture Funded
+  sfs: boolean; // SkillsFuture series
+  lab: boolean; // Lab based
+  ism: boolean; // Independent study
+  urop: boolean; // Undergraduate Research Opportunities Program
+  fyp: boolean; // Honours / Final Year Project
+}>;
+
 // Information for a module for a particular academic year.
 export type Module = {
   acadYear: AcadYear;
@@ -97,6 +108,7 @@ export type Module = {
   faculty: Faculty;
   workload?: Workload;
   aliases?: ModuleCode[];
+  attributes?: NUSModuleAttributes;
 
   // Requsites
   prerequisite?: string;
@@ -106,7 +118,7 @@ export type Module = {
   // Semester data
   semesterData: SemesterData[];
 
-  // Requisites
+  // Requisite tree
   prereqTree?: PrereqTree;
   fulfillRequirements?: ModuleCode[];
 };

--- a/scrapers/nus-v2/src/utils/data.ts
+++ b/scrapers/nus-v2/src/utils/data.ts
@@ -145,29 +145,6 @@ export function mergeDualCodedModules(
   return { lessons: mergedModules, aliases };
 }
 
-// const weekOrder: { [week in LessonWeek]: number } = {
-//   Orientation: 0,
-//   '1': 1,
-//   '2': 2,
-//   '3': 3,
-//   '4': 4,
-//   '5': 5,
-//   '6': 6,
-//   Recess: 6.5,
-//   '7': 7,
-//   '8': 8,
-//   '9': 9,
-//   '10': 10,
-//   '11': 11,
-//   '12': 12,
-//   '13': 13,
-//   Reading: 14,
-// };
-//
-// export function compareWeeks(a: LessonWeek, b: LessonWeek) {
-//   return weekOrder[a] - weekOrder[b];
-// }
-
 export const dayTextMap: Record<string, DayText> = {
   '1': 'Monday',
   '2': 'Tuesday',


### PR DESCRIPTION
These are the module attributes that may be useful to us provided by the RO. We extract them out and add them to a map, currently of boleans, but they can be any other value if necessary. 