### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "schedule:weekends",
     "group:babelMonorepo",
     "group:materialMonorepo",
-    ":automergeBranchPush",
+    ":automergePr",
     ":automergeRequireAllStatusChecks",
     ":automergeMinor",
     ":prConcurrentLimit10",
@@ -66,11 +66,20 @@
     {
       "description": "Group typescript typings together",
       "packagePatterns": ["^@types/"],
-      "excludePackageNames": ["react(-dom|-router)?$", "(redux|reselect|immer|query-string)"],
+      "excludePackageNames": [
+        "@types/react",
+        "@types/react-dom",
+        "@types/react-router-dom",
+        "@types/react-redux",
+        "@types/react-leaflet",
+        "@types/redux",
+        "@types/lodash",
+        "@types/leaflet"
+      ],
       "groupName": "definitelyTyped"
     }
   ],
-  "ignoreDeps": ["query-string"],
+  "ignoreDeps": ["query-string", "@types/query-string"],
   "pathRules": [
     {
       "paths": ["packages/**"],


### PR DESCRIPTION
Turns out commit auto-merges are blocked by our branch-protection mechanism. However PR auto-merge is possible, so let's try that.

Also fixed the fact that "excludePackageNames" need exact matches.