### PR TITLE
Assume the day is available if it is not found in DayAvailability

### DIFF
--- a/website/src/utils/venues.test.ts
+++ b/website/src/utils/venues.test.ts
@@ -98,6 +98,20 @@ describe(filterAvailability, () => {
       }),
     ).toEqual(getVenues('CQT/SR0622'));
   });
+
+  test('should return venue which are empty the whole day', () => {
+    const availableVenues = filterAvailability(
+      [['LT1', []]], // Venue has no lessons at all
+      {
+        day: 0,
+        time: 9,
+        duration: 1,
+      },
+    );
+
+    expect(availableVenues).toHaveLength(1);
+    expect(availableVenues[0][0]).toEqual('LT1');
+  });
 });
 
 describe(floorName, () => {

--- a/website/src/utils/venues.ts
+++ b/website/src/utils/venues.ts
@@ -37,7 +37,7 @@ export function filterAvailability(
   return venues.filter(([, venue]) => {
     const start = time * 100;
     const dayAvailability = venue.find((availability) => availability.day === SCHOOLDAYS[day]);
-    if (!dayAvailability) return false;
+    if (!dayAvailability) return true;
 
     // Check that all half-hour slots within the time requested are vacant
     for (let i = 0; i < duration * 2; i++) {


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->

Fixes #1700 

<!-- Or provide a brief explanation about the problem -->

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

The old code assumed that if the day does not exist, then the room is not available. This is no longer true under API v2, so we flip that around and assume the room *is* available. 

## Other Information

There is a unit test but we should also manually test this to check if my assumption about the cause of the error is correct. 

<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
