### PR TITLE
Add graduate S/U option module attribute and description to website

### DIFF
--- a/website/src/types/modules.ts
+++ b/website/src/types/modules.ts
@@ -93,6 +93,7 @@ export type SemesterDataCondensed = Readonly<{
 type AttributeMap = {
   year: boolean; // Year long
   su: boolean; // Can S/U
+  grsu: boolean;
   ssgf: boolean; // SkillsFuture Funded
   sfs: boolean; // SkillsFuture series
   lab: boolean; // Lab based
@@ -105,7 +106,8 @@ export type NUSModuleAttributes = Partial<AttributeMap>;
 
 export const attributeDescription: { [key in keyof AttributeMap]: string } = {
   year: 'Year long module',
-  su: 'Has S/U option',
+  su: 'Has undergraduate S/U option',
+  grsu: 'Has graduate S/U option',
   ssgf: 'SkillsFuture funded',
   sfs: 'SkillsFuture series',
   lab: 'Lab based module',


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context

#1698 

## Implementation

Adds the new graduate S/U option which will be added to the scraper in #1711. This PR should be deployed **before** the scraper PR is merged to avoid blank attributes in the client (may be unavoidable because some clients will lag behind due to service worker) 
