### PR TITLE
Set higher visual priority for announcement

### DIFF
--- a/website/src/views/components/notfications/Announcements.scss
+++ b/website/src/views/components/notfications/Announcements.scss
@@ -19,6 +19,7 @@
 }
 
 .announcement {
+  z-index: 1;
   display: flex;
   overflow: hidden;
   justify-content: space-between;


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
Fixes #1715 
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

## Implementation
Set `z-index` of announcement to 1, so it has higher visual priority on module details page.
