### PR TITLE
Fix terser config

### DIFF
--- a/website/webpack/webpack.config.prod.js
+++ b/website/webpack/webpack.config.prod.js
@@ -101,6 +101,10 @@ const productionConfig = merge([
           sourceMap: true,
           terserOptions: {
             compress: {
+              // terser enables arrow functions after babel transpilation,
+              // which breaks targetes that have no support for arrow fns
+              // When safari 9.1 support drops, we can re-enable this
+              arrows: false,
               // Two passes yield the most optimal results
               passes: 2,
             },

--- a/website/webpack/webpack.config.prod.js
+++ b/website/webpack/webpack.config.prod.js
@@ -101,9 +101,9 @@ const productionConfig = merge([
           sourceMap: true,
           terserOptions: {
             compress: {
-              // terser enables arrow functions after babel transpilation,
-              // which breaks targetes that have no support for arrow fns
-              // When safari 9.1 support drops, we can re-enable this
+              // Terser enables arrow functions after Babel transpilation,
+              // which breaks targets that have no support for arrow fns.
+              // When we drop support for Safari 9.1, we can re-enable this.
               arrows: false,
               // Two passes yield the most optimal results
               passes: 2,


### PR DESCRIPTION
## Context
Terser tries to be smart and compresses functions to arrow functions if possible. This breaks safari 9.1 because it doesn't have support for arrow functions.

## Implementation
Disable arrow compression settings