### PR TITLE
Fix URL not found crash in scraper V2

### DIFF
--- a/scrapers/nus-v2/src/services/nus-api.ts
+++ b/scrapers/nus-v2/src/services/nus-api.ts
@@ -5,6 +5,7 @@
  * to enforce global concurrency limit on the number of requests made.
  */
 
+import { URL } from 'url';
 import axios from 'axios';
 import oboe from 'oboe';
 import Queue from 'promise-queue';


### PR DESCRIPTION
Fixes a "URL is not defined" crash.

![image](https://user-images.githubusercontent.com/12784593/57576690-e3f75900-7498-11e9-8715-7ae0d5e2f541.png)
