### PR TITLE
Set default module filter to ones offered this AY

### DIFF
--- a/website/src/views/layout/Navtabs.tsx
+++ b/website/src/views/layout/Navtabs.tsx
@@ -51,7 +51,10 @@ export function NavtabsComponent(props: Props) {
         <Calendar />
         <span className={styles.title}>Timetable</span>
       </NavLink>
-      <NavLink {...tabProps} to="/modules">
+      <NavLink
+        {...tabProps}
+        to={{ pathname: '/modules', search: '?sem[0]=1&sem[1]=2&sem[2]=3&sem[3]=4' }}
+      >
         <BookOpen />
         <span className={styles.title}>Modules</span>
       </NavLink>

--- a/website/src/views/layout/__snapshots__/Navtabs.test.tsx.snap
+++ b/website/src/views/layout/__snapshots__/Navtabs.test.tsx.snap
@@ -22,7 +22,12 @@ exports[`NavtabsComponent renders into nav element 1`] = `
   <NavLink
     activeClassName="linkActive"
     className="link"
-    to="/modules"
+    to={
+      Object {
+        "pathname": "/modules",
+        "search": "?sem[0]=1&sem[1]=2&sem[2]=3&sem[3]=4",
+      }
+    }
   >
     <BookOpen
       color="currentColor"


### PR DESCRIPTION
Context: #1775

Add a default query string to the nav bar module page link. Cons: any
existing link to /modules will show all mods without filter. Quick hack
just so that we can ship something that sorta works.

Tested to ensure that the nav bar button is still active when clicked.

![image](https://user-images.githubusercontent.com/12784593/60398121-65a96000-9b87-11e9-8e5f-15f45d5ae6b8.png)
