### PR TITLE
Add exam semesters notice

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -17,3 +17,4 @@ Create a new issue on GitHub with this checklist after the finals every semester
 ## Every Semester
 
 - [ ] Update semester in `app-config.json`
+- [ ] Add semester to `examAvailability` to indicate exam information is available for the semester

--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -79,6 +79,9 @@ module.exports = {
     'react/jsx-filename-extension': ['error', { extensions: ['.tsx', '.jsx'] }],
     'react/default-props-match-prop-types': ['error', { allowRequiredDefaults: true }],
 
+    // TypeScript lints this for us
+    'react/prop-types': 'off',
+
     // Too verbose, creates too many variables
     'react/destructuring-assignment': 'off',
 

--- a/website/src/config/app-config.json
+++ b/website/src/config/app-config.json
@@ -13,6 +13,9 @@
     "2017/2018",
     "2018/2019"
   ],
+  "examAvailability": [
+    1
+  ],
   "semesterNames": {
     "1": "Semester 1",
     "2": "Semester 2",

--- a/website/src/config/index.ts
+++ b/website/src/config/index.ts
@@ -35,6 +35,8 @@ export type Config = {
   semesterNames: { [semester: string]: string };
   shortSemesterNames: { [semester: string]: string };
   archiveYears: string[];
+  examAvailability: Semester[];
+  examAvailabilitySet: Set<Semester>;
 
   defaultPreferences: {
     theme: string;
@@ -84,6 +86,8 @@ const augmentedConfig: Config = {
   holidays: holidays.map((date) => new Date(date)),
 
   corsSchedule: corsData.map(convertCorsDate),
+
+  examAvailabilitySet: new Set(appConfig.examAvailability),
 
   /**
    * Returns a unique key for every acad year + semester

--- a/website/src/utils/moduleFilters.ts
+++ b/website/src/utils/moduleFilters.ts
@@ -80,9 +80,17 @@ function makeDepartmentFilterGroup(departments: Department[]) {
 
 function makeExamFilter() {
   return new FilterGroup(EXAMS, 'Exams', [
-    new Filter('no-exam', 'No Exams', (module: ModuleInformation) =>
-      module.semesterData.every((semesterData) => !semesterData.examDate),
-    ),
+    new Filter('no-exam', 'No Exams', (module: ModuleInformation) => {
+      const semestersWithExamInfo = module.semesterData.filter((semesterData) =>
+        config.examAvailabilitySet.has(semesterData.semester),
+      );
+      // If we don't have data on whether a module has exams then we filter it out just to be safe
+      if (semestersWithExamInfo.length === 0) return false;
+
+      // This assumes that if a module has no exams in sem 1, and we have no info in sem 2, then
+      // the module will also have no exam in sem 2
+      return module.semesterData.every((semesterData) => !semesterData.examDate);
+    }),
   ]);
 }
 

--- a/website/src/utils/react.tsx
+++ b/website/src/utils/react.tsx
@@ -5,6 +5,7 @@ import { escapeRegExp, castArray } from 'lodash';
 export const NBSP = '\u00a0';
 export const ZWSP = '\u200b';
 export const BULLET = ' • ';
+export const BULLET_NBSP = '\u00a0•\u00a0';
 
 /**
  * Replace substring matching the provided regex with React nodes. This is

--- a/website/src/views/components/module-info/ModuleExamInfo.tsx
+++ b/website/src/views/components/module-info/ModuleExamInfo.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+import { SemesterDataCondensed } from 'types/modules';
+
+import config from 'config';
+import { formatExamDate } from 'utils/modules';
+import { BULLET } from 'utils/react';
+
+interface Props {
+  semesterData: SemesterDataCondensed;
+}
+
+const ModuleExamInfo: React.FC<Props> = ({ semesterData }) =>
+  config.examAvailabilitySet.has(semesterData.semester) ? (
+    <p>
+      {formatExamDate(semesterData.examDate)}{' '}
+      {semesterData.examDuration && `${BULLET} ${semesterData.examDuration / 60} hrs`}
+    </p>
+  ) : (
+    <p>Exam date not yet available</p>
+  );
+
+export default ModuleExamInfo;

--- a/website/src/views/components/module-info/ModuleSemesterInfo.tsx
+++ b/website/src/views/components/module-info/ModuleSemesterInfo.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 
 import { ModuleCode, Semester, SemesterDataCondensed } from 'types/modules';
 
-import { formatExamDate, getFirstAvailableSemester } from 'utils/modules';
-import { BULLET } from 'utils/react';
+import { getFirstAvailableSemester } from 'utils/modules';
 import SemesterPicker from './SemesterPicker';
 import ModuleExamClash from './ModuleExamClash';
+import ModuleExamInfo from './ModuleExamInfo';
 
 type Props = {
   moduleCode: ModuleCode;
@@ -52,10 +52,7 @@ export default class ModuleSemesterInfo extends React.Component<Props, State> {
           <div className="module-semester-info">
             <section className="module-exam">
               <h4>Exam</h4>
-              <p>
-                {formatExamDate(semester.examDate)}{' '}
-                {semester.examDuration && `${BULLET} ${semester.examDuration / 60} hrs`}
-              </p>
+              <ModuleExamInfo semesterData={semester} />
 
               <ModuleExamClash
                 semester={semester.semester}

--- a/website/src/views/modules/ModulePageContent.tsx
+++ b/website/src/views/modules/ModulePageContent.tsx
@@ -6,7 +6,7 @@ import { kebabCase, map, mapValues, values, sortBy } from 'lodash';
 import { Module, NUSModuleAttributes, attributeDescription } from 'types/modules';
 
 import config from 'config';
-import { formatExamDate, getSemestersOffered } from 'utils/modules';
+import { getSemestersOffered } from 'utils/modules';
 import { intersperse } from 'utils/array';
 import { BULLET } from 'utils/react';
 import { NAVTAB_HEIGHT } from 'views/layout/Navtabs';
@@ -21,6 +21,7 @@ import SideMenu from 'views/components/SideMenu';
 import LessonTimetable from 'views/components/module-info/LessonTimetable';
 import ModuleExamClash from 'views/components/module-info/ModuleExamClash';
 import ModuleWorkload from 'views/components/module-info/ModuleWorkload';
+import ModuleExamInfo from 'views/components/module-info/ModuleExamInfo';
 import AddModuleDropdown from 'views/components/module-info/AddModuleDropdown';
 import Announcements from 'views/components/notfications/Announcements';
 import Title from 'views/components/Title';
@@ -189,10 +190,8 @@ export default class ModulePageContent extends React.Component<Props, State> {
                         {module.semesterData.length > 1 && config.semesterNames[semester.semester]}{' '}
                         Exam
                       </h3>
-                      <p>
-                        {formatExamDate(semester.examDate)}{' '}
-                        {semester.examDuration && `${BULLET} ${semester.examDuration / 60} hrs`}
-                      </p>
+
+                      <ModuleExamInfo semesterData={semester} />
 
                       <ModuleExamClash
                         semester={semester.semester}

--- a/website/src/views/timetable/ModulesTableFooter.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.tsx
@@ -5,9 +5,11 @@ import { connect } from 'react-redux';
 
 import { ModuleTableOrder } from 'types/reducers';
 import { Module, Semester } from 'types/modules';
+import { State } from 'types/state';
+
 import { setModuleTableOrder } from 'actions/settings';
 import { getExamDate, renderMCs } from 'utils/modules';
-import { State } from 'types/state';
+import config from 'config';
 import styles from './TimetableModulesTable.scss';
 
 type ModuleOrder = {
@@ -25,6 +27,7 @@ export const moduleOrders: { [moduleTableOrder: string]: ModuleOrder } = {
 };
 
 type Props = {
+  semester: Semester;
   moduleTableOrder: ModuleTableOrder;
   modules: Module[];
 
@@ -37,6 +40,12 @@ function ModulesTableFooter(props: Props) {
   return (
     <div className={classnames(styles.footer, 'row align-items-center')}>
       <div className="col-12">
+        {!config.examAvailabilitySet.has(props.semester) && (
+          <div className="alert alert-warning">
+            Exam dates are not available for this semester yet. Module combinations may not be
+            available due to conflicting exams.
+          </div>
+        )}
         <hr />
       </div>
       <div className="col">

--- a/website/src/views/timetable/TimetableActions.tsx
+++ b/website/src/views/timetable/TimetableActions.tsx
@@ -8,6 +8,7 @@ import { SemTimetableConfig } from 'types/timetables';
 
 import { Calendar, Grid, Sidebar, Type } from 'views/components/icons';
 import elements from 'views/elements';
+import config from 'config';
 import ShareTimetable from './ShareTimetable';
 import ExportMenu from './ExportMenu';
 
@@ -59,25 +60,27 @@ function TimetableActions(props: Props) {
           </button>
         )}
 
-        <button
-          type="button"
-          className={classnames(
-            styles.calendarBtn,
-            elements.examCalendarBtn,
-            'btn-outline-primary btn btn-svg',
-          )}
-          onClick={props.toggleExamCalendar}
-        >
-          {props.showExamCalendar ? (
-            <>
-              <Grid className="svg svg-small" /> Timetable
-            </>
-          ) : (
-            <>
-              <Calendar className="svg svg-small" /> Exam Calendar
-            </>
-          )}
-        </button>
+        {config.examAvailabilitySet.has(props.semester) && (
+          <button
+            type="button"
+            className={classnames(
+              styles.calendarBtn,
+              elements.examCalendarBtn,
+              'btn-outline-primary btn btn-svg',
+            )}
+            onClick={props.toggleExamCalendar}
+          >
+            {props.showExamCalendar ? (
+              <>
+                <Grid className="svg svg-small" /> Timetable
+              </>
+            ) : (
+              <>
+                <Calendar className="svg svg-small" /> Exam Calendar
+              </>
+            )}
+          </button>
+        )}
       </div>
 
       <div className={styles.buttonGroup} role="group" aria-label="Timetable exporting">

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -409,7 +409,7 @@ class TimetableContent extends React.Component<Props, State> {
                 {this.renderModuleSections(addedModules, !isVerticalOrientation)}
               </div>
               <div className="col-12">
-                <ModulesTableFooter modules={addedModules} />
+                <ModulesTableFooter modules={addedModules} semester={semester} />
               </div>
             </div>
           </div>

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -7,6 +7,8 @@ import { sortBy } from 'lodash';
 import { ModuleWithColor } from 'types/views';
 import { ColorIndex } from 'types/timetables';
 import { ModuleCode, Semester } from 'types/modules';
+import { State as StoreState } from 'types/state';
+import { ModuleTableOrder } from 'types/reducers';
 
 import ColorPicker from 'views/components/ColorPicker';
 import { Eye, EyeOff, Trash } from 'views/components/icons';
@@ -16,12 +18,13 @@ import {
   showLessonInTimetable,
 } from 'actions/timetables';
 import { getExamDate, getFormattedExamDate, renderMCs } from 'utils/modules';
+import { intersperse } from 'utils/array';
+import { BULLET_NBSP } from 'utils/react';
 import { modulePage } from 'views/routes/paths';
 import elements from 'views/elements';
 import Tooltip from 'views/components/Tooltip';
-import { State as StoreState } from 'types/state';
+import config from 'config';
 
-import { ModuleTableOrder } from 'types/reducers';
 import styles from './TimetableModulesTable.scss';
 import ModuleTombstone from './ModuleTombstone';
 import { moduleOrders } from './ModulesTableFooter';
@@ -93,6 +96,16 @@ class TimetableModulesTable extends React.PureComponent<Props> {
       return <ModuleTombstone module={module} resetTombstone={resetTombstone} />;
     }
 
+    // Second row of text consists of the exam date and the MCs
+    const secondRowText = [renderMCs(module.moduleCredit)];
+    if (config.examAvailabilitySet.has(semester)) {
+      secondRowText.unshift(
+        getExamDate(module, semester)
+          ? `Exam: ${getFormattedExamDate(module, semester)}`
+          : 'No Exam',
+      );
+    }
+
     return (
       <>
         <div className={styles.moduleColor}>
@@ -110,13 +123,7 @@ class TimetableModulesTable extends React.PureComponent<Props> {
           <Link to={modulePage(module.moduleCode, module.title)}>
             {module.moduleCode} {module.title}
           </Link>
-          <div className={styles.moduleExam}>
-            {getExamDate(module, semester)
-              ? `Exam: ${getFormattedExamDate(module, semester)}`
-              : 'No Exam'}
-            &nbsp;&middot;&nbsp;
-            {renderMCs(module.moduleCredit)}
-          </div>
+          <div className={styles.moduleExam}>{intersperse(secondRowText, BULLET_NBSP)}</div>
         </div>
       </>
     );


### PR DESCRIPTION

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

Inform students of missing exam date data in the configurable list of semesters instead of just assuming there's no exams. 

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

<img width="150" alt="Capture" src="https://user-images.githubusercontent.com/445650/60642061-60485180-9de3-11e9-933b-5b15d428685b.PNG">

<img width="372" alt="Capture" src="https://user-images.githubusercontent.com/445650/60642083-735b2180-9de3-11e9-91a0-3f702bcee547.PNG">

- Exam filters have been updated to only allow no exams if all semesters for which there is semester info have no exams
- Common exam info display in module finder and module info page has been extracted to a separate component 
- Exam calendar button is hidden when the semester has no exam data 
- Warning is shown below timetable module table when semester has no exam data 

The 'Exam Date' sort order is deliberately not fixed because the amount of work to reconcile the Redux state is really not worth the effort 

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->

![](https://media.giphy.com/media/mZH7nolwOhC6s/giphy.gif) 
