### PR TITLE
Make GlobalSearch onChange handle clearing selection

### DIFF
--- a/website/src/views/layout/GlobalSearch.tsx
+++ b/website/src/views/layout/GlobalSearch.tsx
@@ -73,21 +73,23 @@ class GlobalSearch extends React.Component<Props, State> {
     this.setState({ inputValue: newInputValue });
   };
 
-  onChange = (item: SearchItem) => {
-    const { onSelectModule, onSelectVenue, onSearch } = this.props;
+  onChange = (item: SearchItem | null) => {
+    if (item) {
+      const { onSelectModule, onSelectVenue, onSearch } = this.props;
 
-    switch (item.type) {
-      case VENUE_RESULT:
-        onSelectVenue(item.venue);
-        break;
+      switch (item.type) {
+        case VENUE_RESULT:
+          onSelectVenue(item.venue);
+          break;
 
-      case MODULE_RESULT:
-        onSelectModule(item.module);
-        break;
+        case MODULE_RESULT:
+          onSelectModule(item.module);
+          break;
 
-      case SEARCH_RESULT:
-        onSearch(item.type, item.term);
-        break;
+        case SEARCH_RESULT:
+          onSearch(item.type, item.term);
+          break;
+      }
     }
 
     this.onClose();


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Pressing escape when the global search is opened crashed the component and make it disappear.

According to Downshift docs, https://github.com/downshift-js/downshift#default-handlers, default handler for escape clears downshift's state. This calls `onChange` with argument `null` (https://github.com/downshift-js/downshift#onchange). Currently `null` is not handled at all in the `onChange` handler of `GlobalSearch`.

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
I changed the type signature of argument of `onChange` by making it nullable as it should according to downshift docs.

Upon receiving `null` in `onChange` (user clearing the selection), skip the part of the code that decides what action to do based on the selected item.

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
Feel free to ignore this PR if you think you prefer to have esc do something else instead of clearing state.