### PR TITLE
Fix odd week logic for formatNumericWeeks

### DIFF
--- a/website/src/test-utils/timetable.ts
+++ b/website/src/test-utils/timetable.ts
@@ -3,7 +3,7 @@ import { ColoredLesson, Lesson } from 'types/timetables';
 
 export const EVERY_WEEK = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
 export const EVEN_WEEK = [2, 4, 6, 8, 10, 12];
-export const ODD_WEEK = [1, 3, 5, 7, 9, 11];
+export const ODD_WEEK = [3, 5, 7, 9, 11, 13];
 
 // A generic lesson with some default.
 export function createGenericLesson(

--- a/website/src/test-utils/timetable.ts
+++ b/website/src/test-utils/timetable.ts
@@ -3,7 +3,7 @@ import { ColoredLesson, Lesson } from 'types/timetables';
 
 export const EVERY_WEEK = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
 export const EVEN_WEEK = [2, 4, 6, 8, 10, 12];
-export const ODD_WEEK = [3, 5, 7, 9, 11, 13];
+export const ODD_WEEK = [1, 3, 5, 7, 9, 11, 13];
 
 // A generic lesson with some default.
 export function createGenericLesson(

--- a/website/src/utils/timetables.ts
+++ b/website/src/utils/timetables.ts
@@ -391,9 +391,11 @@ export function formatNumericWeeks(weeks: number[]): string | null {
   if (weeks.length === 13) return null;
   if (weeks.length === 1) return `Week ${weeks[0]}`;
 
-  // Check for odd / even weeks
-  if (weeks.length >= 6 && deltas(weeks).every((d) => d === 2)) {
-    return weeks[0] % 2 ? 'Odd Weeks' : 'Even Weeks';
+  // Check for odd / even weeks. There are more odd weeks then even weeks, so we have to split
+  // the length check.
+  if (deltas(weeks).every((d) => d === 2)) {
+    if (weeks[0] % 2 === 0 && weeks.length >= 6) return 'Even Weeks';
+    if (weeks[0] % 2 === 1 && weeks.length >= 7) return 'Odd Weeks';
   }
 
   // Merge consecutive

--- a/website/src/utils/timetables.ts
+++ b/website/src/utils/timetables.ts
@@ -393,7 +393,7 @@ export function formatNumericWeeks(weeks: number[]): string | null {
 
   // Check for odd / even weeks
   if (weeks.length >= 6 && deltas(weeks).every((d) => d === 2)) {
-    return weeks[0] === 1 ? 'Odd Weeks' : 'Even Weeks';
+    return weeks[0] % 2 ? 'Odd Weeks' : 'Even Weeks';
   }
 
   // Merge consecutive


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

There's a bug in the logic for this function. Should've done a proper `% 2 === 0` check instead of being lazy. 
