### PR TITLE
Use yarn instead of npm in scripts

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
     "test:watch": "jest --watch",
     "e2e": "nightwatch -e default,safariMobile,safariDesktop,edge",
     "cors": "node scripts/cors-crawler",
-    "ci": "cross-env NODE_ENV=production npm run lint && npm run typecheck && npm test && npm test:integration && npm rebuild node-sass && npm run build"
+    "ci": "cross-env NODE_ENV=production yarn lint && yarn typecheck && yarn test && yarn test:integration && npm rebuild node-sass && yarn build"
   },
   "author": "NUSModifications",
   "license": "MIT",


### PR DESCRIPTION
## Context
Fix failing `yarn run ci` script and change instances of `npm` to `yarn` where possible.

## Other Information
Consider using `npm rebuild --update-binary node-sass` instead (as mentioned in yarnpkg/yarn#2069 and yarnpkg/yarn#5271) as it doesn't create a `package-lock.json` file (though I haven't had this problem).
