### PR TITLE
Fix venue location display for 0 floor venues

### DIFF
--- a/website/src/utils/venues.test.ts
+++ b/website/src/utils/venues.test.ts
@@ -115,6 +115,10 @@ describe(filterAvailability, () => {
 });
 
 describe(floorName, () => {
+  it('should show 0 as the ground floor', () => {
+    expect(floorName(0)).toEqual('the ground floor');
+  });
+
   it('should add B to basement floors', () => {
     expect(floorName(-1)).toEqual('floor B1');
     expect(floorName(-2)).toEqual('floor B2');

--- a/website/src/utils/venues.ts
+++ b/website/src/utils/venues.ts
@@ -56,6 +56,10 @@ export function floorName(floor: number | string): string {
     return `${floor.toLowerCase()} floor`;
   }
 
+  if (floor === 0) {
+    return 'the ground floor';
+  }
+
   const floorNumber = floor < 0 ? `B${-floor}` : floor;
   return `floor ${floorNumber}`;
 }

--- a/website/src/views/venues/VenueLocation/VenueLocation.tsx
+++ b/website/src/views/venues/VenueLocation/VenueLocation.tsx
@@ -80,7 +80,7 @@ export default class VenueLocation extends React.PureComponent<Props, State> {
       <div>
         <p>
           <strong>{location.roomName}</strong> ({venue})
-          {location.floor && (
+          {location.floor != null && (
             <>
               {' '}
               is on <strong>{floorName(location.floor)}</strong>


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

Floor 0 is being displayed as the 0 of shame in the venue location page. This PR fixes that so it shows up as 'the ground floor instead' 
