### PR TITLE
Update API footer URL

### DIFF
--- a/website/src/views/layout/Footer.tsx
+++ b/website/src/views/layout/Footer.tsx
@@ -58,9 +58,7 @@ export function FooterComponent(props: Props) {
             <ExternalLink href={config.contact.blog}>Blog</ExternalLink>
           </li>
           <li>
-            <ExternalLink href="https://github.com/nusmodifications/nusmods/tree/master/api">
-              API
-            </ExternalLink>
+            <ExternalLink href="https://api.nusmods.com/v2">API</ExternalLink>
           </li>
           <li>
             <Link to="/apps">Apps</Link>


### PR DESCRIPTION
The footer link used to link to our API docs in the repo, but now that's gone. Changed the link to point to the Swagger docs on our server.