### PR TITLE
Add team credentials

### DIFF
--- a/website/src/data/team.json
+++ b/website/src/data/team.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Beng (Eu Beng Hee)",
-    "description": "He's Beng. Nuff' said.",
+    "description": "He's Beng. Nuff' said. Software Engineer (Ads Speed Tech Lead) @ Google",
     "link": "https://www.github.com/ahbeng",
     "gravatar": "601eddec66c2e48891195af393144c17",
     "gravatarAlt": "Beng",
@@ -12,7 +12,7 @@
   },
   {
     "name": "Yangshun Tay",
-    "description": "Front End developer who loves good code, design and typography.",
+    "description": "The open source guy. Front End Engineer @ Facebook.",
     "link": "http://yangshun.im",
     "gravatar": "66eca275a85a6a0c06b0a0f7039b074b",
     "gravatarAlt": "Yangshun Tay",
@@ -23,7 +23,7 @@
   },
   {
     "name": "Liu Xinan",
-    "description": "A crazy developer who likes magic, ...and tea!",
+    "description": "A crazy developer who likes magic, ...and tea! Software Engineer @ Google",
     "link": "https://www.github.com/xinan",
     "gravatar": "802da99824fb41330a44af89256da661",
     "gravatarAlt": "Liu Xinan",
@@ -33,7 +33,7 @@
   },
   {
     "name": "Ng Zhi An",
-    "description": "undefined is not a function.",
+    "description": "undefined is not a function. Software Engineer @ Google",
     "link": "https://www.ngzhian.com",
     "gravatar": "959333b0fda0517060c9750f8c49ead0",
     "gravatarAlt": "Ng Zhi An",
@@ -44,7 +44,7 @@
   },
   {
     "name": "Li Kai",
-    "description": "Happy to help.",
+    "description": "Happy to help. Ex-Front End Engineer Intern @ Facebook, Software Engineer @ Zendesk",
     "active": true,
     "link": "https://www.github.com/li-kai",
     "gravatar": "3d2bcece0409c7578b2e9d87f0c1b6d7",
@@ -55,7 +55,7 @@
   },
   {
     "name": "Xu Bili",
-    "description": "Loves to read and write elegant code. JavaScript enthusiast.",
+    "description": "Loves to read and write elegant code. JavaScript enthusiast. Software Engineer @ Edison",
     "link": "https://www.github.com/xbili",
     "gravatar": "a26e376c4bc050614f13581cf6a13e09",
     "gravatarAlt": "Xu Bili",
@@ -75,7 +75,7 @@
   },
   {
     "name": "Zhang Yi Jiang",
-    "description": "Fan of pretty purple pony princesses.",
+    "description": "Fan of pretty purple pony princesses. Software Engineer @ Ironclad",
     "active": true,
     "link": "https://meebleforp.com",
     "gravatar": "263859aefe62ee6cc1aa993e8e2293e0",
@@ -85,7 +85,7 @@
   },
   {
     "name": "E-Liang Tan",
-    "description": "Makers gotta make.",
+    "description": "Makers gotta make. Software Engineer Intern @ Facebook",
     "active": true,
     "link": "https://www.eliangtan.com/",
     "gravatar": "3064783701c7bb1b4451c79318e1b536",

--- a/website/src/data/team.json
+++ b/website/src/data/team.json
@@ -66,7 +66,7 @@
   },
   {
     "name": "Ang Yen Ling",
-    "description": "Bubbly girl who loves new things, matcha ice cream and marketing.",
+    "description": "Bubbly girl who loves new things, matcha ice cream and marketing. Business Analyst @ GE Healthcare",
     "link": "https://www.facebook.com/ang.yenling",
     "gravatar": "630fe6848c11082312b57b1360a0dd09",
     "gravatarAlt": "Ang Yen Ling",


### PR DESCRIPTION
## Context

Establish existing team credentials which can either attract or scare off future contributors depending on how we see it:

Attract future contributors:

- Wow I can learn from FANG engineers
- Wow I can be a FANG engineer

Scare off future contributors:

- Damn I need to be a FANG engineer-level to contribute to NUSMods

Thoughts? I'm leaning towards attract :pray: 

#accept2ship