### PR TITLE
Update scraper config to scrape hourly

### DIFF
--- a/scrapers/nus-v2/ecosystem.config.js
+++ b/scrapers/nus-v2/ecosystem.config.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/camelcase */
+
 module.exports = {
   apps: [
     {
@@ -5,12 +7,12 @@ module.exports = {
       script: 'scripts/run.sh',
 
       instances: 1,
-      // Set to false since this is a script and not a server, otherwise pm2 will keep trying
-      // to restart this
-      autorestart: false,
-      watch: false,
+      // Can't get pm2 cron or system cron to work, and since the API is so unpredictably bad,
+      // we just restart the script every hour regardless of whether it is successful or not
+      autorestart: true,
+      restart_delay: 60 * 60 * 1000,
 
-      cron_restart: '10 * * * *',
+      watch: false,
 
       env: {
         NODE_ENV: 'production',

--- a/scrapers/nus-v2/ecosystem.config.js
+++ b/scrapers/nus-v2/ecosystem.config.js
@@ -10,7 +10,7 @@ module.exports = {
       autorestart: false,
       watch: false,
 
-      cron_restart: '10 4,5 * * *',
+      cron_restart: '10 * * * *',
 
       env: {
         NODE_ENV: 'production',

--- a/scrapers/nus-v2/scripts/run.sh
+++ b/scrapers/nus-v2/scripts/run.sh
@@ -26,4 +26,3 @@ rsync -ahz --delete-after --exclude='cache/' data/ ../../../api.nusmods.com/v2
 # pm2 doesn't restart processes that have stopped, so this just noops until
 # the next cron restart
 echo "Finished syncing data. Sleeping."
-sleep 86400


### PR DESCRIPTION
There have been many complaints of outdated data. We were previously
promised in a meeting that the data will only be updated at around 4am
everyday, but this does not appear to be true as ModReg gets data faster
than that. Let's just scrape hourly to ensure that we're up to date as
well.

#accept2ship