### PR TITLE
Minor UI tweaks to better support iPhone X landscape notch

### DIFF
--- a/website/src/index.html
+++ b/website/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1">
+    <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1,viewport-fit=cover">
     <link href="${htmlWebpackPlugin.files.publicPath}apple-icon-180x180.png" rel="apple-touch-icon" sizes="180x180">
     <link href="${htmlWebpackPlugin.files.publicPath}favicon-32x32.png" rel="icon" type="image/png" sizes="32x32">
     <link href="${htmlWebpackPlugin.files.publicPath}favicon-16x16.png" rel="icon" type="image/png" sizes="16x16">

--- a/website/src/styles/layout/site.scss
+++ b/website/src/styles/layout/site.scss
@@ -47,6 +47,7 @@ a {
 
 .main-container {
   flex: 1 auto;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 
   @include media-breakpoint-down(sm) {
     .main-content {

--- a/website/src/views/AppShell.scss
+++ b/website/src/views/AppShell.scss
@@ -14,6 +14,7 @@ $logo-vert-padding: 0.875rem;
   display: flex;
   justify-content: space-between;
   height: $navbar-height;
+  padding: 0 env(safe-area-inset-right) 0 env(safe-area-inset-left);
   background: var(--gray-lightest);
 }
 

--- a/website/src/views/layout/Footer.scss
+++ b/website/src/views/layout/Footer.scss
@@ -2,7 +2,7 @@
 
 .footer {
   composes: text-muted from global;
-  padding: 4rem 0;
+  padding: 4rem env(safe-area-inset-right) calc(env(safe-area-inset-bottom) + 4rem) env(safe-area-inset-left);
   margin-top: 4rem;
   font-size: 0.85rem;
   text-align: center;

--- a/website/src/views/layout/Navtabs.scss
+++ b/website/src/views/layout/Navtabs.scss
@@ -7,8 +7,6 @@
 .nav {
   position: fixed;
   top: $navbar-height;
-  right: 0;
-  left: 0;
   z-index: $navtabs-z-index;
   // See site.scss for width on md and lg sizes
   display: flex;

--- a/website/src/views/venues/VenuesContainer.scss
+++ b/website/src/views/venues/VenuesContainer.scss
@@ -40,15 +40,16 @@ $venue-list-width: 16rem;
 
   .venuesList {
     width: $venue-list-width;
+    padding-bottom: env(safe-area-inset-bottom);
     border-right: 1px solid var(--gray-lighter);
 
     @include scrollable-y;
   }
 
   .venueDetail {
-    right: 0;
-    left: calc(#{$venue-list-width + $side-nav-width-md} + #{$gutter});
-    padding: 0 $gutter;
+    right: env(safe-area-inset-right);
+    left: calc(env(safe-area-inset-left) + #{$venue-list-width + $side-nav-width-md} + #{$gutter});
+    padding: 0 $gutter env(safe-area-inset-bottom) $gutter;
   }
 }
 


### PR DESCRIPTION
## Context

iPhone X was released years ago and NUSMods has not been updated for it, resulting in really ugly white bars in landscape (see screenshot). This cannot be allow.

## Screenshots

### Before

White bars beside nav bar and footer.

![image](https://user-images.githubusercontent.com/12784593/67935099-26a61c80-fc04-11e9-8256-a44a8d621f9e.png)

![image](https://user-images.githubusercontent.com/12784593/67935113-2ad23a00-fc04-11e9-8624-2738677da33c.png)

### After

![image](https://user-images.githubusercontent.com/12784593/67935291-7be22e00-fc04-11e9-8887-8833355c4c04.png)

The backgrounds of the nav bar and footer now stretch to the edges of the screen.

![image](https://user-images.githubusercontent.com/12784593/67935124-2f96ee00-fc04-11e9-8db5-770593130ddc.png)

Venues page. Bottom padding was added so that the UI content is safely away from iOS's bar.

![image](https://user-images.githubusercontent.com/12784593/67935142-34f43880-fc04-11e9-817d-7ae5c5d791ce.png)

## Tests

Changes tested on:
* iPhone 11 running iOS 13.1 IRL
* iPhone X running iOS 11 on Browserstack (footer's left padding is messed up) 
![image](https://user-images.githubusercontent.com/12784593/67935626-3d00a800-fc05-11e9-8822-36e20adcd4ad.png)
* iPhone XS Max running iOS 12 on Browserstack

Portrait mode was confirmed to remain unchanged on the above devices.

Also ensured that there were no observable differences on:
* Chrome on Linux locally
* iPhone 7 running iOS 10 on Browserstack (iOS 10 does not support `env`)
* Chrome on Android 9 Pie on a OnePlus 7 on Browserstack
* Chrome on Android 9 Pie on a Google Pixel 3 XL on Browserstack

Android browsers do not display content behind the notch, so they display content like notchless phones.

More testing should be done on Android browsers before merging.

## Other Information

Support matrix for `env()` can be found at https://caniuse.com/#feat=css-env-function.