### PR TITLE
Align footer content to main content

### DIFF
--- a/website/src/views/layout/Footer.scss
+++ b/website/src/views/layout/Footer.scss
@@ -23,8 +23,20 @@
     line-height: 1.3;
   }
 
+  .footerContainer {
+    padding: 0 15px;
+  }
+
   @include media-breakpoint-up(sm) {
     text-align: left;
+  }
+
+  @include media-breakpoint-up(md) {
+    padding-left: calc(env(safe-area-inset-left) + #{$side-nav-width-md});
+  }
+
+  @include media-breakpoint-up(xl) {
+    padding-left: calc(env(safe-area-inset-left) + #{$side-nav-width-lg});
   }
 }
 

--- a/website/src/views/layout/Footer.tsx
+++ b/website/src/views/layout/Footer.tsx
@@ -40,7 +40,7 @@ export function FooterComponent(props: Props) {
 
   return (
     <footer className={styles.footer}>
-      <div className="container">
+      <div className={styles.footerContainer}>
         <ul className={styles.footerLinks}>
           <li>
             <ExternalLink href={config.contact.githubRepo}>GitHub</ExternalLink>


### PR DESCRIPTION
## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

The footer currently uses its own padding, independent of the main content's. This causes the footer to often be misaligned from the text, or overlap with the navtabs. This PR copies the padding logic from the main content to the footer.

This PR is based on the iphonex branch (PR: #2269), and is tested with the notch on iOS.

## Screenshots

iPhone 11 landscape

| Before | After |
|-|-|
|![image](https://user-images.githubusercontent.com/12784593/67938572-b8b12380-fc0a-11e9-87b2-2ca89fb193c5.png)|![image](https://user-images.githubusercontent.com/12784593/67938599-c666a900-fc0a-11e9-92a3-c07e4669d9c7.png)|

Chrome Linux 600px

| Before | After |
|-|-|
|![nusmods com_](https://user-images.githubusercontent.com/12784593/67938632-d67e8880-fc0a-11e9-957a-62c9f9093362.png)|![localhost_8080_timetable_sem-1 (1)](https://user-images.githubusercontent.com/12784593/67938635-d8e0e280-fc0a-11e9-844a-d821387a5899.png)|

Chrome Linux 768px

| Before | After |
|-|-|
|![nusmods com_ (1)](https://user-images.githubusercontent.com/12784593/67938687-f0b86680-fc0a-11e9-8f22-5fe15bbee759.png)|![localhost_8080_timetable_sem-1 (2)](https://user-images.githubusercontent.com/12784593/67938678-eeeea300-fc0a-11e9-82aa-00e2676c4b47.png)|

Chrome Linux 947px

| Before | After |
|-|-|
|![nusmods com_ (2)](https://user-images.githubusercontent.com/12784593/67938782-23625f00-fc0b-11e9-9fe1-5371590b769a.png)|![localhost_8080_timetable_sem-1 (3)](https://user-images.githubusercontent.com/12784593/67938788-24938c00-fc0b-11e9-8c4f-bf443221ae84.png)|