### PR TITLE
Scraper: Move lesson validation logic to standard validations

### DIFF
--- a/scrapers/nus-v2/src/services/validation.test.ts
+++ b/scrapers/nus-v2/src/services/validation.test.ts
@@ -36,8 +36,25 @@ describe(validateLesson, () => {
       day: null,
     };
 
+    const invalidLesson3: any = {
+      term: '1810',
+      room: null,
+      numweeks: 0,
+      start_time: '12:00',
+      end_time: '12:00',
+      activity: 'L',
+      csize: 40,
+      module: 'EL4401',
+      eventdate: null,
+      session: '1',
+      modgrp: 'L1',
+      deptfac: '00104ACAD1',
+      day: null,
+    };
+
     expect(validateLesson(invalidLesson1)).toBe(false);
     expect(validateLesson(invalidLesson2)).toBe(false);
+    expect(validateLesson(invalidLesson3)).toBe(false);
   });
 
   test('should return true for valid lessons', () => {

--- a/scrapers/nus-v2/src/services/validation.ts
+++ b/scrapers/nus-v2/src/services/validation.ts
@@ -16,7 +16,7 @@ const lessonSchema = Joi.object({
   // Allow null because we can still use the rest of the information
   room: Joi.string().allow(null),
   start_time: Joi.string(),
-  end_time: Joi.string(),
+  end_time: Joi.string().not(Joi.ref('start_time')),
   eventdate: Joi.string().isoDate(),
 
   activity: Joi.string().only(Object.keys(activityLessonType)),

--- a/scrapers/nus-v2/src/services/validation.ts
+++ b/scrapers/nus-v2/src/services/validation.ts
@@ -16,6 +16,7 @@ const lessonSchema = Joi.object({
   // Allow null because we can still use the rest of the information
   room: Joi.string().allow(null),
   start_time: Joi.string(),
+  end_time: Joi.string(),
   eventdate: Joi.string().isoDate(),
 
   activity: Joi.string().only(Object.keys(activityLessonType)),

--- a/scrapers/nus-v2/src/tasks/GetSemesterTimetable.ts
+++ b/scrapers/nus-v2/src/tasks/GetSemesterTimetable.ts
@@ -99,7 +99,7 @@ export function mapLessonWeeks(dates: string[], semester: number, logger: Logger
   return weekRange;
 }
 
-export function mapTimetableLesson(lesson: TimetableLesson, logger: Logger): TempRawLesson | null {
+export function mapTimetableLesson(lesson: TimetableLesson, logger: Logger): TempRawLesson {
   const { room, start_time, end_time, day, module, modgrp, activity, eventdate, csize } = lesson;
 
   if (has(unrecognizedLessonTypes, activity)) {
@@ -107,15 +107,6 @@ export function mapTimetableLesson(lesson: TimetableLesson, logger: Logger): Tem
       { moduleCode: module, activity },
       'Lesson type not recognized by the frontend used',
     );
-  }
-
-  if (!start_time || !end_time) {
-    const { session, term } = lesson;
-    logger.error(
-      { moduleCode: module, end_time, start_time },
-      'Lesson has no start and/or end time',
-    );
-    return null;
   }
 
   return {
@@ -191,6 +182,16 @@ export default class GetSemesterTimetable extends BaseTask implements Task<Input
           timetables[lesson.module] = {};
         }
 
+        // Report serious error to Sentry
+        if (!lesson.start_time || !lesson.end_time) {
+          const { start_time, end_time, module } = lesson;
+          this.logger.error(
+            { moduleCode: module, end_time, start_time },
+            'Lesson has no start and/or end time',
+          );
+          return null;
+        }
+
         invalid += 1;
         return;
       }
@@ -210,10 +211,7 @@ export default class GetSemesterTimetable extends BaseTask implements Task<Input
       if (rawLesson) {
         rawLesson.weeks.push(lesson.eventdate);
       } else {
-        const lessons = mapTimetableLesson(lesson, this.logger);
-        if (lessons) {
-          timetable[key] = lessons;
-        }
+        timetable[key] = mapTimetableLesson(lesson, this.logger);
       }
     });
 

--- a/scrapers/nus-v2/src/tasks/GetSemesterTimetable.ts
+++ b/scrapers/nus-v2/src/tasks/GetSemesterTimetable.ts
@@ -183,13 +183,12 @@ export default class GetSemesterTimetable extends BaseTask implements Task<Input
         }
 
         // Report serious error to Sentry
-        if (!lesson.start_time || !lesson.end_time) {
+        if (!lesson.start_time || !lesson.end_time || lesson.start_time === lesson.end_time) {
           const { start_time, end_time, module } = lesson;
           this.logger.error(
             { moduleCode: module, end_time, start_time },
             'Lesson has no start and/or end time',
           );
-          return null;
         }
 
         invalid += 1;


### PR DESCRIPTION
Improve implementation of #2380 by moving validation logic to shared checks in validations.ts, to allow number of valid/invalid lessons to be counted correctly.