### PR TITLE
Add codecov.yml with path fix

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+fixes:
+  # For now we only report website coverage, and since tests are run directly in
+  # the /website folder we need to add this
+  - "::website/"


### PR DESCRIPTION


## Context

Currently trying to view code cov deltas fail because the coverage uses /website as root when collecting coverage, which means the report is missing that part of the file path. 

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

This PR adds the config for that according to https://docs.codecov.io/docs/fixing-paths 
