### PR TITLE
Fix misleading ContributorList error message

### DIFF
--- a/website/src/views/contribute/ContributorList.tsx
+++ b/website/src/views/contribute/ContributorList.tsx
@@ -51,7 +51,7 @@ const ContributorList = Loadable.Map<Props, Export>({
   },
   loading: (props: LoadingComponentProps) => {
     if (props.error) {
-      return <ApiError dataName="venue locations" retry={props.retry} />;
+      return <ApiError dataName="list of contributors" retry={props.retry} />;
     }
     if (props.pastDelay) {
       return <LoadingSpinner />;


### PR DESCRIPTION
Partially resolves #2536. Screenshot in that issue shows the error message "We can't load the venue locations" when it's actually the contributor list that can't be loaded. This commit corrects this message.