### PR TITLE
Add round countdown in ModReg notification

### DIFF
--- a/website/src/views/components/notfications/ModRegNotification.tsx
+++ b/website/src/views/components/notfications/ModRegNotification.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { formatDistance } from 'date-fns';
 
 import { NotificationOptions } from 'types/reducers';
 import { State } from 'types/state';
@@ -35,12 +36,16 @@ export function notificationText(
   now: Date,
 ): React.ReactNode {
   const isRoundOpen = now >= round.startDate;
+  const timeFromNow = formatDistance(now, isRoundOpen ? round.endDate : round.startDate, {
+    includeSeconds: true,
+  });
 
   return (
     <>
       {isRoundOpen ? 'Current' : 'Next'} <strong>{round.type}</strong>{' '}
       {round.name ? `(Round ${round.name})` : ''}: {useLineBreaks && <br />}
       {isRoundOpen ? ' till' : ' at'} <strong>{isRoundOpen ? round.end : round.start}</strong>
+      {useLineBreaks && <br />} ({timeFromNow} from now)
     </>
   );
 }


### PR DESCRIPTION
## Context
Addresses #2033 by adding a countdown to the ModReg notification
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/20502803/78468595-03037700-774c-11ea-8f8e-d821ba040774.png)|![image](https://user-images.githubusercontent.com/20502803/78468574-d64f5f80-774b-11ea-92ce-cccfa7867755.png)|

## Implementation
`date-fns` has a handy function `formatDistance()` so I merely leveraged that. 

#### What's the mapping between duration (an integer) and text description (a string)?
The mapping is detailed in the [docs](https://date-fns.org/v2.11.1/docs/formatDistance). This might be more arbitrary/give us less control than we'd like, but I feel that this beats the trouble of maintaining our own duration-to-description logic. Most importantly, the library provides descriptions that become more granular as the duration gets shorter, which is what we want.

The option `includeSeconds` is also set to `True` to select the higher granularity option provided by the library.

*Sidenote: You might notice that `date-fns` avoids being extremely precise about the duration - the most granular being "less than 5 seconds". I think this works in our favour because we can't guarantee, to the second, that the rounds begin/end according to our countdown*

## Manual Tests

- [x] **Different Durations**

With `forceTimer()` from `debug.ts`, the current time was set to varying durations from the next round start/end:
||Before a Round (> 1 Day)|Before a Round (< 1 Day)|Before a Round (< 1 Min)|During a Round|
|---|---|---|---|---|
|**Test URL**|`/timetable/sem-1?date=July 23 2019, 12:00:00`|`/timetable/sem-1?date=July 24 2019, 12:00:00`|`/timetable/sem-1?date=July 25 2019, 08:59:45`|`/timetable/sem-1?date=July 25 2019, 09:59:20`|
|**Screenshot**|![image](https://user-images.githubusercontent.com/20502803/78468884-58d91e80-774e-11ea-9db5-c56edab127bf.png)|![image](https://user-images.githubusercontent.com/20502803/78468903-802feb80-774e-11ea-9ee9-e43f1c3f2624.png)|![image](https://user-images.githubusercontent.com/20502803/78468945-e74da000-774e-11ea-8b8f-004540f1ac52.png)|![image](https://user-images.githubusercontent.com/20502803/78469033-b3bf4580-774f-11ea-9ba3-710837af77e0.png)

- [x] **Mobile**

Test URL: `/timetable/sem-1?date=July 25 2019, 09:59:20`
![image](https://user-images.githubusercontent.com/20502803/78469056-e36e4d80-774f-11ea-99f9-293be69e23d9.png)

- [x] **Other Timezones**

Setting my computer to be in Pacific Time (GMT -7:00):
- Round Start in GMT + 8:00: 9am July 25 2019
- Round Start in GMT -7:00: 6pm July 24 2019

Test URL: `/timetable/sem-1?date=July 24 2019, 17:59:20`
![image](https://user-images.githubusercontent.com/20502803/78469461-1fa3ad00-7754-11ea-862f-d245a8950605.png)

## Questions
1. Would more precise descriptions be preferred? E.g. "2 days 12 hours from now" as originally proposed in #2033 vs "2 days from now" as provided by `formatDistance()`
2. The notification component is rendered only on the page's initial load. Given that users might expect the countdown to be active, should we implement a periodic rerender? What frequency would be ideal?
3. I'm new to this project, so I'm not sure if a change like this (where the logic is mostly from an external library) needs tests? I haven't explored the test coverage on the existing component, so I don't yet have a gauge of the effort required. I'll be doing so while this PR is in review.


