### PR TITLE
Address 20 lint warnings

### DIFF
--- a/website/src/actions/moduleBank.ts
+++ b/website/src/actions/moduleBank.ts
@@ -73,11 +73,11 @@ export function fetchModule(moduleCode: ModuleCode) {
         url: NUSModsApi.moduleDetailsUrl(moduleCode),
       }),
     ).then(
-      (result: any) => {
+      (result: string) => {
         onFinally();
         return result;
       },
-      (error: any) => {
+      (error: Error) => {
         onFinally();
         throw error;
       },

--- a/website/src/actions/requests.ts
+++ b/website/src/actions/requests.ts
@@ -35,7 +35,7 @@ export const requestAction: RequestActionCreator = (
   key: RequestKey,
   type: string | AxiosRequestConfig,
   options?: AxiosRequestConfig,
-): RequestAction<any> => {
+): RequestAction<RequestKey | string> => {
   let payload: AxiosRequestConfig;
 
   if (typeof type !== 'string') {
@@ -45,7 +45,6 @@ export const requestAction: RequestActionCreator = (
   } else if (options) {
     payload = options;
   } else {
-    // Keeps Flow happy
     throw new Error();
   }
 

--- a/website/src/middlewares/requests-middleware.ts
+++ b/website/src/middlewares/requests-middleware.ts
@@ -4,18 +4,16 @@ import { FAILURE, REQUEST, SUCCESS } from 'types/reducers';
 import { API_REQUEST } from 'actions/requests';
 import { State } from 'types/state';
 
-export type RequestType<Type extends string> = Type & { __requestType: any };
-export type SuccessType<Type extends string> = Type & { __successType: any };
-export type ErrorType<Type extends string> = Type & { __errorType: any };
+export type ActionType<Action extends string, Type extends string> = Action & { __type: Type };
 
 export type RequestAction<Type extends string, Meta = {}> = {
-  type: RequestType<Type>;
+  type: ActionType<Type, typeof REQUEST>;
   payload: AxiosRequestConfig;
   meta: Meta;
 };
 
 export type SuccessAction<Type extends string, Response, Meta = {}> = {
-  type: SuccessType<Type>;
+  type: ActionType<Type, typeof SUCCESS>;
   payload: Response;
   meta: Meta & {
     requestStatus: typeof SUCCESS;
@@ -24,7 +22,7 @@ export type SuccessAction<Type extends string, Response, Meta = {}> = {
 };
 
 export type FailureAction<Type extends string, Meta = {}> = {
-  type: ErrorType<Type>;
+  type: ActionType<Type, typeof FAILURE>;
   payload: Error;
   meta: Meta & {
     requestStatus: typeof FAILURE;
@@ -45,12 +43,12 @@ function makeRequest(request: AxiosRequestConfig) {
   });
 }
 
-export function SUCCESS_KEY<Type extends string>(key: Type): SuccessType<Type> {
-  return (key + SUCCESS) as SuccessType<Type>;
+export function SUCCESS_KEY<Type extends string>(key: Type): ActionType<Type, typeof SUCCESS> {
+  return (key + SUCCESS) as ActionType<Type, typeof SUCCESS>;
 }
 
-export function FAILURE_KEY<Type extends string>(key: Type): ErrorType<Type> {
-  return (key + FAILURE) as ErrorType<Type>;
+export function FAILURE_KEY<Type extends string>(key: Type): ActionType<Type, typeof FAILURE> {
+  return (key + FAILURE) as ActionType<Type, typeof FAILURE>;
 }
 
 // TODO: Figure out how to type Dispatch correctly

--- a/website/src/reducers/index.ts
+++ b/website/src/reducers/index.ts
@@ -28,9 +28,8 @@ const planner = persistReducer('planner', plannerReducer);
 // State default is delegated to its child reducers.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const defaultState: State = {} as any;
-const undoReducer = createUndoReducer({
+const undoReducer = createUndoReducer<State>({
   limit: 1,
-  reducerName: 'undoHistory',
   actionsToWatch: [REMOVE_MODULE, SET_TIMETABLE],
   whitelist: ['timetables', 'theme.colors'],
 });

--- a/website/src/reducers/planner.ts
+++ b/website/src/reducers/planner.ts
@@ -35,14 +35,14 @@ export default function planner(
       return {
         ...state,
         minYear: action.payload,
-        maxYear: max([action.payload, state.maxYear])!,
+        maxYear: max([action.payload, state.maxYear]) as string,
       };
 
     case SET_PLANNER_MAX_YEAR:
       return {
         ...state,
         maxYear: action.payload,
-        minYear: min([action.payload, state.minYear])!,
+        minYear: min([action.payload, state.minYear]) as string,
       };
 
     case SET_PLANNER_IBLOCS:

--- a/website/src/reducers/undoHistory.test.ts
+++ b/website/src/reducers/undoHistory.test.ts
@@ -26,7 +26,7 @@ type TestState = {
     notToTouch: number[];
   };
   untouchable: { payload: string };
-  undoHistoryState: UndoHistoryState;
+  undoHistory: UndoHistoryState<TestState>;
 };
 
 const state: TestState = {
@@ -38,7 +38,7 @@ const state: TestState = {
     notToTouch: [3, 1, 4],
   },
   untouchable: { payload: 'donottouch' },
-  undoHistoryState: emptyUndoHistory,
+  undoHistory: emptyUndoHistory,
 };
 
 const mutatedState = produce(state, (draft) => {
@@ -47,21 +47,20 @@ const mutatedState = produce(state, (draft) => {
 });
 
 const config: UndoHistoryConfig = {
-  reducerName: 'undoHistoryState',
   actionsToWatch: [WATCHED_ACTION],
   whitelist: ['data.toMutate.numbers', 'data.toMutate.string'],
 };
 
 describe('#computeUndoStacks()', () => {
   test('should ignore irrelevant actions', () => {
-    const hist0 = state.undoHistoryState;
+    const hist0 = state.undoHistory;
     const hist1 = computeUndoStacks(hist0, newFSA(IGNORED_ACTION), state, mutatedState, config);
     expect(hist1).toEqual(hist0);
   });
 
   test('should store data when relevant actions dispatched', () => {
-    const hist0 = produce(state.undoHistoryState, (draft) => {
-      draft.future.push(draft);
+    const hist0 = produce(state.undoHistory, (draft) => {
+      draft.future.push(state);
     });
     const hist1 = computeUndoStacks(hist0, newFSA(WATCHED_ACTION), state, mutatedState, config);
     const hist2 = computeUndoStacks(hist1, newFSA(WATCHED_ACTION), mutatedState, state, config);
@@ -91,7 +90,7 @@ describe('#computeUndoStacks()', () => {
   });
 
   test('should undo', () => {
-    const hist0 = state.undoHistoryState; // Empty past, present and future
+    const hist0 = state.undoHistory; // Empty past, present and future
     const hist1 = computeUndoStacks(hist0, newFSA(WATCHED_ACTION), state, mutatedState, config); // Populate past and present
 
     // Expect present to be pushed to future
@@ -116,7 +115,7 @@ describe('#computeUndoStacks()', () => {
   });
 
   test('should redo', () => {
-    const hist0 = state.undoHistoryState; // Empty past, present and future
+    const hist0 = state.undoHistory; // Empty past, present and future
     const hist1 = computeUndoStacks(hist0, newFSA(WATCHED_ACTION), state, mutatedState, config); // Populate past and present
     const hist2 = computeUndoStacks(hist1, undo(), mutatedState, mutatedState, config); // Populate present and future, clears past
 
@@ -149,7 +148,7 @@ describe('#computeUndoStacks()', () => {
     const limitN = { ...config, limit: -1 }; // Edge case
 
     // Expect limit > 0 to be enforced
-    const hist0 = state.undoHistoryState; // Empty past, present and future
+    const hist0 = state.undoHistory; // Empty past, present and future
     const hist10 = computeUndoStacks(hist0, newFSA(WATCHED_ACTION), state, mutatedState, limit1); // Populate past and present
     const hist11 = computeUndoStacks(hist10, newFSA(WATCHED_ACTION), mutatedState, state, limit1);
     expect(hist11.past).toHaveLength(1); // Expect length to be limited
@@ -193,25 +192,25 @@ describe('#mergePresent()', () => {
 });
 
 describe('#undoHistory()()', () => {
-  const unredo = undoHistory(config);
+  const unredo = undoHistory<TestState>(config);
 
   test('should set history state and merges present state', () => {
-    const hist0 = state.undoHistoryState; // Empty past, present and future
+    const hist0 = state.undoHistory; // Empty past, present and future
     const hist1 = computeUndoStacks(hist0, newFSA(WATCHED_ACTION), state, mutatedState, config); // Populate past and present
 
     // Updates state if watched action dispatched
     const state0 = unredo(state, mutatedState, newFSA(WATCHED_ACTION)); // undoHistoryState populated
-    expect(state0.undoHistoryState).toEqual(hist1);
+    expect(state0.undoHistory).toEqual(hist1);
 
     // Expect undo to change a subset of data and change history state
     const state1 = unredo(state0, state0, undo()); // Undo
     expect(state1.data.notToTouch).toEqual(state0.data.notToTouch); // Make sure what's not persisted is not touched
     expect(state1).not.toEqual(state0);
-    expect(state1.undoHistoryState).not.toEqual(state0.undoHistoryState);
+    expect(state1.undoHistory).not.toEqual(state0.undoHistory);
 
     // Expect redo to reset a subset of data and history state
     const state2 = unredo(state1, state1, redo()); // Redo
     expect(state2).toEqual(state0);
-    expect(state2.undoHistoryState).toEqual(state0.undoHistoryState);
+    expect(state2.undoHistory).toEqual(state0.undoHistory);
   });
 });

--- a/website/src/reducers/undoHistory.ts
+++ b/website/src/reducers/undoHistory.ts
@@ -5,30 +5,26 @@ import { UndoHistoryState } from 'types/reducers';
 import { Actions } from 'types/actions';
 
 export type UndoHistoryConfig = {
-  reducerName: string;
   limit?: number;
   actionsToWatch: string[];
   whitelist: string[];
-};
-
-// Call the reducer with empty action to populate the initial state
-const initialState: UndoHistoryState = {
-  past: [],
-  present: undefined, // Don't pretend to know the present
-  future: [],
 };
 
 // Update undo history using the action and app states
 // Basically a reducer but not really, as it needs to know the previous state.
 // Passing state in even though state === presentAppState[config.reducerName] as the "reducer"
 // doesn't need to know that.
-export function computeUndoStacks<T extends Record<string, any>>(
-  state: UndoHistoryState = initialState,
+export function computeUndoStacks<T extends { undoHistory: UndoHistoryState<T> }>(
+  state: UndoHistoryState<T> = {
+    past: [],
+    present: undefined, // Don't pretend to know the present
+    future: [],
+  },
   action: Actions,
-  previousAppState: T,
-  presentAppState: T,
+  previousAppState: Partial<T>,
+  presentAppState: Partial<T>,
   config: UndoHistoryConfig,
-): UndoHistoryState {
+): UndoHistoryState<T> {
   const { past, present, future } = state;
 
   // If action is undo/redoable, store state
@@ -75,9 +71,9 @@ export function computeUndoStacks<T extends Record<string, any>>(
 }
 
 // Copy all keyPaths in present into a new copy of state
-export function mergePresent<T extends Record<string, any>>(
+export function mergePresent<T extends Record<string, unknown>>(
   state: T,
-  present: Record<string, any>,
+  present: Record<string, unknown>,
   keyPaths: string[],
 ): T {
   const newState = { ...state };
@@ -90,10 +86,12 @@ export function mergePresent<T extends Record<string, any>>(
 
 // Given a config object, returns function which compute new state after
 // undoing/redoing/storing present as required by action.
-export default function createUndoReducer(config: UndoHistoryConfig) {
-  return <T extends Record<string, any>>(previousState: T, presentState: T, action: Actions) => {
+export default function createUndoReducer<T extends { undoHistory: UndoHistoryState<T> }>(
+  config: UndoHistoryConfig,
+) {
+  return (previousState: T, presentState: T, action: Actions) => {
     // Calculate un/redone history
-    const undoHistoryState = presentState[config.reducerName];
+    const undoHistoryState = presentState.undoHistory;
     const updatedHistory = computeUndoStacks(
       undoHistoryState,
       action,
@@ -101,7 +99,7 @@ export default function createUndoReducer(config: UndoHistoryConfig) {
       presentState,
       config,
     );
-    const updatedState = { ...presentState, [config.reducerName]: updatedHistory };
+    const updatedState = { ...presentState, undoHistory: updatedHistory };
 
     // Applies undo and redo actions on overall app state
     // Applies updatedHistory.present to state if action.type === {UNDO,REDO}

--- a/website/src/types/reducers.ts
+++ b/website/src/types/reducers.ts
@@ -174,10 +174,10 @@ export type ModuleBank = {
 /**
  * undoHistory types
  */
-export type UndoHistoryState = {
-  past: Record<string, any>[];
-  present: Record<string, any> | undefined;
-  future: Record<string, any>[];
+export type UndoHistoryState<T extends { undoHistory: UndoHistoryState<T> }> = {
+  past: Partial<T>[];
+  present: Partial<T> | undefined;
+  future: Partial<T>[];
 };
 
 /**

--- a/website/src/types/state.ts
+++ b/website/src/types/state.ts
@@ -19,5 +19,5 @@ export type State = {
   theme: ThemeState;
   settings: SettingsState;
   planner: PlannerState;
-  undoHistory: UndoHistoryState;
+  undoHistory: UndoHistoryState<State>;
 };

--- a/website/src/utils/timetables.ts
+++ b/website/src/utils/timetables.ts
@@ -3,6 +3,7 @@ import {
   castArray,
   difference,
   each,
+  first,
   flatMapDeep,
   get,
   groupBy,
@@ -101,7 +102,8 @@ export function randomModuleLessonConfig(lessons: readonly RawLesson[]): ModuleL
 
   return mapValues(
     lessonByGroupsByClassNo,
-    (group: { [classNo: string]: readonly RawLesson[] }) => sample(group)![0].classNo,
+    (group: { [classNo: string]: readonly RawLesson[] }) =>
+      (first(sample(group)) as RawLesson).classNo,
   );
 }
 
@@ -258,7 +260,7 @@ export function isLessonAvailable(
 ): boolean {
   return consumeWeeks(
     lesson.weeks,
-    (weeks) => weeks.includes(weekInfo.num!),
+    (weeks) => weeks.includes(weekInfo.num as number),
     (weekRange) => {
       const end = minDate([parseISO(weekRange.end), date]);
       for (let current = parseISO(weekRange.start); current <= end; current = addDays(current, 7)) {

--- a/website/src/views/components/KeyboardShortcuts.tsx
+++ b/website/src/views/components/KeyboardShortcuts.tsx
@@ -169,7 +169,7 @@ export class KeyboardShortcutsComponent extends React.PureComponent<Props, State
           {map(sections, (shortcuts, heading) => (
             <tbody key={heading}>
               <tr>
-                <th />
+                <th aria-label="Key column" />
                 <th>{heading}</th>
               </tr>
 

--- a/website/src/views/components/filters/ChecklistFilter.tsx
+++ b/website/src/views/components/filters/ChecklistFilter.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
+import { ElasticSearchFilter } from 'types/vendor/elastic-search';
 import FilterContainer from './FilterContainer';
 import CheckboxItemFilter from './CheckboxItemFilter';
 
 export type FilterItem = {
   key: string;
   label: string;
-  filter: any;
+  filter: ElasticSearchFilter;
 };
 
 interface ChecklistFilterProps {

--- a/website/src/views/tetris/overlays/HighScoreForm.tsx
+++ b/website/src/views/tetris/overlays/HighScoreForm.tsx
@@ -91,7 +91,7 @@ export default class HighScoreForm extends React.PureComponent<Props, State> {
         <table className={classnames(styles.table, 'table table-sm table-borderless')}>
           <thead>
             <tr>
-              <th />
+              <th aria-label="Rank" />
               <th>Name</th>
               <th>Score</th>
             </tr>


### PR DESCRIPTION
## Overview
Fixes 17 lint warnings in the `website` folder.

The set of warnings producing the greatest change are those related to undoHistory:

**nusmods/website/src/reducers/undoHistory.ts (4 warnings)**
```
  25:60  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  78:55  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  80:27  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  94:36  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

**nusmods/website/src/types/reducers.ts (3 warnings)**
```
  178:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  179:27  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  180:26  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

While addressing the above, I took the opportunity to tighten typing in `undoHistory.ts`. Instead of dynamically accepting a string to be the reducer name in State, I mandate that the key for `undoHistoryState` be called `"undoHistory"`. For functions that rely on this key being present, this allows me to enforce that compatible states are being passed as input. Example:
```
function createUndoReducer<T extends { undoHistory: UndoHistoryState<T> }>(...) {
  return (previousState: T, presentState: T, action: Actions) => {
    const undoHistoryState = presentState.undoHistory;
    ...
  }
}
```

I've also made `UndoHistoryState` be aware of the State type it's tracking via a generic `T`. This is so that `past`, `present` and `future` are not simply arbitrary records. See the type definition in [`reducers.ts`](https://github.com/nusmodifications/nusmods/compare/master...afterdusk:website-lint-warnings?expand=1#diff-f86df7ae139b0713cdc8f4ca3ea593a0L177-R180).

All the undoHistory related changes are found in the second commit, if you want to review them in isolation. I'm also happy to add more details if anything's unclear. (Sidenote: The tighter typing helped me find a bug in [`undoHistory.test.ts`](https://github.com/nusmodifications/nusmods/compare/master...afterdusk:website-lint-warnings?expand=1#diff-58d094118547eb5cc905cc0488b70164L64))

## Remaining Warnings
There are 3 remaining warnings that I am open to fixing in this PR, but I need some help.

- [ ] **nusmods/website/src/middlewares/requests-middleware.ts (3 warnings)**
```
  7:72  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  8:72  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  9:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```
corresponding to:
https://github.com/nusmodifications/nusmods/blob/b6ed0289de2abfbbc625be7d0edc0cec72558352/website/src/middlewares/requests-middleware.ts#L7-L9
I'm unclear what `__requestType`, `__successType` and `__errorType` are for. This was introduced as part of #2280.
