### PR TITLE
Speed up CI by disabling node_modules cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,20 +4,6 @@ defaults: &defaults
   docker:
     - image: circleci/node:12
 
-restore_cache: &restore_node_deps
-  name: Restore node_modules cache
-  keys:
-    - v2-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
-    - v2-node-{{ arch }}-{{ .Branch }}-
-    - v2-node-{{ arch }}-
-
-save_cache: &save_node_deps
-  name: Save node_modules cache
-  key: v2-node-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
-  paths:
-    - ~/.cache/yarn
-    - node_modules
-
 jobs:
   checkout:
     <<: *defaults
@@ -36,9 +22,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/nusmods
-      - restore_cache: *restore_node_deps
       - run: yarn --frozen-lockfile --non-interactive
-      - save_cache: *save_node_deps
       - run: yarn lint
       - run: yarn test --runInBand
       - run:
@@ -53,9 +37,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/nusmods
-      - restore_cache: *restore_node_deps
       - run: yarn --frozen-lockfile --non-interactive
-      - save_cache: *save_node_deps
       - run: yarn lint
       - run: yarn test --runInBand
       - run:
@@ -70,9 +52,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/nusmods
-      - restore_cache: *restore_node_deps
       - run: yarn --frozen-lockfile --non-interactive
-      - save_cache: *save_node_deps
       - run: yarn lint
       - run: yarn test --runInBand
       - run: yarn build
@@ -91,11 +71,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/nusmods
-      - restore_cache: *restore_node_deps
       - run:
           name: Install dependencies
           command: yarn --frozen-lockfile --non-interactive --production=false
-      - save_cache: *save_node_deps
       - run:
           name: Lint code
           command: yarn lint:code --cache --cache-location 'node_modules/.eslintcache/'


### PR DESCRIPTION
CI's cache was very slow and took a significant amount of time - eyeballed numbers:

* Cache restoration: 30 sec - 2 min for each of the 4 jobs
* Cache saving: 0-7 min

This PR removes caching entirely, relying on `yarn` to install fresh packages every time. On all 4 jobs, this seems to take 50 sec - 1 min.

Most of our CI workload is caused by dependency upgrades, which by definition will cause a fresh cache save, and a `yarn install` time of ~30s (as opposed to 0-8s if there's no deps change).

I think it's an overall win:
* The `website` job takes roughly 5 min to restore/yarn/save on non-dep upgrade PRs, so this decreases the time by about 5x.
* On the other 3 jobs, there may be some very small savings (~30s max) by using the cache, but cache restoration often takes longer than just running yarn, so I don't think there's any win by using the cache on average.