### PR TITLE
Clean up website ESLint rules

### DIFF
--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -30,9 +30,6 @@ module.exports = {
     'no-debugger': warnInDevelopment,
     'no-console': warnInDevelopment,
 
-    'no-alert': 'off',
-    'prefer-destructuring': 'off',
-
     'import/extensions': [
       warnInDevelopment,
       'always',
@@ -44,20 +41,12 @@ module.exports = {
       },
     ],
 
-    // Allow properties that are logically grouped together to be written
-    // without line breaks
-    'lines-between-class-members': 'off',
-
     // Enable i++ in for loops
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
-    'no-bitwise': 'off',
 
     'react/no-unescaped-entities': 'off',
 
     'react/no-array-index-key': 'off',
-
-    // SEE: https://github.com/yannickcr/eslint-plugin-react/issues
-    'react/no-unused-prop-types': 'off',
 
     // Enables typing to be placed above lifecycle
     'react/sort-comp': [
@@ -76,7 +65,6 @@ module.exports = {
     ],
 
     // These lints are not useful
-    'react/require-default-props': 'off',
     'react/jsx-props-no-spreading': 'off',
     'react/state-in-constructor': 'off',
 
@@ -91,9 +79,6 @@ module.exports = {
 
     // Too verbose, creates too many variables
     'react/destructuring-assignment': 'off',
-
-    // TODO: Fix this
-    'react/no-access-state-in-setstate': 'warn',
 
     'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
     'react-hooks/exhaustive-deps': 'warn', // Checks effect dependencies

--- a/website/.postcssrc.js
+++ b/website/.postcssrc.js
@@ -1,4 +1,3 @@
-/* eslint-disable global-require, import/no-extraneous-dependencies */
 const config = {
   plugins: [require('autoprefixer')],
 };

--- a/website/.stylelintrc.js
+++ b/website/.stylelintrc.js
@@ -369,9 +369,6 @@ module.exports = {
       ],
       { unspecified: 'bottomAlphabetical' },
     ],
-    'value-keyword-case': [
-      'lower',
-      { ignoreProperties: ['composes'] },
-    ],
+    'value-keyword-case': ['lower', { ignoreProperties: ['composes'] }],
   },
 };

--- a/website/scripts/build.js
+++ b/website/scripts/build.js
@@ -39,7 +39,6 @@ function handleErrors(stats) {
   });
 
   if (process.env.CI && statsJson.warnings.length) {
-    // eslint-disable-next-line max-len
     printErrors(
       'Failed to compile. When process.env.CI = true, warnings are treated as failures. Most CI servers set this automatically.',
       stats.compilation.warnings,

--- a/website/scripts/download-bus-stops.js
+++ b/website/scripts/download-bus-stops.js
@@ -2,19 +2,16 @@ const path = require('path');
 const axios = require('axios');
 const fs = require('fs-extra');
 
-/**
- * Download bus stop location information from ComfortDelGro's
- * NUS NextBus API
- */
-
-/* eslint-disable camelcase */
-
 const routes = ['A1', 'A2', 'B1', 'B2', 'C', 'BTC1', 'BTC2', 'D1', 'D2'];
 const getBusStop = 'https://nextbus.comfortdelgro.com.sg/eventservice.svc/busstops';
 const getBusRoute = 'https://nextbus.comfortdelgro.com.sg/eventservice.svc/pickuppoint';
 
 const dataPath = path.join(__dirname, '../src/data/bus-stops.json');
 
+/**
+ * Download bus stop location information from ComfortDelGro's
+ * NUS NextBus API
+ */
 async function downloadBusStops() {
   const busStopResponse = await axios.get(getBusStop);
   const data = busStopResponse.data.BusStopsResult.busstops;
@@ -42,18 +39,18 @@ async function downloadBusStops() {
 
   // Insert the bus stops for each route into their bus stops
   await Promise.all(
-    routes.map(async (route_code) => {
-      const response = await axios.get(getBusRoute, { params: { route_code } });
+    routes.map(async (routeCode) => {
+      const response = await axios.get(getBusRoute, { params: { route_code: routeCode } });
       response.data.PickupPointResult.pickuppoint.forEach((point) => {
         if (!point) return;
 
         if (!busStops[point.busstopcode]) {
           console.warn(point);
-          console.warn(`For route ${route_code}`);
+          console.warn(`For route ${routeCode}`);
           return;
         }
 
-        busStops[point.busstopcode].routes.push(route_code);
+        busStops[point.busstopcode].routes.push(routeCode);
       });
     }),
   );

--- a/website/src/.eslintrc.js
+++ b/website/src/.eslintrc.js
@@ -104,9 +104,5 @@ module.exports = {
 
     // We use type aliases for data types, ie. things that are not new-able
     '@typescript-eslint/prefer-interface': 'off',
-
-    // TODO: Fix these
-    '@typescript-eslint/no-explicit-any': 'warn',
-    '@typescript-eslint/no-non-null-assertion': 'warn',
   },
 };

--- a/website/src/.eslintrc.js
+++ b/website/src/.eslintrc.js
@@ -86,10 +86,6 @@ module.exports = {
     'default-case': 'off',
     '@typescript-eslint/switch-exhaustiveness-check': 'error',
 
-    // Rule is buggy when used with TypeScript
-    // TODO: Remove this when https://github.com/benmosher/eslint-plugin-import/issues/1282 is resolved
-    'import/named': 'off',
-
     // Makes the code unnecessarily verbose
     '@typescript-eslint/explicit-function-return-type': 'off',
 

--- a/website/src/.eslintrc.js
+++ b/website/src/.eslintrc.js
@@ -91,9 +91,6 @@ module.exports = {
     'import/named': 'off',
 
     // Makes the code unnecessarily verbose
-    '@typescript-eslint/explicit-member-accessibility': 'off',
-
-    // Makes the code unnecessarily verbose
     '@typescript-eslint/explicit-function-return-type': 'off',
 
     '@typescript-eslint/no-unused-vars': [
@@ -102,8 +99,5 @@ module.exports = {
         ignoreRestSiblings: true,
       },
     ],
-
-    // We use type aliases for data types, ie. things that are not new-able
-    '@typescript-eslint/prefer-interface': 'off',
   },
 };

--- a/website/src/.eslintrc.js
+++ b/website/src/.eslintrc.js
@@ -82,8 +82,9 @@ module.exports = {
   ],
 
   rules: {
-    // Assume TypeScript will catch this for us
+    // Use @typescript-eslint to catch this
     'default-case': 'off',
+    '@typescript-eslint/switch-exhaustiveness-check': 'error',
 
     // Rule is buggy when used with TypeScript
     // TODO: Remove this when https://github.com/benmosher/eslint-plugin-import/issues/1282 is resolved

--- a/website/src/bootstrapping/configure-store.ts
+++ b/website/src/bootstrapping/configure-store.ts
@@ -6,12 +6,12 @@ import requestsMiddleware from 'middlewares/requests-middleware';
 import ravenMiddleware from 'middlewares/raven-middleware';
 import { setAutoFreeze } from 'immer';
 
-import { FSA, GetState } from 'types/redux';
+import { GetState } from 'types/redux';
 import { State } from 'types/state';
+import { Actions } from 'types/actions';
 
 // For redux-devtools-extensions - see
 // https://github.com/zalmoxisus/redux-devtools-extension
-// eslint-disable-next-line no-underscore-dangle
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 // immer uses Object.freeze on returned state objects, which is incompatible with
@@ -22,16 +22,15 @@ export default function configureStore(defaultState?: State) {
   const middlewares = [ravenMiddleware, thunk, requestsMiddleware];
 
   if (process.env.NODE_ENV === 'development') {
-    /* eslint-disable */
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-extraneous-dependencies
     const { createLogger } = require('redux-logger');
-    /* eslint-enable */
     const logger = createLogger({
       level: 'info',
       collapsed: true,
       duration: true,
       diff: true,
       // Avoid diffing actions that insert a lot of stuff into the state to prevent console from lagging
-      diffPredicate: (getState: GetState, action: FSA) =>
+      diffPredicate: (getState: GetState, action: Actions) =>
         !action.type.startsWith('FETCH_MODULE_LIST') && !action.type.startsWith('persist/'),
     });
     middlewares.push(logger);

--- a/website/src/data/academic-calendar.ts
+++ b/website/src/data/academic-calendar.ts
@@ -2,10 +2,10 @@ import academicCalendarJSON from './academic-calendar.json';
 
 // Force TS to accept our typing instead of inferring from the JSON
 type DateTuple = [number, number, number];
-const academicCalendar: {
+const academicCalendar = (academicCalendarJSON as unknown) as {
   [year: string]: {
     [semester: string]: { start: DateTuple };
   };
-} = academicCalendarJSON as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+};
 
 export default academicCalendar;

--- a/website/src/reducers/index.ts
+++ b/website/src/reducers/index.ts
@@ -26,8 +26,7 @@ const settings = persistReducer('settings', settingsReducer, settingsPersistConf
 const planner = persistReducer('planner', plannerReducer);
 
 // State default is delegated to its child reducers.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const defaultState: State = {} as any;
+const defaultState = ({} as unknown) as State;
 const undoReducer = createUndoReducer<State>({
   limit: 1,
   actionsToWatch: [REMOVE_MODULE, SET_TIMETABLE],

--- a/website/src/reducers/planner.test.ts
+++ b/website/src/reducers/planner.test.ts
@@ -23,8 +23,6 @@ const defaultState: PlannerState = {
   custom: {},
 };
 
-/* eslint-disable no-useless-computed-key */
-
 describe(SET_PLANNER_MIN_YEAR, () => {
   test('should set min year', () => {
     expect(reducer(defaultState, setPlannerMinYear('2016/2017'))).toEqual({

--- a/website/src/reducers/requests.ts
+++ b/website/src/reducers/requests.ts
@@ -1,6 +1,16 @@
-import { FSA } from 'types/redux';
 import { Requests, FAILURE, REQUEST, SUCCESS } from 'types/reducers';
 import { API_REQUEST } from 'actions/requests';
+
+/**
+ * Flux Standard Action: https://github.com/acdlite/flux-standard-action
+ * @deprecated Use Actions from types/actions instead
+ */
+type FSA = {
+  type: string;
+  payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  meta?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  error?: boolean;
+};
 
 export default function requests(state: Requests = {}, action: FSA): Requests {
   const { meta } = action;

--- a/website/src/selectors/planner.ts
+++ b/website/src/selectors/planner.ts
@@ -16,8 +16,6 @@ import { findExamClashes } from 'utils/timetables';
 import { State } from 'types/state';
 import { CustomModuleData, ModuleTime } from 'types/planner';
 
-/* eslint-disable no-useless-computed-key */
-
 /**
  * Get a list of modules planned for a specific semester in an acad year
  * in the order specified by the index

--- a/website/src/storage/index.ts
+++ b/website/src/storage/index.ts
@@ -2,10 +2,8 @@ import { isString } from 'lodash';
 import { captureException } from 'utils/error';
 import getLocalStorage from './localStorage';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 // Simple wrapper around localStorage to automagically parse and stringify payloads.
-function setItem(key: string, value: any) {
+function setItem(key: string, value: unknown) {
   try {
     getLocalStorage().setItem(key, isString(value) ? value : JSON.stringify(value));
   } catch (e) {
@@ -28,7 +26,7 @@ function setItem(key: string, value: any) {
   }
 }
 
-function getItem(key: string): any {
+function getItem(key: string): unknown {
   let value;
   try {
     value = getLocalStorage().getItem(key);

--- a/website/src/types/export.ts
+++ b/website/src/types/export.ts
@@ -3,8 +3,6 @@ import { Semester, ModuleCode } from 'types/modules';
 import { Mode } from 'types/settings';
 import { ColorMapping, ThemeState } from 'types/reducers';
 
-/* eslint-disable import/prefer-default-export */
-
 export type ExportData = {
   readonly semester: Semester;
   readonly timetable: SemTimetableConfig;

--- a/website/src/types/redux.ts
+++ b/website/src/types/redux.ts
@@ -1,17 +1,6 @@
 import { State } from './state';
 import { Values } from './utils';
 
-/**
- * Flux Standard Action: https://github.com/acdlite/flux-standard-action
- * @deprecated Use Actions from types/actions instead
- */
-export type FSA = {
-  type: string;
-  payload: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  meta?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-  error?: boolean;
-};
-
 export type GetState = () => State;
 
 /**

--- a/website/src/utils/array.ts
+++ b/website/src/utils/array.ts
@@ -36,8 +36,7 @@ export function deltas(numbers: readonly number[]): number[] {
   if (typeof previous !== 'number') return result;
 
   numbers.slice(1).forEach((element) => {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    result.push(element - previous!);
+    result.push(element - previous);
     previous = element;
   });
 

--- a/website/src/utils/colors.ts
+++ b/website/src/utils/colors.ts
@@ -23,9 +23,7 @@ export function getNewColor(currentColors: ColorIndex[], randomize = true): Colo
   });
 
   if (randomize) {
-    // Safe to assert non null because the previous step ensures availableColorIndices is never empty
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return sample(availableColors)!;
+    return sample(availableColors) ?? availableColors[0];
   }
 
   return availableColors[0];

--- a/website/src/utils/elasticSearch.ts
+++ b/website/src/utils/elasticSearch.ts
@@ -6,11 +6,11 @@ const POST_TAG = '</mark>';
 const PRE_TAG_REGEX = new RegExp(escapeRegExp(PRE_TAG), 'gi');
 const POST_TAG_REGEX = new RegExp(escapeRegExp(POST_TAG), 'gi');
 
-/* eslint-disable @typescript-eslint/camelcase, no-underscore-dangle */
-
 // For options, see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html#highlighting-settings
 export const HIGHLIGHT_OPTIONS = {
+  // eslint-disable-next-line @typescript-eslint/camelcase
   pre_tags: [PRE_TAG],
+  // eslint-disable-next-line @typescript-eslint/camelcase
   post_tags: [POST_TAG],
   fields: {
     moduleCode: {},

--- a/website/src/utils/error.ts
+++ b/website/src/utils/error.ts
@@ -2,9 +2,7 @@ import * as Sentry from '@sentry/browser';
 import { each, size } from 'lodash';
 import { retry } from 'utils/promise';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-export function captureException(error: any, extra: any = {}) {
+export function captureException(error: Error, extra: { [key: string]: unknown } = {}) {
   Sentry.withScope((scope) => {
     each(extra, (data, key) => {
       scope.setExtra(key, extra[key]);
@@ -22,7 +20,7 @@ export function captureException(error: any, extra: any = {}) {
  * scripts using <script> tags
  */
 export function getScriptErrorHandler(scriptName: string) {
-  return (error: any) => {
+  return (error: unknown) => {
     if (error instanceof Error) {
       captureException(error);
     } else {

--- a/website/src/utils/modules.ts
+++ b/website/src/utils/modules.ts
@@ -70,8 +70,7 @@ export function getFirstAvailableSemester(
 ): Semester {
   const availableSemesters = semesters.map((semesterData) => semesterData.semester);
   // Assume there is at least 1 semester
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return availableSemesters.includes(current) ? current : _.min(availableSemesters)!;
+  return availableSemesters.includes(current) ? current : Math.min(...availableSemesters);
 }
 
 export function getSemestersOffered(module: Module): Semester[] {

--- a/website/src/utils/promise.ts
+++ b/website/src/utils/promise.ts
@@ -1,15 +1,20 @@
-// Recursively retry fn until success, retries has been reached, or shouldRetry returns false.
-// Based on https://stackoverflow.com/a/30471209/5281021
-// TODO: Remove eslint-disable-line comment when other functions have been added to this file
-export function retry<T>( // eslint-disable-line import/prefer-default-export
+/**
+ * Recursively retry `fn` until success, `retries` has been reached, or
+ * `shouldRetry` returns false.
+ *
+ * Implementation based on https://stackoverflow.com/a/30471209/5281021.
+ */
+export async function retry<T>(
   retries: number,
   fn: () => Promise<T>,
   shouldRetry: (error: Error) => boolean = () => true,
 ): Promise<T> {
-  return fn().catch((err) => {
+  try {
+    return fn();
+  } catch (err) {
     if (retries <= 0 || !shouldRetry(err)) {
       throw err;
     }
     return retry(retries - 1, fn, shouldRetry);
-  });
+  }
 }

--- a/website/src/utils/promise.ts
+++ b/website/src/utils/promise.ts
@@ -10,7 +10,8 @@ export async function retry<T>(
   shouldRetry: (error: Error) => boolean = () => true,
 ): Promise<T> {
   try {
-    return fn();
+    // Be sure to await before returning!
+    return await fn();
   } catch (err) {
     if (retries <= 0 || !shouldRetry(err)) {
       throw err;

--- a/website/src/utils/react.test.tsx
+++ b/website/src/utils/react.test.tsx
@@ -31,7 +31,7 @@ describe(highlight, () => {
 });
 
 describe('wrapComponentName()', () => {
-  /* eslint-disable react/prefer-stateless-function, react/no-multi-comp */
+  /* eslint-disable react/prefer-stateless-function */
   class TestComponent extends React.Component<{}> {}
   class TestPureComponent extends React.PureComponent<{}> {}
   class TestComponentWithDisplayName extends React.Component<{}> {

--- a/website/src/views/components/Omelette.tsx
+++ b/website/src/views/components/Omelette.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import config from 'config';
 
-/* eslint-disable */
-
 const eggs: Record<string, string> = {
   'JXg8I04=': 'JiEnPRxeXGE0PSQCAQcmMD4oHEoeITB8OwYAFiF6OCIBSRYqZH4jDAYXf2VrfUETFiw4',
   'LDQ4KAILHSEyMjkOFho=':
@@ -15,11 +13,12 @@ const k = config.brandName;
 
 const fryingPans = [
   (c: string) => c.charCodeAt(0),
-  (c: number, i: number) => c ^ k.charCodeAt(i % k.length),
+  (c: number, i: number) => c ^ k.charCodeAt(i % k.length), // eslint-disable-line no-bitwise
   String.fromCharCode,
   (c: string) => c.charAt(0),
 ];
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 const cook = (query: string) => fryingPans.reduce((a, b) => a.map(b), Array.from(query)).join('');
 
@@ -28,6 +27,7 @@ export const matchEgg = (query: string) => {
     return eggs[btoa(cook(query.toLowerCase()))];
   } catch (e) {
     // Swallow error
+    return undefined;
   }
 };
 
@@ -39,6 +39,7 @@ const Omelette: React.FC<Props> = (props) => {
   const yolk = matchEgg(props.query);
   if (!yolk) return null;
 
+  /* eslint-disable jsx-a11y/accessible-emoji, jsx-a11y/media-has-caption */
   return (
     <>
       <p className="text-center">We did find this though ⤵️</p>
@@ -47,6 +48,7 @@ const Omelette: React.FC<Props> = (props) => {
       </p>
     </>
   );
+  /* eslint-enable */
 };
 
 export default Omelette;

--- a/website/src/views/components/disqus/DisqusComments.tsx
+++ b/website/src/views/components/disqus/DisqusComments.tsx
@@ -30,6 +30,7 @@ class DisqusComments extends React.PureComponent<Props, State> {
   state = {
     allowDisqus: false,
   };
+
   componentDidMount() {
     this.loadInstance();
   }

--- a/website/src/views/components/disqus/DisqusComments.tsx
+++ b/website/src/views/components/disqus/DisqusComments.tsx
@@ -46,8 +46,6 @@ class DisqusComments extends React.PureComponent<Props, State> {
     }
   }
 
-  /* eslint-disable @typescript-eslint/camelcase */
-
   loadInstance = () => {
     if (this.props.loadDisqusManually && !this.state.allowDisqus) return;
 
@@ -60,8 +58,8 @@ class DisqusComments extends React.PureComponent<Props, State> {
     } else {
       // Inject the Disqus script if we're loading it for the first time, ie. when
       // window.DISQUS is not set
-      window.disqus_config = this.getDisqusConfig();
-      window.disqus_shortname = config.disqusShortname;
+      window.disqus_config = this.getDisqusConfig(); // eslint-disable-line @typescript-eslint/camelcase
+      window.disqus_shortname = config.disqusShortname; // eslint-disable-line @typescript-eslint/camelcase
 
       insertScript(`https://${config.disqusShortname}.disqus.com/embed.js`, {
         id: SCRIPT_ID,

--- a/website/src/views/components/map/BusStops.tsx
+++ b/website/src/views/components/map/BusStops.tsx
@@ -65,7 +65,7 @@ export default class BusStops extends React.PureComponent<Props, State> {
     if (!allowBusStopEditing()) return;
 
     const { target } = evt;
-    const code = target.getElement().children[0].dataset.code;
+    const { code } = target.getElement().children[0].dataset;
     const { lat, lng } = target.getLatLng();
 
     this.setState((state) =>

--- a/website/src/views/components/map/icons.ts
+++ b/website/src/views/components/map/icons.ts
@@ -1,5 +1,4 @@
 import { Icon } from 'leaflet';
-// eslint-disable-next-line import/extensions
 import marker from 'img/marker.svg?url';
 import styles from './LocationMap.scss';
 

--- a/website/src/views/components/map/withVenueLocations.tsx
+++ b/website/src/views/components/map/withVenueLocations.tsx
@@ -11,8 +11,7 @@ export type VenueLocations = {
   readonly venueLocations: VenueLocationMap;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ErrorProps = { error: any; retry: () => void };
+export type ErrorProps = { error: unknown; retry: () => void };
 
 export type WithVenueLocationsOptions = {
   Error?: ComponentType<ErrorProps>;
@@ -67,7 +66,6 @@ export default function withVenueLocations<Props extends VenueLocations>(
       return null;
     },
 
-    // eslint-disable-next-line react/prop-types
     render({ Component, venueLocations }, props: Subtract<Props, VenueLocations>) {
       return <Component venueLocations={venueLocations} {...(props as Props)} />;
     },

--- a/website/src/views/components/notfications/Notification.tsx
+++ b/website/src/views/components/notfications/Notification.tsx
@@ -48,6 +48,7 @@ const TRANSITION_DURATION = 250;
  */
 export class NotificationComponent extends React.Component<Props, State> {
   openTimeoutId?: number;
+
   closeTimeoutId?: number;
 
   element = React.createRef<HTMLDivElement>();
@@ -147,7 +148,7 @@ export class NotificationComponent extends React.Component<Props, State> {
               className="mdc-snackbar__action-button"
               onClick={() => {
                 this.setState({ actionClicked: true });
-                const handler = action.handler;
+                const { handler } = action;
                 // Don't auto-close if handler returns false
                 if (handler && handler() === false) return;
                 this.props.popNotification();

--- a/website/src/views/components/searchkit/Pagination.tsx
+++ b/website/src/views/components/searchkit/Pagination.tsx
@@ -40,9 +40,13 @@ export default class Pagination extends SearchkitComponent<PaginationProps, {}> 
   }
 
   onGoToFirst = () => this.setPage(FIRST_PAGE_INDEX);
+
   onGoToPrevious = () => this.setPage(this.getCurrentPage() - 1);
+
   onGoToPage = (page: number) => this.setPage(page);
+
   onGoToNext = () => this.setPage(this.getCurrentPage() + 1);
+
   onGoToLast = () => this.setPage(this.getTotalPages());
 
   setPage(requestedPage: number) {

--- a/website/src/views/contribute/ContributorList.tsx
+++ b/website/src/views/contribute/ContributorList.tsx
@@ -59,7 +59,6 @@ const ContributorList = Loadable.Map<Props, Export>({
   },
 
   // This is not a proper render function, so prop validation doesn't work
-  /* eslint-disable react/prop-types */
   render(loaded, props) {
     let { contributors } = loaded;
     if (props.size) contributors = contributors.slice(0, props.size);

--- a/website/src/views/elements.js
+++ b/website/src/views/elements.js
@@ -2,7 +2,6 @@
 // and assert against elements, which would be difficult to do otherwise because
 // we use CSS modules, which mangles the classnames.
 
-/* eslint-disable spaced-comment */
 const elements = {
   // Global
   timetable: 'timetable',

--- a/website/src/views/modules/ModuleFinderContainer/ModuleFinderContainer.tsx
+++ b/website/src/views/modules/ModuleFinderContainer/ModuleFinderContainer.tsx
@@ -35,12 +35,11 @@ const searchkit = new SearchkitManager(esHostUrl);
 
 const pageHead = <Title>Modules</Title>;
 
-/* eslint-disable no-underscore-dangle */
-
 const ModuleInformationListComponent: React.FC<HitsListProps> = ({ hits }) => (
   <ul className={styles.modulesList}>
     {hits.map((hit) => {
       const result = hit as ElasticSearchResult<ModuleInformation>;
+      /* eslint-disable no-underscore-dangle */
       return (
         <ModuleFinderItem
           key={result._source.moduleCode}
@@ -48,6 +47,7 @@ const ModuleInformationListComponent: React.FC<HitsListProps> = ({ hits }) => (
           highlight={result.highlight}
         />
       );
+      /* eslint-enable */
     })}
   </ul>
 );

--- a/website/src/views/modules/ModulePageContainer.tsx
+++ b/website/src/views/modules/ModulePageContainer.tsx
@@ -134,7 +134,7 @@ export class ModulePageContainerComponent extends React.PureComponent<Props, Sta
 }
 
 const getPropsFromMatch = (match: Match<Params>) => {
-  const year = match.params.year;
+  const { year } = match.params;
 
   return {
     moduleCode: (match.params.moduleCode || '').toUpperCase(),

--- a/website/src/views/tetris/ScrollingNumber.tsx
+++ b/website/src/views/tetris/ScrollingNumber.tsx
@@ -6,8 +6,7 @@ type Props = {
   className?: string;
 
   // Additional props
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 type State = {

--- a/website/src/views/tetris/TetrisGame.tsx
+++ b/website/src/views/tetris/TetrisGame.tsx
@@ -326,7 +326,7 @@ export default class TetrisGame extends React.PureComponent<Props, State> {
 
     this.setState((state) =>
       produce(state, (draft) => {
-        const holdPiece = draft.holdPiece;
+        const { holdPiece } = draft;
 
         // Reset the position of the current piece when it is held
         draft.holdPiece = {

--- a/website/src/views/tetris/board.ts
+++ b/website/src/views/tetris/board.ts
@@ -14,11 +14,9 @@ import { convertIndexToTime } from 'utils/timify';
 export const ROWS = 20;
 export const COLUMNS = 9;
 
-/**
+/*
  * Contains most of the gameplay logic
  */
-
-/* eslint-disable no-continue, consistent-return, no-loop-func */
 
 // The first timetable row index to be used
 export const INITIAL_ROW_INDEX = 16; // 8am
@@ -127,6 +125,7 @@ function iterateBoard(
 
     for (let row = 0; row < column.length; row++) {
       const tile = column[row];
+      // eslint-disable-next-line no-continue
       if (!tile) continue;
       if (iterator(tile, col, row) === false) {
         continueIterating = false;
@@ -217,6 +216,7 @@ export function isPieceInBounds(piece: Piece) {
       isValid = false;
       return false;
     }
+    return undefined;
   });
 
   return isValid;
@@ -231,6 +231,7 @@ export function isPiecePositionValid(board: Board, piece: Piece) {
       isValid = false;
       return false;
     }
+    return undefined;
   });
 
   return isValid;
@@ -266,7 +267,9 @@ export function removeCompleteRows(board: Board) {
     // TODO: Optimize based on where the piece has landed
     let row = ROWS - 1;
     while (row >= 0) {
+      // eslint-disable-next-line no-loop-func
       if (draft.every((column) => column[row] != null)) {
+        // eslint-disable-next-line no-loop-func
         draft.forEach((column) => {
           column.splice(row, 1);
           column.unshift(null);

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -286,7 +286,7 @@ class TimetableContent extends React.Component<Props, State> {
       .filter((lesson) => !this.isHiddenInTimetable(lesson.moduleCode));
 
     if (activeLesson) {
-      const moduleCode = activeLesson.moduleCode;
+      const { moduleCode } = activeLesson;
       // Remove activeLesson because it will appear again
       timetableLessons = timetableLessons.filter(
         (lesson) => !areLessonsSameClass(lesson, activeLesson),
@@ -436,7 +436,7 @@ class TimetableContent extends React.Component<Props, State> {
 
 function mapStateToProps(state: StoreState, ownProps: OwnProps) {
   const { semester, timetable } = ownProps;
-  const modules = state.moduleBank.modules;
+  const { modules } = state.moduleBank;
   const timetableWithLessons = hydrateSemTimetableWithLessons(timetable, modules, semester);
   const hiddenInTimetable = state.timetables.hidden[semester] || [];
 

--- a/website/src/views/today/TodayContainer/TodayContainer.tsx
+++ b/website/src/views/today/TodayContainer/TodayContainer.tsx
@@ -344,7 +344,7 @@ export class TodayContainerComponent extends React.PureComponent<Props, State> {
 }
 
 export const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
-  const modules = state.moduleBank.modules;
+  const { modules } = state.moduleBank;
   const lastDay = addDays(ownProps.currentTime, DAYS);
   const weekInfo = NUSModerator.academicCalendar.getAcadWeekInfo(lastDay);
   const semester = semesterNameMap[weekInfo.sem];

--- a/website/src/views/venues/VenueLocation/ImproveVenueForm.tsx
+++ b/website/src/views/venues/VenueLocation/ImproveVenueForm.tsx
@@ -40,8 +40,7 @@ type State = {
   // from location
   viewport: Viewport;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error?: any;
+  error?: Error;
 };
 
 const wellKnownLocations: Record<string, LatLngTuple> = {

--- a/website/src/views/venues/VenuesContainer.tsx
+++ b/website/src/views/venues/VenuesContainer.tsx
@@ -36,8 +36,6 @@ import VenueDetails from './VenueDetails';
 import VenueLocation from './VenueLocation';
 import styles from './VenuesContainer.scss';
 
-/* eslint-disable react/prop-types */
-
 export type Params = {
   q: string;
   venue: string;


### PR DESCRIPTION
Clean up `eslint-disable` and ESLint rules.

Depends on #2628.

## Implementation

* Removed as many `eslint-disable`s as I could.
* Made some file-level eslint-disables more specific by changing them to `eslint-disable(-next)?-line`
* In eslintrc, Un-disable rules that no longer cause any problems. Most of them just don't cause any more errors. Some of them were redundantly disabled, i.e. they were already disabled in our presets. I fixed the errors for 1 or 2.
* Add the awesome and sorely needed `@typescript-eslint/switch-exhaustiveness-check`, because turns out TypeScript doesn't check for switch case exhaustiveness.