### PR TITLE
Update .nvmrc node version to node 12 LTS

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/erbium

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Tip: Pick an area you're interested in, and just focus on it. It is not necessar
 
 ## Development Tools
 
-You should have [Node.js](https://nodejs.org/) version 10.13.0 or above and [Yarn](https://yarnpkg.com/en/) version 1.2.0 or above. We recommend using [nvm](https://github.com/creationix/nvm) to manage your Node versions.
+You should have [Node.js](https://nodejs.org/) version 12 or above (use Node 12 LTS or `lts/erbium` if possible) and [Yarn](https://yarnpkg.com/en/) version 1.2.0 or above. We recommend using [nvm](https://github.com/creationix/nvm) to manage your Node versions.
 
 ## Proposing a Change
 

--- a/website/README.md
+++ b/website/README.md
@@ -18,7 +18,7 @@ Don't know where to start? First, read our repository [contribution guide](../CO
 
 ## Getting Started
 
-Install [Node 10+](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/en/docs/install) then run the following command:
+Install [Node 12 LTS](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/en/docs/install) then run the following command:
 
 ```sh
 $ yarn


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
We use the Docker image `node:12-alpine`, which defaults to current Node 12 LTS release (v12.18.1 as of this PR) in prod. This PR updates `.nvmrc` and the docs so that contributors can more easily set up a reproducible dev environment.

## Implementation
Change some words

## Other Information
All tests pass with latest Node 12 LTS release
