### PR TITLE
Add keyboard shortcut for navigating to Today page

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -5,9 +5,9 @@ Create a new issue on GitHub with this checklist after the finals every semester
 ## Every Year
 
 - [ ] Update academic year and semester in `website/src/config/app-config.json`, and add current academic year to archive years
+- [ ] In `app-config.json`, update `examAvailability` to include only the semesters where exam information is available
 - [ ] Update with next year's holiday data from https://github.com/rjchow/singapore_public_holidays and delete old data, then run `scripts/holidays-csv-to-json.js`
 - [ ] Update `website/src/data/academic-calendar.json` with data for the new academic year
-- [ ] Update `examAvailability` to include only the semesters where exam information is available
 - [ ] Add announcement to website
 - [ ] On server: update academic year in `scrapers/nus-v2/src/config.ts`
 - [ ] Ensure that scraper is scraping next AY's data
@@ -18,4 +18,4 @@ Create a new issue on GitHub with this checklist after the finals every semester
 ## Every Semester
 
 - [ ] Update semester in `website/src/config/app-config.json`
-- [ ] Add semester to `examAvailability` to indicate exam information is available for the semester
+- [ ] In `app-config.json`, add semester to `examAvailability` to indicate exam information is available for the semester

--- a/website/src/views/components/KeyboardShortcuts.tsx
+++ b/website/src/views/components/KeyboardShortcuts.tsx
@@ -52,6 +52,10 @@ export class KeyboardShortcutsComponent extends React.PureComponent<Props, State
     const { dispatch, history } = this.props;
 
     // Navigation
+    this.bind('y', NAVIGATION, 'Go to today', () => {
+      history.push('/today');
+    });
+
     this.bind('t', NAVIGATION, 'Go to timetable', () => {
       history.push('/timetable');
     });


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
This PR adds a keyboard shortcut for 'Today' page. 
It also makes a minor change to maintenance doc to make it clearer.

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
The <kbd>y</kbd> button now navigates to the Toda**y** page. I didn't use <kbd>t</kbd> because it has already been taken by Timetable page.

<img src="https://user-images.githubusercontent.com/46853051/87220770-7d6e1380-c399-11ea-9aa0-b795f4619a95.png" width="400" />

The changes can be tested on the deployment preview 
