### PR TITLE
Show E-Learning venues as "E-Learning"

### DIFF
--- a/website/src/views/timetable/TimetableCell.tsx
+++ b/website/src/views/timetable/TimetableCell.tsx
@@ -132,7 +132,7 @@ const TimetableCell: React.FC<Props> = (props) => {
         <div>
           {LESSON_TYPE_ABBREV[lesson.lessonType]} [{lesson.classNo}]
         </div>
-        <div>{lesson.venue}</div>
+        <div>{lesson.venue.startsWith('E-Learn') ? 'E-Learning' : lesson.venue}</div>
         {weekText && <div>{weekText}</div>}
       </div>
     </Cell>

--- a/website/src/views/today/DayEvents.tsx
+++ b/website/src/views/today/DayEvents.tsx
@@ -46,7 +46,8 @@ const DayEvents = React.memo<Props>((props) => {
           <p>
             {lesson.lessonType} {lesson.classNo}
           </p>
-          <MapPin className={styles.venueIcon} /> {lesson.venue}
+          <MapPin className={styles.venueIcon} />{' '}
+          {lesson.venue.startsWith('E-Learn') ? 'E-Learning' : lesson.venue}
           <div>
             <EventMapInline
               className={styles.map}

--- a/website/src/views/venues/VenueList.tsx
+++ b/website/src/views/venues/VenueList.tsx
@@ -15,7 +15,9 @@ type Props = {
 };
 
 const VenueList: React.FC<Props> = (props) => {
-  const venueList = groupBy(props.venues, (venue) => venue.charAt(0).toUpperCase());
+  // Added during the horrible COVID-19 times to hide E-Learning venues
+  const physicalVenues = props.venues.filter((venue) => !venue.startsWith('E-Learn'));
+  const venueList = groupBy(physicalVenues, (venue) => venue.charAt(0).toUpperCase());
   const sortedVenueList = sortBy(toPairs(venueList), ([key]) => key);
 
   return (


### PR DESCRIPTION
## Context
Before:
| Venues Page | Timetable Cell | Today Page |
| ------------- | -------------- | ------------ |
|![image](https://user-images.githubusercontent.com/4933577/87232294-48d97680-c3f0-11ea-9fbf-2788376cc21b.png)|![image](https://user-images.githubusercontent.com/4933577/87232207-b0db8d00-c3ef-11ea-91d2-69ecbae87f46.png)|![image](https://user-images.githubusercontent.com/4933577/87232729-d5d1ff00-c3f3-11ea-9011-502b42b0a33c.png)|


After:
| Venues Page | Timetable Cell | Today Page |
| ------------- | -------------- | ------------ |
|![image](https://user-images.githubusercontent.com/4933577/87232315-7faf8c80-c3f0-11ea-883b-5cf13ef51066.png)|![image](https://user-images.githubusercontent.com/4933577/87232231-e6807600-c3ef-11ea-9f16-ab1857c18eb3.png)|![image](https://user-images.githubusercontent.com/4933577/87232752-0c0f7e80-c3f4-11ea-924b-5cb5ca0c1071.png)|


`E-Learn_*` venues are hidden from the Venues page, but they are still accessible directly via permalink (e.g. if the user visits https://nusmods.com/venues/E-Learn_C directly), though that shouldn't be a big problem.