### PR TITLE
Fix polyfills working incorrectly on Edge

### DIFF
--- a/website/src/entry/main.tsx
+++ b/website/src/entry/main.tsx
@@ -1,5 +1,10 @@
 // Import Sentry earliest to capture exceptions
 import 'bootstrapping/sentry';
+// core-js has issues with Promise feature detection on Edge, and hence
+// polyfills Promise incorrectly. Importing this polyfill directly resolves that.
+// This is necessary as PersistGate used in ./App uses `Promise.prototype.finally`.
+// See: https://github.com/zloirock/core-js/issues/579#issuecomment-504325213
+import 'core-js/es/promise/finally';
 
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
## Context
Users who use the non-Chromium Edge were reporting that they were seeing a white-screen of death when loading NUSMods, caused by:
![image](https://user-images.githubusercontent.com/4933577/87255225-6cb5be80-c4bb-11ea-8318-2001a047cead.png)

Which is caused by:
![image](https://user-images.githubusercontent.com/4933577/87255239-88b96000-c4bb-11ea-8114-07856d0200b4.png)

`PersistGate` from one of our deps, `redux-persist` uses `Promise.prototype.finally` which somehow isn't supported on Edge.

But no, the story doesn't end here.

`Promise.prototype.finally` actually IS SUPPORTED by Edge. Except that there is some oddity with our polyfill library `core-js` or with Edge that causes it to [fail Promise feature detection](https://github.com/zloirock/core-js/issues/579#issuecomment-504325213), and Promise is entirely polyfilled incorrectly by `core-js` on Edge, causing the native implementation of `finally` to be gone.

To resolve this, we polyfill `finally`.

## Implementation

Tried 3 methods

1. Add `require.resolve('redux-persist/integration/react')` to the list of files transpiled by Babel. This should make a lot of sense, but somehow `core-js` has [issues with adding polyfills to deps](https://github.com/babel/babel/issues/9419). ❌
1. Change `useBuiltIns: usage` to `useBuiltIns: entry` in Babel's config, so that it adds *every single stable polyfill from `core-js` to every file*. Works great, but greatly increases the bundle size (+13 KB), see https://github.com/nusmodifications/nusmods/pull/2741. ✅
1. Just import the polyfill directly. Works great! Minimal bundle size increase! (In fact, it decreased??) ✅ ✅ ✅
<img width="350" alt="Screenshot 2020-07-13 at 3 25 44 AM" src="https://user-images.githubusercontent.com/4933577/87255578-92909280-c4be-11ea-9329-83f6f88ade3b.png">

Tested on Edge 44.17763.1.0 (which is from donkey years ago).

## Other Information
Congrats to the 70 people who use Edge! 🥴 🤢 🤮 You can now use NUSMods again!

![image](https://user-images.githubusercontent.com/4933577/87255666-5c074780-c4bf-11ea-941a-2bc3fedd869d.png)

