### PR TITLE
Fix bug where new service worker cannot take over when importScripts fail

### DIFF
--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -69,9 +69,20 @@ self.addEventListener('message', (event) => {
   }
 });
 
-self.importScripts('https://browser.sentry-cdn.com/5.5.0/bundle.min.js');
-Sentry.init({ dsn: 'https://4b4fe71954424fd39ac88a4f889ffe20@sentry.io/213986' });
+/**
+ * Some adblockers will block access to Sentry's domains
+ * which will result in `importScripts` failing and crashing the new service worker.
+ * As this prevents the new service worker from taking over,
+ * we have to wrap everything below in a try/catch block.
+ */
+try {
+  self.importScripts('https://browser.sentry-cdn.com/5.5.0/bundle.min.js');
+  Sentry.init({ dsn: 'https://4b4fe71954424fd39ac88a4f889ffe20@sentry.io/213986' });
 
-self.addEventListener('error', (error) => {
-  Sentry.captureException(error);
-});
+  self.addEventListener('error', (error) => {
+    Sentry.captureException(error);
+  });
+} catch (error) {
+  // Ignore all errors produced here as they are uncapturable.
+  console.warn(error);
+}


### PR DESCRIPTION
## Context
Users are reporting seeing the old nusmods despite the new sw file which does not do any caching. 

## Implementation
We know that adblock is preventing Sentry from loading. This PR captures that error and makes sure the service worker doesn't crash because of that.

## Other Information
🧑‍⚕️
