### PR TITLE
Timetable start

### DIFF
--- a/website/src/utils/timify.test.ts
+++ b/website/src/utils/timify.test.ts
@@ -38,79 +38,110 @@ describe('convertTimeToIndex', () => {
 
 describe('calculateBorderTimings()', () => {
   test('calculate default border timings, with no start and end index preference, correctly', () => {
-    const timings = calculateBorderTimings([
-      createGenericLesson('Anyday', '1100', '1230'),
-      createGenericLesson('Anyday', '1330', '1400'),
-      createGenericLesson('Anyday', '1300', '1500'),
-    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
+    const timings = calculateBorderTimings(
+      [
+        createGenericLesson('Anyday', '1100', '1230'),
+        createGenericLesson('Anyday', '1330', '1400'),
+        createGenericLesson('Anyday', '1300', '1500'),
+      ],
+      convertTimeToIndex(DEFAULT_EARLIEST_TIME),
+      convertTimeToIndex(DEFAULT_LATEST_TIME),
+    );
     expect(timings.startingIndex).toBe(convertTimeToIndex(DEFAULT_EARLIEST_TIME));
     expect(timings.endingIndex).toBe(convertTimeToIndex(DEFAULT_LATEST_TIME));
   });
 
   test('calculate border timings, with no start and end index preference, correctly', () => {
-    const timings = calculateBorderTimings([
-      createGenericLesson('Anyday', '0800', '1230'),
-      createGenericLesson('Anyday', '1330', '1400'),
-      createGenericLesson('Anyday', '1300', '1500'),
-    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
+    const timings = calculateBorderTimings(
+      [
+        createGenericLesson('Anyday', '0800', '1230'),
+        createGenericLesson('Anyday', '1330', '1400'),
+        createGenericLesson('Anyday', '1300', '1500'),
+      ],
+      convertTimeToIndex(DEFAULT_EARLIEST_TIME),
+      convertTimeToIndex(DEFAULT_LATEST_TIME),
+    );
     expect(timings.startingIndex).toBe(convertTimeToIndex('0800'));
     expect(timings.endingIndex).toBe(convertTimeToIndex(DEFAULT_LATEST_TIME));
 
-    const timings2 = calculateBorderTimings([
-      createGenericLesson('Anyday', '1100', '1230'),
-      createGenericLesson('Anyday', '1330', '1400'),
-      createGenericLesson('Anyday', '2000', '2100'),
-    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
+    const timings2 = calculateBorderTimings(
+      [
+        createGenericLesson('Anyday', '1100', '1230'),
+        createGenericLesson('Anyday', '1330', '1400'),
+        createGenericLesson('Anyday', '2000', '2100'),
+      ],
+      convertTimeToIndex(DEFAULT_EARLIEST_TIME),
+      convertTimeToIndex(DEFAULT_LATEST_TIME),
+    );
     expect(timings2.startingIndex).toBe(convertTimeToIndex(DEFAULT_EARLIEST_TIME));
     expect(timings2.endingIndex).toBe(convertTimeToIndex('2100'));
   });
 
   test('calculate non-hour border timings, with no start and end index preference, correctly', () => {
-    const timings = calculateBorderTimings([
-      createGenericLesson('Anyday', '0830', '1230'),
-      createGenericLesson('Anyday', '1330', '1400'),
-      createGenericLesson('Anyday', '1300', '1500'),
-    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
+    const timings = calculateBorderTimings(
+      [
+        createGenericLesson('Anyday', '0830', '1230'),
+        createGenericLesson('Anyday', '1330', '1400'),
+        createGenericLesson('Anyday', '1300', '1500'),
+      ],
+      convertTimeToIndex(DEFAULT_EARLIEST_TIME),
+      convertTimeToIndex(DEFAULT_LATEST_TIME),
+    );
     expect(timings.startingIndex).toBe(convertTimeToIndex('0800'));
     expect(timings.endingIndex).toBe(convertTimeToIndex(DEFAULT_LATEST_TIME));
 
-    const timings2 = calculateBorderTimings([
-      createGenericLesson('Anyday', '1100', '1230'),
-      createGenericLesson('Anyday', '1330', '1400'),
-      createGenericLesson('Anyday', '2000', '2130'),
-    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
+    const timings2 = calculateBorderTimings(
+      [
+        createGenericLesson('Anyday', '1100', '1230'),
+        createGenericLesson('Anyday', '1330', '1400'),
+        createGenericLesson('Anyday', '2000', '2130'),
+      ],
+      convertTimeToIndex(DEFAULT_EARLIEST_TIME),
+      convertTimeToIndex(DEFAULT_LATEST_TIME),
+    );
     expect(timings2.startingIndex).toBe(convertTimeToIndex(DEFAULT_EARLIEST_TIME));
     expect(timings2.endingIndex).toBe(convertTimeToIndex('2200'));
 
-    const timings3 = calculateBorderTimings([
-      createGenericLesson('Anyday', '0630', '1230'),
-      createGenericLesson('Anyday', '1330', '1400'),
-      createGenericLesson('Anyday', '2000', '2230'),
-    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
+    const timings3 = calculateBorderTimings(
+      [
+        createGenericLesson('Anyday', '0630', '1230'),
+        createGenericLesson('Anyday', '1330', '1400'),
+        createGenericLesson('Anyday', '2000', '2230'),
+      ],
+      convertTimeToIndex(DEFAULT_EARLIEST_TIME),
+      convertTimeToIndex(DEFAULT_LATEST_TIME),
+    );
     expect(timings3.startingIndex).toBe(convertTimeToIndex('0600'));
     expect(timings3.endingIndex).toBe(convertTimeToIndex('2300'));
   });
 
   test('calculate non-hour border timings, with start and end index preference overidden, correctly', () => {
-    const timings = calculateBorderTimings([
-      createGenericLesson('Anyday', '0830', '1230'),
-      createGenericLesson('Anyday', '1330', '1400'),
-      createGenericLesson('Anyday', '1300', '1500'),
-    ], convertTimeToIndex('0900'), convertTimeToIndex('1400'));
+    const timings = calculateBorderTimings(
+      [
+        createGenericLesson('Anyday', '0830', '1230'),
+        createGenericLesson('Anyday', '1330', '1400'),
+        createGenericLesson('Anyday', '1300', '1500'),
+      ],
+      convertTimeToIndex('0900'),
+      convertTimeToIndex('1400'),
+    );
     expect(timings.startingIndex).toBe(convertTimeToIndex('0800'));
     expect(timings.endingIndex).toBe(convertTimeToIndex('1500'));
   });
 
   test('calculate non-hour border timings, with start and end index preference not overidden, correctly', () => {
-    const timings = calculateBorderTimings([
-      createGenericLesson('Anyday', '0830', '1230'),
-      createGenericLesson('Anyday', '1330', '1400'),
-      createGenericLesson('Anyday', '1300', '1500'),
-    ], convertTimeToIndex('0700'), convertTimeToIndex('1600'));
+    const timings = calculateBorderTimings(
+      [
+        createGenericLesson('Anyday', '0830', '1230'),
+        createGenericLesson('Anyday', '1330', '1400'),
+        createGenericLesson('Anyday', '1300', '1500'),
+      ],
+      convertTimeToIndex('0700'),
+      convertTimeToIndex('1600'),
+    );
     expect(timings.startingIndex).toBe(convertTimeToIndex('0700'));
     expect(timings.endingIndex).toBe(convertTimeToIndex('1600'));
   });
-
 });
 
 describe('formatHour()', () => {

--- a/website/src/utils/timify.test.ts
+++ b/website/src/utils/timify.test.ts
@@ -37,22 +37,22 @@ describe('convertTimeToIndex', () => {
 });
 
 describe('calculateBorderTimings()', () => {
-  test('calculate default border timings correctly', () => {
+  test('calculate default border timings, with no start and end index preference, correctly', () => {
     const timings = calculateBorderTimings([
       createGenericLesson('Anyday', '1100', '1230'),
       createGenericLesson('Anyday', '1330', '1400'),
       createGenericLesson('Anyday', '1300', '1500'),
-    ]);
+    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
     expect(timings.startingIndex).toBe(convertTimeToIndex(DEFAULT_EARLIEST_TIME));
     expect(timings.endingIndex).toBe(convertTimeToIndex(DEFAULT_LATEST_TIME));
   });
 
-  test('calculate border timings correctly', () => {
+  test('calculate border timings, with no start and end index preference, correctly', () => {
     const timings = calculateBorderTimings([
       createGenericLesson('Anyday', '0800', '1230'),
       createGenericLesson('Anyday', '1330', '1400'),
       createGenericLesson('Anyday', '1300', '1500'),
-    ]);
+    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
     expect(timings.startingIndex).toBe(convertTimeToIndex('0800'));
     expect(timings.endingIndex).toBe(convertTimeToIndex(DEFAULT_LATEST_TIME));
 
@@ -60,17 +60,17 @@ describe('calculateBorderTimings()', () => {
       createGenericLesson('Anyday', '1100', '1230'),
       createGenericLesson('Anyday', '1330', '1400'),
       createGenericLesson('Anyday', '2000', '2100'),
-    ]);
+    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
     expect(timings2.startingIndex).toBe(convertTimeToIndex(DEFAULT_EARLIEST_TIME));
     expect(timings2.endingIndex).toBe(convertTimeToIndex('2100'));
   });
 
-  test('calculate non-hour border timings correctly', () => {
+  test('calculate non-hour border timings, with no start and end index preference, correctly', () => {
     const timings = calculateBorderTimings([
       createGenericLesson('Anyday', '0830', '1230'),
       createGenericLesson('Anyday', '1330', '1400'),
       createGenericLesson('Anyday', '1300', '1500'),
-    ]);
+    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
     expect(timings.startingIndex).toBe(convertTimeToIndex('0800'));
     expect(timings.endingIndex).toBe(convertTimeToIndex(DEFAULT_LATEST_TIME));
 
@@ -78,7 +78,7 @@ describe('calculateBorderTimings()', () => {
       createGenericLesson('Anyday', '1100', '1230'),
       createGenericLesson('Anyday', '1330', '1400'),
       createGenericLesson('Anyday', '2000', '2130'),
-    ]);
+    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
     expect(timings2.startingIndex).toBe(convertTimeToIndex(DEFAULT_EARLIEST_TIME));
     expect(timings2.endingIndex).toBe(convertTimeToIndex('2200'));
 
@@ -86,10 +86,31 @@ describe('calculateBorderTimings()', () => {
       createGenericLesson('Anyday', '0630', '1230'),
       createGenericLesson('Anyday', '1330', '1400'),
       createGenericLesson('Anyday', '2000', '2230'),
-    ]);
+    ], convertTimeToIndex(DEFAULT_EARLIEST_TIME), convertTimeToIndex(DEFAULT_LATEST_TIME));
     expect(timings3.startingIndex).toBe(convertTimeToIndex('0600'));
     expect(timings3.endingIndex).toBe(convertTimeToIndex('2300'));
   });
+
+  test('calculate non-hour border timings, with start and end index preference overidden, correctly', () => {
+    const timings = calculateBorderTimings([
+      createGenericLesson('Anyday', '0830', '1230'),
+      createGenericLesson('Anyday', '1330', '1400'),
+      createGenericLesson('Anyday', '1300', '1500'),
+    ], convertTimeToIndex('0900'), convertTimeToIndex('1400'));
+    expect(timings.startingIndex).toBe(convertTimeToIndex('0800'));
+    expect(timings.endingIndex).toBe(convertTimeToIndex('1500'));
+  });
+
+  test('calculate non-hour border timings, with start and end index preference not overidden, correctly', () => {
+    const timings = calculateBorderTimings([
+      createGenericLesson('Anyday', '0830', '1230'),
+      createGenericLesson('Anyday', '1330', '1400'),
+      createGenericLesson('Anyday', '1300', '1500'),
+    ], convertTimeToIndex('0700'), convertTimeToIndex('1600'));
+    expect(timings.startingIndex).toBe(convertTimeToIndex('0700'));
+    expect(timings.endingIndex).toBe(convertTimeToIndex('1600'));
+  });
+
 });
 
 describe('formatHour()', () => {

--- a/website/src/utils/timify.ts
+++ b/website/src/utils/timify.ts
@@ -89,9 +89,11 @@ export const DEFAULT_LATEST_TIME: LessonTime = '1800';
 export function calculateBorderTimings(
   lessons: Lesson[],
   period?: TimePeriod,
+  startIndexPreference: number, 
+  endIndexPreference: number,
 ): { startingIndex: number; endingIndex: number } {
-  let earliestTime: number = convertTimeToIndex(DEFAULT_EARLIEST_TIME);
-  let latestTime: number = convertTimeToIndex(DEFAULT_LATEST_TIME);
+  let earliestTime: number = startIndexPreference;
+  let latestTime: number = endIndexPreference;
   lessons.forEach((lesson) => {
     earliestTime = Math.min(earliestTime, convertTimeToIndex(lesson.startTime));
     latestTime = Math.max(latestTime, convertTimeToIndex(lesson.endTime));

--- a/website/src/utils/timify.ts
+++ b/website/src/utils/timify.ts
@@ -88,9 +88,9 @@ export const DEFAULT_LATEST_TIME: LessonTime = '1800';
 // This bounds will then be used to decide the starting and ending hours of the timetable.
 export function calculateBorderTimings(
   lessons: Lesson[],
-  period?: TimePeriod,
   startIndexPreference: number, 
   endIndexPreference: number,
+  period?: TimePeriod,
 ): { startingIndex: number; endingIndex: number } {
   let earliestTime: number = startIndexPreference;
   let latestTime: number = endIndexPreference;

--- a/website/src/utils/timify.ts
+++ b/website/src/utils/timify.ts
@@ -88,7 +88,7 @@ export const DEFAULT_LATEST_TIME: LessonTime = '1800';
 // This bounds will then be used to decide the starting and ending hours of the timetable.
 export function calculateBorderTimings(
   lessons: Lesson[],
-  startIndexPreference: number, 
+  startIndexPreference: number,
   endIndexPreference: number,
   period?: TimePeriod,
 ): { startingIndex: number; endingIndex: number } {

--- a/website/src/views/timetable/Timetable.tsx
+++ b/website/src/views/timetable/Timetable.tsx
@@ -36,8 +36,8 @@ type Props = TimerData & {
 
 type State = {
   hoverLesson: HoverLesson | null;
-  earliestIndexPreference: number,
-  latestIndexPreference: number,
+  earliestIndexPreference: number;
+  latestIndexPreference: number;
 };
 
 const nullCurrentTimeIndicatorStyle: React.CSSProperties = {
@@ -60,24 +60,19 @@ class Timetable extends React.PureComponent<Props, State> {
     latestIndexPreference: convertTimeToIndex(DEFAULT_LATEST_TIME),
   };
 
-  componentDidMount() {
-    console.log(this.state.earliestIndexPreference);
-    console.log(this.state.latestIndexPreference);
-  }
-
   onCellHover = (hoverLesson: HoverLesson | null) => {
     this.setState({ hoverLesson });
   };
 
-  onChangeEarliestIndexPreference = (amount: number) => {    
+  onChangeEarliestIndexPreference = (amount: number) => {
     this.setState((prevState) => ({
-      earliestIndexPreference: prevState.earliestIndexPreference + (amount * 2)
+      earliestIndexPreference: prevState.earliestIndexPreference + amount * 2,
     }));
   };
 
   onChangeLatestIndexPreference = (amount: number) => {
     this.setState((prevState) => ({
-      latestIndexPreference: prevState.latestIndexPreference + (amount * 2),
+      latestIndexPreference: prevState.latestIndexPreference + amount * 2,
     }));
   };
 

--- a/website/src/views/timetable/Timetable.tsx
+++ b/website/src/views/timetable/Timetable.tsx
@@ -69,16 +69,13 @@ class Timetable extends React.PureComponent<Props, State> {
     this.setState({ hoverLesson });
   };
 
-  onChangeEarliestIndexPreference = (amount) => {
-    console.log(amount);
-    
+  onChangeEarliestIndexPreference = (amount: number) => {    
     this.setState((prevState) => ({
       earliestIndexPreference: prevState.earliestIndexPreference + (amount * 2)
     }));
   };
 
-  onChangeLatestIndexPreference = (amount) => {
-    console.log(amount);
+  onChangeLatestIndexPreference = (amount: number) => {
     this.setState((prevState) => ({
       latestIndexPreference: prevState.latestIndexPreference + (amount * 2),
     }));
@@ -86,13 +83,18 @@ class Timetable extends React.PureComponent<Props, State> {
 
   render() {
     const { highlightPeriod } = this.props;
-
     const schoolDays = SCHOOLDAYS.filter(
       (day) => day !== 'Saturday' || this.props.lessons.Saturday,
     );
 
     const lessons = flattenDeep<ColoredLesson>(values(this.props.lessons));
-    const { startingIndex, endingIndex } = calculateBorderTimings(lessons, highlightPeriod, this.state.earliestIndexPreference, this.state.latestIndexPreference);
+    const { startingIndex, endingIndex } = calculateBorderTimings(
+      lessons,
+      this.state.earliestIndexPreference,
+      this.state.latestIndexPreference,
+      highlightPeriod,
+    );
+
     const currentDayIndex = getDayIndex(); // Monday = 0, Friday = 4
 
     // Calculate the margin offset for the CurrentTimeIndicator

--- a/website/src/views/timetable/Timetable.tsx
+++ b/website/src/views/timetable/Timetable.tsx
@@ -6,6 +6,9 @@ import { ColoredLesson, HoverLesson, TimetableArrangement } from 'types/timetabl
 import { OnModifyCell } from 'types/views';
 
 import {
+  DEFAULT_EARLIEST_TIME,
+  DEFAULT_LATEST_TIME,
+  convertTimeToIndex,
   calculateBorderTimings,
   getCurrentHours,
   getCurrentMinutes,
@@ -33,6 +36,8 @@ type Props = TimerData & {
 
 type State = {
   hoverLesson: HoverLesson | null;
+  earliestIndexPreference: number,
+  latestIndexPreference: number,
 };
 
 const nullCurrentTimeIndicatorStyle: React.CSSProperties = {
@@ -51,10 +56,32 @@ class Timetable extends React.PureComponent<Props, State> {
 
   state = {
     hoverLesson: null,
+    earliestIndexPreference: convertTimeToIndex(DEFAULT_EARLIEST_TIME),
+    latestIndexPreference: convertTimeToIndex(DEFAULT_LATEST_TIME),
   };
+
+  componentDidMount() {
+    console.log(this.state.earliestIndexPreference);
+    console.log(this.state.latestIndexPreference);
+  }
 
   onCellHover = (hoverLesson: HoverLesson | null) => {
     this.setState({ hoverLesson });
+  };
+
+  onChangeEarliestIndexPreference = (amount) => {
+    console.log(amount);
+    
+    this.setState((prevState) => ({
+      earliestIndexPreference: prevState.earliestIndexPreference + (amount * 2)
+    }));
+  };
+
+  onChangeLatestIndexPreference = (amount) => {
+    console.log(amount);
+    this.setState((prevState) => ({
+      latestIndexPreference: prevState.latestIndexPreference + (amount * 2),
+    }));
   };
 
   render() {
@@ -65,7 +92,7 @@ class Timetable extends React.PureComponent<Props, State> {
     );
 
     const lessons = flattenDeep<ColoredLesson>(values(this.props.lessons));
-    const { startingIndex, endingIndex } = calculateBorderTimings(lessons, highlightPeriod);
+    const { startingIndex, endingIndex } = calculateBorderTimings(lessons, highlightPeriod, this.state.earliestIndexPreference, this.state.latestIndexPreference);
     const currentDayIndex = getDayIndex(); // Monday = 0, Friday = 4
 
     // Calculate the margin offset for the CurrentTimeIndicator
@@ -84,7 +111,12 @@ class Timetable extends React.PureComponent<Props, State> {
     return (
       <div>
         <div className={classnames(styles.container, elements.timetable)}>
-          <TimetableTimings startingIndex={startingIndex} endingIndex={endingIndex} />
+          <TimetableTimings
+            startingIndex={startingIndex}
+            endingIndex={endingIndex}
+            onChangeEarliestIndexPreference={this.onChangeEarliestIndexPreference}
+            onChangeLatestIndexPreference={this.onChangeLatestIndexPreference}
+          />
           <ol className={styles.days}>
             {schoolDays.map((day, index) => (
               <TimetableDay

--- a/website/src/views/timetable/TimetableTimings.scss
+++ b/website/src/views/timetable/TimetableTimings.scss
@@ -29,25 +29,39 @@
   }
 }
 
+.relative{
+    position:relative;
+}
+
 .buttonLeft {
-  float: left;
-  z-index: -1;
   margin-top: -5px;
+  position: absolute;
+  left: 0;
+  top: 0;
   border: 0;
+  padding: 0;
   @include media-breakpoint-down(sm) {
     display:none;
   }
 }
 
 .buttonRight {
-  float: right;
-  z-index: -1;
-  margin-left: -40px;
-  margin-top: -25px;
+  margin-top: -5px;
+  position: absolute;
+  right: 0%;
+  top: 0;
   border: 0;
+  padding: 0;
   @include media-breakpoint-down(sm) {
     display:none;
   }
+}
+
+.svg {
+  display: inline-block;
+  width: 1.1rem;
+  margin-left: -5px;
+  border: 0;
 }
 
 .time {

--- a/website/src/views/timetable/TimetableTimings.scss
+++ b/website/src/views/timetable/TimetableTimings.scss
@@ -29,6 +29,27 @@
   }
 }
 
+.buttonLeft {
+  float: left;
+  z-index: -1;
+  margin-top: -5px;
+  border: 0;
+  @include media-breakpoint-down(sm) {
+    display:none;
+  }
+}
+
+.buttonRight {
+  float: right;
+  z-index: -1;
+  margin-left: -40px;
+  margin-top: -25px;
+  border: 0;
+  @include media-breakpoint-down(sm) {
+    display:none;
+  }
+}
+
 .time {
   transform: translateX(-50%);
 

--- a/website/src/views/timetable/TimetableTimings.scss
+++ b/website/src/views/timetable/TimetableTimings.scss
@@ -30,28 +30,28 @@
 }
 
 .relative{
-    position:relative;
+  position:relative;
 }
 
 .buttonLeft {
-  margin-top: -5px;
   position: absolute;
-  left: 0;
   top: 0;
-  border: 0;
+  left: 0;
   padding: 0;
+  margin-top: -5px;
+  border: 0;
   @include media-breakpoint-down(sm) {
     display:none;
   }
 }
 
 .buttonRight {
-  margin-top: -5px;
   position: absolute;
-  right: 0%;
   top: 0;
-  border: 0;
+  right: 0%;
   padding: 0;
+  margin-top: -5px;
+  border: 0;
   @include media-breakpoint-down(sm) {
     display:none;
   }

--- a/website/src/views/timetable/TimetableTimings.tsx
+++ b/website/src/views/timetable/TimetableTimings.tsx
@@ -16,14 +16,15 @@ const TimetableTimings: React.FC<Props> = (props) => {
   const indices = range(props.startingIndex, props.endingIndex);
 
   return (
-    <div>
-      <button
-        className={classnames('btn btn-inline', styles.buttonLeft)}
-        type="button"
-        aria-label="Previous Hours"
-      >
-        <ChevronLeft />
-      </button>
+    <div className={styles.relative}>
+      <div className={styles.buttonLeft}>
+        <button className={classnames('btn btn-inline')} type="button" aria-label="Previous Hours">
+          <ChevronLeft className={styles.svg} />
+        </button>
+        <button className={classnames('btn btn-inline')} type="button" aria-label="Previous Hours">
+          <ChevronRight className={styles.svg} />
+        </button>
+      </div>
       <div className={styles.timings}>
         {indices.map((i) => {
           const time = convertIndexToTime(i);
@@ -39,13 +40,14 @@ const TimetableTimings: React.FC<Props> = (props) => {
         })}
         <span />
       </div>
-      <button
-        className={classnames('btn btn-inline', styles.buttonRight)}
-        type="button"
-        aria-label="Previous Hours"
-      >
-        <ChevronRight />
-      </button>
+      <div className={styles.buttonRight}>
+        <button className={classnames('btn btn-inline')} type="button" aria-label="Previous Hours">
+          <ChevronLeft className={styles.svg} />
+        </button>
+        <button className={classnames('btn btn-inline')} type="button" aria-label="Previous Hours">
+          <ChevronRight className={styles.svg} />
+        </button>
+      </div>
     </div>
   );
 };

--- a/website/src/views/timetable/TimetableTimings.tsx
+++ b/website/src/views/timetable/TimetableTimings.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { range } from 'lodash';
+import classnames from 'classnames';
+
+import { ChevronLeft, ChevronRight } from 'react-feather';
 
 import { convertIndexToTime } from 'utils/timify';
 import styles from './TimetableTimings.scss';
@@ -13,20 +16,36 @@ const TimetableTimings: React.FC<Props> = (props) => {
   const indices = range(props.startingIndex, props.endingIndex);
 
   return (
-    <div className={styles.timings}>
-      {indices.map((i) => {
-        const time = convertIndexToTime(i);
+    <div>
+      <button
+        className={classnames('btn btn-inline', styles.buttonLeft)}
+        type="button"
+        aria-label="Previous Hours"
+      >
+        <ChevronLeft />
+      </button>
+      <div className={styles.timings}>
+        {indices.map((i) => {
+          const time = convertIndexToTime(i);
 
-        // Only mark even ticks
-        if (i % 2 === 1) return null;
+          // Only mark even ticks
+          if (i % 2 === 1) return null;
 
-        return (
-          <time key={time} className={styles.time}>
-            {time}
-          </time>
-        );
-      })}
-      <span />
+          return (
+            <time key={time} className={styles.time}>
+              {time}
+            </time>
+          );
+        })}
+        <span />
+      </div>
+      <button
+        className={classnames('btn btn-inline', styles.buttonRight)}
+        type="button"
+        aria-label="Previous Hours"
+      >
+        <ChevronRight />
+      </button>
     </div>
   );
 };

--- a/website/src/views/timetable/TimetableTimings.tsx
+++ b/website/src/views/timetable/TimetableTimings.tsx
@@ -24,6 +24,7 @@ const TimetableTimings: React.FC<Props> = (props) => {
           className={classnames('btn btn-inline')}
           type="button"
           aria-label="Previous Start Hour"
+          disabled={props.startingIndex <= 12}
           onClick={() => props.onChangeEarliestIndexPreference(-1)}
         >
           <ChevronLeft className={styles.svg} />
@@ -31,7 +32,8 @@ const TimetableTimings: React.FC<Props> = (props) => {
         <button
           className={classnames('btn btn-inline')}
           type="button"
-          aria-label="Previous Start Hour"
+          aria-label="Next Start Hour"
+          disabled={props.endingIndex - props.startingIndex <= 4}
           onClick={() => props.onChangeEarliestIndexPreference(1)}
         >
           <ChevronRight className={styles.svg} />
@@ -57,6 +59,7 @@ const TimetableTimings: React.FC<Props> = (props) => {
           className={classnames('btn btn-inline')}
           type="button"
           aria-label="Previous End Hour"
+          disabled={props.endingIndex - props.startingIndex <= 4}
           onClick={() => props.onChangeLatestIndexPreference(-1)}
         >
           <ChevronLeft className={styles.svg} />
@@ -65,7 +68,8 @@ const TimetableTimings: React.FC<Props> = (props) => {
           className={classnames('btn btn-inline')}
           type="button"
           aria-label="Next End Hour"
-          onClick={() => props.onChangeLatestIndexPreference(-1)}
+          disabled={props.endingIndex >= 48}
+          onClick={() => props.onChangeLatestIndexPreference(1)}
         >
           <ChevronRight className={styles.svg} />
         </button>

--- a/website/src/views/timetable/TimetableTimings.tsx
+++ b/website/src/views/timetable/TimetableTimings.tsx
@@ -10,6 +10,8 @@ import styles from './TimetableTimings.scss';
 type Props = {
   startingIndex: number;
   endingIndex: number;
+  onChangeEarliestIndexPreference: (amount: number) => void;
+  onChangeLatestIndexPreference: (amount: number) => void;
 };
 
 const TimetableTimings: React.FC<Props> = (props) => {
@@ -18,10 +20,20 @@ const TimetableTimings: React.FC<Props> = (props) => {
   return (
     <div className={styles.relative}>
       <div className={styles.buttonLeft}>
-        <button className={classnames('btn btn-inline')} type="button" aria-label="Previous Hours">
+        <button
+          className={classnames('btn btn-inline')}
+          type="button"
+          aria-label="Previous Start Hour"
+          onClick={() => props.onChangeEarliestIndexPreference(-1)}
+        >
           <ChevronLeft className={styles.svg} />
         </button>
-        <button className={classnames('btn btn-inline')} type="button" aria-label="Previous Hours">
+        <button
+          className={classnames('btn btn-inline')}
+          type="button"
+          aria-label="Previous Start Hour"
+          onClick={() => props.onChangeEarliestIndexPreference(1)}
+        >
           <ChevronRight className={styles.svg} />
         </button>
       </div>
@@ -41,10 +53,20 @@ const TimetableTimings: React.FC<Props> = (props) => {
         <span />
       </div>
       <div className={styles.buttonRight}>
-        <button className={classnames('btn btn-inline')} type="button" aria-label="Previous Hours">
+        <button
+          className={classnames('btn btn-inline')}
+          type="button"
+          aria-label="Previous End Hour"
+          onClick={() => props.onChangeLatestIndexPreference(-1)}
+        >
           <ChevronLeft className={styles.svg} />
         </button>
-        <button className={classnames('btn btn-inline')} type="button" aria-label="Previous Hours">
+        <button
+          className={classnames('btn btn-inline')}
+          type="button"
+          aria-label="Next End Hour"
+          onClick={() => props.onChangeLatestIndexPreference(-1)}
+        >
           <ChevronRight className={styles.svg} />
         </button>
       </div>


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
#2750 
There is a feature request to make the timetable have an adjustable starting time.
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

## Implementation
I added two buttons on each side of the start and end time of the timetable, where people can click and adjust their own starting and ending time of their timetable. 

<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
![demo feature timetable start](https://user-images.githubusercontent.com/44172431/89752086-799eef80-db05-11ea-9299-546b5b8d6bda.gif)
