### PR TITLE
Save e-learning venues as E-Learning in scraper

### DIFF
--- a/scrapers/nus-v2/src/tasks/GetSemesterTimetable.test.ts
+++ b/scrapers/nus-v2/src/tasks/GetSemesterTimetable.test.ts
@@ -1613,4 +1613,115 @@ Object {
 }
 `);
   });
+
+  // Lessons with E-Learn_* in venue should have E-Learning as venue
+  test('should save venue of lessons with E-Learning venues correctly', async () => {
+    const task = createTask(
+      CS4238Timetable.map((lesson) => {
+        return { ...lesson, room: 'E-Learn_C' };
+      }),
+    );
+    const timetable = await task.run();
+
+    expect(timetable.CS4238).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "classNo": "1",
+    "day": "Monday",
+    "endTime": "2030",
+    "lessonType": "Lecture",
+    "size": 40,
+    "startTime": "1830",
+    "venue": "E-Learning",
+    "weeks": Array [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+    ],
+  },
+  Object {
+    "classNo": "2",
+    "day": "Tuesday",
+    "endTime": "2030",
+    "lessonType": "Lecture",
+    "size": 40,
+    "startTime": "1830",
+    "venue": "E-Learning",
+    "weeks": Array [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+    ],
+  },
+  Object {
+    "classNo": "2",
+    "day": "Tuesday",
+    "endTime": "2130",
+    "lessonType": "Laboratory",
+    "size": 40,
+    "startTime": "2030",
+    "venue": "E-Learning",
+    "weeks": Array [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+    ],
+  },
+  Object {
+    "classNo": "1",
+    "day": "Monday",
+    "endTime": "2130",
+    "lessonType": "Laboratory",
+    "size": 40,
+    "startTime": "2030",
+    "venue": "E-Learning",
+    "weeks": Array [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+    ],
+  },
+]
+`);
+  });
 });

--- a/scrapers/nus-v2/src/tasks/GetSemesterTimetable.ts
+++ b/scrapers/nus-v2/src/tasks/GetSemesterTimetable.ts
@@ -111,7 +111,20 @@ export function transformModgrpToClassNo(modgrp: string, activity: string): stri
 }
 
 export function mapTimetableLesson(lesson: TimetableLesson, logger: Logger): TempRawLesson {
-  const { room, start_time, end_time, day, module, modgrp, activity, eventdate, csize } = lesson;
+  const {
+    room: providedRoom,
+    start_time,
+    end_time,
+    day,
+    module,
+    modgrp,
+    activity,
+    eventdate,
+    csize,
+  } = lesson;
+
+  // Save E-Learn_* venues as E-Learning
+  const room = providedRoom?.startsWith('E-Learn_') ? 'E-Learning' : providedRoom;
 
   if (has(unrecognizedLessonTypes, activity)) {
     logger.warn(

--- a/scrapers/nus-v2/tsconfig.json
+++ b/scrapers/nus-v2/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "outDir": "build",
-    "target": "es2020",
+    "target": "es2018",
+    "lib": ["es2020", "dom"],
     "module": "commonjs",
     "baseUrl": "./src",
     "resolveJsonModule": true,

--- a/scrapers/nus-v2/tsconfig.json
+++ b/scrapers/nus-v2/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "build",
     "target": "es2018",
-    "lib": ["es2020", "dom"],
+    "lib": ["dom", "es2020"],
     "module": "commonjs",
     "baseUrl": "./src",
     "resolveJsonModule": true,


### PR DESCRIPTION
Follow up of https://github.com/nusmodifications/nusmods/pull/2736.

This PR changes the scraper to save lesson venues as "E-Learning" when the API returns a `room` of `E-Learn_*` for lessons.

To see current shaped of our scraped data: https://nusmods.com/api/v2/2020-2021/modules/CS1010.json

@ZhangYiJiang does this look right to you? Also would need some help to test this, if possible. 😅

Also, don't merge this yet. Still need to add the frontend changes.