### PR TITLE
Fix typo in FAQ

### DIFF
--- a/website/src/views/static/FaqContainer.tsx
+++ b/website/src/views/static/FaqContainer.tsx
@@ -92,7 +92,7 @@ const FaqContainer: React.FC = () => (
         students.
       </p>
       <p>
-        If you think the error is caused by a bug in NUSMods itself, please report it
+        If you think the error is caused by a bug in NUSMods itself, please report it{' '}
         <ExternalLink href="https://github.com/nusmodifications/nusmods/issues/new?template=Bug_report.md">
           using GitHub
         </ExternalLink>{' '}


### PR DESCRIPTION
## Context
Add space before `using Github` link
![Screenshot 2020-08-18 at 12 31 38 AM](https://user-images.githubusercontent.com/42177597/90420187-338bf200-e0ea-11ea-9671-1279bb50a797.png)
