### PR TITLE
Module finder: Fix UI search total and pagination on Elasticsearch 7

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -173,7 +173,7 @@
     "redux-persist": "6.0.0",
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
-    "searchkit": "2.4.1"
+    "searchkit": "2.4.1-alpha.5"
   },
   "browserslist": [
     "extends browserslist-config-nusmods"

--- a/website/src/views/components/searchkit/Pagination.tsx
+++ b/website/src/views/components/searchkit/Pagination.tsx
@@ -35,9 +35,7 @@ export default class Pagination extends SearchkitComponent<PaginationProps, {}> 
   }
 
   getTotalPages() {
-    return Math.ceil(
-      get(this.getResults(), 'hits.total', 1) / get(this.getQuery(), 'query.size', 10),
-    );
+    return Math.ceil(this.getHitsCount() / get(this.getQuery(), 'query.size', 10));
   }
 
   onGoToFirst = () => this.setPage(FIRST_PAGE_INDEX);

--- a/website/src/views/modules/ModuleFinderContainer/ModuleFinderContainer.tsx
+++ b/website/src/views/modules/ModuleFinderContainer/ModuleFinderContainer.tsx
@@ -31,7 +31,10 @@ import config from 'config';
 import styles from './ModuleFinderContainer.scss';
 
 const esHostUrl = `${forceElasticsearchHost() || config.elasticsearchBaseUrl}/modules`;
-const searchkit = new SearchkitManager(esHostUrl);
+const searchkit = new SearchkitManager(esHostUrl, {
+  // Ensure displayed no. modules found is accurate.
+  searchUrlPath: '_search?track_total_hits=true',
+});
 
 const pageHead = <Title>Modules</Title>;
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -13952,10 +13952,10 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
-searchkit@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/searchkit/-/searchkit-2.4.1.tgz#1c67bace9564985aa1c0d7ff1fc04d032fea65a4"
-  integrity sha512-K/oDM5SXCT7oVfciBoZgsy3UcQ3KmZ1XH8b7nVzQ/LRRj3eyx7Qd2hj4UEgoiVAdZe47iF1fqT4nxjalSkSfcQ==
+searchkit@2.4.1-alpha.5:
+  version "2.4.1-alpha.5"
+  resolved "https://registry.yarnpkg.com/searchkit/-/searchkit-2.4.1-alpha.5.tgz#e2ca37b6bc227dbcbeaf055d8506210b4b4f9351"
+  integrity sha512-IhNwdLH3OW4hsDi2bpm4oPvjmIT7DuLjmm4M6G7TlHpEDApjS+74by6pEFPxS2hLQCRJbR1/IeJAcl1KHk1/KA==
   dependencies:
     "@types/history" "^4.6.0"
     "@types/lodash" "^4.14.77"


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

#2915 adds scraper support for Elasticsearch 7. This PR fixes website to add support for ES 7 while retaining ES 6 support. Unblocks testing and merging of #2784.

## Test plan

Tested with Elasticsearch 7:

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/12784593/96392914-18c02180-11f0-11eb-8a50-f9c2fbbbdb42.png)|![image](https://user-images.githubusercontent.com/12784593/96392918-1eb60280-11f0-11eb-9916-8cbe4346fe46.png)|
|![image](https://user-images.githubusercontent.com/12784593/96392929-2675a700-11f0-11eb-9091-fb1b095473ef.png)|![image](https://user-images.githubusercontent.com/12784593/96392936-2b3a5b00-11f0-11eb-8a1d-c50b1c37bb03.png)|

Tested with production ES server (ES 6.8.1):

![image](https://user-images.githubusercontent.com/12784593/96393009-78b6c800-11f0-11eb-84b9-cfa6ff92dfed.png)

## Deployment plan (updated from #2915)

1. Merge this PR.
1. Deploy Dockerized services (to deploy new website with ES 7 support).
1. Upgrade Elasticsearch.
1. Upgrade scraper.