### PR TITLE
Fix vertical timetable cell layout

### DIFF
--- a/website/src/views/timetable/TimetableCell.scss
+++ b/website/src/views/timetable/TimetableCell.scss
@@ -21,6 +21,11 @@ $cell-border-radius: 6px;
   &:focus {
     outline: none;
   }
+
+  @include vertical-mode {
+    position: absolute;
+    width: 100%;
+  }
 }
 
 .coloredCell {


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

Fixes #2920 by adding back CSS styles for vertical mode. Thanks @JingYenLoh for reporting it!

## Test Plan
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->

Vertical

|`master`|This PR|
|-|-|
|![image](https://user-images.githubusercontent.com/12784593/96538545-59d93400-12cb-11eb-9621-fbb08a4f7e62.png)|![image](https://user-images.githubusercontent.com/12784593/96538503-3e6e2900-12cb-11eb-9259-4ae7ef3c8a7d.png)|

Horizontal (unchanged)

![image](https://user-images.githubusercontent.com/12784593/96538511-44640a00-12cb-11eb-91f5-bc33dd07febc.png)
