### PR TITLE
Attempt to fix intermittent ModTris test failure caused by Immer upgrade

### DIFF
--- a/website/src/views/tetris/board.ts
+++ b/website/src/views/tetris/board.ts
@@ -200,7 +200,7 @@ export function placePieceOnBoard(board: Board, ...pieces: Piece[]): Board {
   return produce(board, (draft) => {
     pieces.forEach((piece) => {
       iteratePiece(piece, (tile: Square, col: number, row: number) => {
-        draft[col][row] = tile;
+        draft[col][row] = { ...tile };
       });
     });
   });


### PR DESCRIPTION
CI on master and in many of our PRs are failing due to an intermittently failing integration test. Seems to have been caused by #2925.

[This line (in a recent Immer PR)](https://github.com/immerjs/immer/commit/c0e6749e8df3e20d880d61b726b1395167ba2088?diff=unified#diff-fd10ff16a0a07d7e9da7d8a20028d729e977c84bc5404b3dd9ba19a414c5eeccR150) is crashing, but I don't see how this is leading to our intermittent test failure.

Although I'm not sure if this PR fixes it, this PR passed 10 `yarn test:integration` runs, so there's a good chance that it has? If anyone can figure this out it'll be great as it's blocking the other PRs.