### PR TITLE
Fix ical export regression after webpack 5 update

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -142,7 +142,7 @@
     "core-js": "3.8.1",
     "date-fns": "2.16.1",
     "downshift": "6.0.6",
-    "ical-generator": "https://github.com/chrisgzf/ical-generator.git#8fa2fc0e",
+    "ical-generator": "https://github.com/nusmodifications/ical-generator.git#a2aa62ed",
     "immer": "8.0.0",
     "json2mq": "0.2.0",
     "leaflet": "1.7.1",

--- a/website/package.json
+++ b/website/package.json
@@ -142,7 +142,7 @@
     "core-js": "3.8.1",
     "date-fns": "2.16.1",
     "downshift": "6.0.6",
-    "ical-generator": "https://github.com/ZhangYiJiang/ical-generator.git#ed6928fe",
+    "ical-generator": "https://github.com/chrisgzf/ical-generator.git#8fa2fc0e",
     "immer": "8.0.0",
     "json2mq": "0.2.0",
     "leaflet": "1.7.1",

--- a/website/webpack/webpack.config.common.js
+++ b/website/webpack/webpack.config.common.js
@@ -24,13 +24,6 @@ const commonConfig = {
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
     // We don't use symlinks, so disable for performance
     symlinks: false,
-    // ical-generator imports Node.js core modules, which don't exist in a
-    // browser environment. Tell Webpack to provide empty modules for them so
-    // importing them works.
-    fallback: {
-      fs: false,
-      os: false,
-    },
   },
 
   context: parts.PATHS.src,

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7845,9 +7845,9 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-"ical-generator@https://github.com/chrisgzf/ical-generator.git#8fa2fc0e":
+"ical-generator@https://github.com/nusmodifications/ical-generator.git#a2aa62ed":
   version "0.2.10"
-  resolved "https://github.com/chrisgzf/ical-generator.git#8fa2fc0e7495de6bf08c66d922fea24028697c07"
+  resolved "https://github.com/nusmodifications/ical-generator.git#a2aa62ed82a7c947b3f02172ac2c8ed5a9e32eb8"
 
 icalendar@0.7.1:
   version "0.7.1"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7845,9 +7845,9 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-"ical-generator@https://github.com/ZhangYiJiang/ical-generator.git#ed6928fe":
+"ical-generator@https://github.com/chrisgzf/ical-generator.git#8fa2fc0e":
   version "0.2.10"
-  resolved "https://github.com/ZhangYiJiang/ical-generator.git#ed6928fecce6789db4d99f856413074de7eb5a1e"
+  resolved "https://github.com/chrisgzf/ical-generator.git#8fa2fc0e7495de6bf08c66d922fea24028697c07"
 
 icalendar@0.7.1:
   version "0.7.1"


### PR DESCRIPTION
Closes https://github.com/nusmodifications/nusmods/issues/3036

## Context
https://github.com/nusmodifications/nusmods/pull/2933 seems to have broken the package we used for exporting iCal files. The package we used was frozen at a 2018-ish version from @ZhangYiJiang's fork (PR #779), to fix some macOS iCal bugs. That version of the package made use of some nodejs-specific libraries (`os` and `fs`), which were polyfilled by webpack 4. Webpack 5 no longer provides nodejs polyfills automatically, which broke that library.

## Implementation

EDIT: scrap everything below. the updated package fixes the issue but it includes `moment-timezone` (a huge package) into our bundle. the alternate fix here is to remove all nodejs package calls in our fork of `ical-generator`. which is done at https://github.com/nusmodifications/ical-generator/commit/a2aa62ed82a7c947b3f02172ac2c8ed5a9e32eb8,  and then use that updated package in nusmods

Update `ical-generator` package to latest stable version, and then manually test for regression.

After updating, ical export works and the download is started.

The generated ical file that I tested came up with this timetable:
![image](https://user-images.githubusercontent.com/4933577/101484440-999bce00-3994-11eb-88bd-3882286965a8.png)

for this timetable:
![image](https://user-images.githubusercontent.com/4933577/101484139-22663a00-3994-11eb-95e9-a5dca746dc83.png)

which is correct. Each timetable entry also contains its associated metadata (location, tutorial group number, etc.)

I also exported my sem1 timetable from the last build that had a working iCal export, and exported it again after the new library was added to compare the generated iCal files.

The diff is here: https://gist.github.com/chrisgzf/87524d8f729295827991a8d5a724de8c

tldr: no functional difference, new library's generated files are more concise and smaller