### PR TITLE
Fix uncaught promise rejection in actions/moduleBank.test.ts

### DIFF
--- a/website/src/actions/moduleBank.test.ts
+++ b/website/src/actions/moduleBank.test.ts
@@ -57,13 +57,11 @@ describe(actions.fetchModule, () => {
     const thunk = actions.fetchModule('CS1010S');
 
     const error = new Error('ModuleBank Test: Error loading module');
-    const dispatch = jest.fn().mockRejectedValue(error);
+    const dispatch = jest.fn().mockRejectedValueOnce(error);
     const getState = jest.fn().mockReturnValue({
       moduleBank: { modules: { CS1010S: {} } },
     } as any);
 
-    // This line causes an uncaught promise exception, even though it should
-    // be caught. Not sure why.
     await expect(thunk(dispatch, getState)).rejects.toThrowError(error);
   });
 });


### PR DESCRIPTION
Cause: the action's promise rejection handler calls `onFinally`, which
calls `dispatch` twice, both times expecting `dispatch` to be a standard
Redux dispatch function that returns immediately (they're plain Redux
actions). However, `dispatch` has been mocked to return a promise that
rejects. Because `onFinally` (rightly) does not `await` on those
`dispatch` calls, the errors are not caught.

Solution: change the mock `dispatch` to only reject once, simulating a
failure to fetch the module. Subsequent calls to `dispatch` will then be
synchronous and succeed, which is what we'll expect when `onFinally`
dispatches those plain Redux actions in prod.