### PR TITLE
Rounder Add to Semester button

### DIFF
--- a/website/src/views/components/module-info/AddModuleDropdown.tsx
+++ b/website/src/views/components/module-info/AddModuleDropdown.tsx
@@ -120,34 +120,39 @@ export class AddModuleDropdownComponent extends PureComponent<Props, State> {
               </button>
 
               {!!otherSemesters.length && (
-                <button
-                  id={id}
-                  type="button"
-                  className="btn btn-outline-primary dropdown-toggle dropdown-toggle-split"
-                  onClick={() => toggleMenu()}
-                  data-toggle="dropdown"
-                  aria-haspopup="true"
-                  aria-expanded={isOpen}
-                >
-                  <span className="sr-only">Toggle Dropdown</span>
-                </button>
-              )}
-
-              <div className={classnames('dropdown-menu', { show: isOpen })} {...getMenuProps()}>
-                {otherSemesters.map((semester, index) => (
+                <>
                   <button
-                    {...getItemProps({ item: semester })}
+                    id={id}
                     type="button"
-                    key={semester}
-                    className={classnames('dropdown-item', styles.dropdownItem, {
-                      'dropdown-selected': index === highlightedIndex,
-                    })}
-                    onClick={() => this.onSelect(semester)}
+                    className="btn btn-outline-primary dropdown-toggle dropdown-toggle-split"
+                    onClick={() => toggleMenu()}
+                    data-toggle="dropdown"
+                    aria-haspopup="true"
+                    aria-expanded={isOpen}
                   >
-                    {this.buttonLabel(semester)}
+                    <span className="sr-only">Toggle Dropdown</span>
                   </button>
-                ))}
-              </div>
+
+                  <div
+                    className={classnames('dropdown-menu', { show: isOpen })}
+                    {...getMenuProps()}
+                  >
+                    {otherSemesters.map((semester, index) => (
+                      <button
+                        {...getItemProps({ item: semester })}
+                        type="button"
+                        key={semester}
+                        className={classnames('dropdown-item', styles.dropdownItem, {
+                          'dropdown-selected': index === highlightedIndex,
+                        })}
+                        onClick={() => this.onSelect(semester)}
+                      >
+                        {this.buttonLabel(semester)}
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
(This is a trivial visual change, feel free to ignore)

I was getting a little annoyed by half-round half sharp corners... so I made them totally round when there's only one semester.

Before
![image](https://user-images.githubusercontent.com/31354724/103241967-b2921080-498f-11eb-84d3-0f05f32ae07b.png)
After
![image](https://user-images.githubusercontent.com/31354724/103241898-81194500-498f-11eb-92ef-a95c21bb0d2a.png)
More than one sem: unchanged
![image](https://user-images.githubusercontent.com/31354724/103242053-f9800600-498f-11eb-8c80-7c70997ce517.png)

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
The "Add to default Semester" button had sharp corners because it wasn't the last child in the button group. It wasn't the last child because of the dropdown buttons ("Add to other Semester") which appear when there's more than 1 semester. So I simply moved that logic into the `{!!otherSemesters.length ... }` block too.

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
