### PR TITLE
Update CircleCI config to version 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           path: README.md
 
   export:
-    <<: *defaults
+    executor: node-executor
     working_directory: ~/nusmods/export
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,13 @@
-version: 2
+version: 2.1
 
-defaults: &defaults
-  docker:
-    - image: circleci/node:12
+executors:
+  node-executor:
+    docker:
+      - image: circleci/node:12
 
 jobs:
   checkout:
-    <<: *defaults
+    executor: node-executor
     working_directory: ~/nusmods
     steps:
       - checkout
@@ -17,7 +18,7 @@ jobs:
             - .
 
   nus-scrapers:
-    <<: *defaults
+    executor: node-executor
     working_directory: ~/nusmods/scrapers/nus-v2
     steps:
       - attach_workspace:
@@ -32,7 +33,7 @@ jobs:
           command: yarn build
 
   nusmoderator:
-    <<: *defaults
+    executor: node-executor
     working_directory: ~/nusmods/packages/nusmoderator
     steps:
       - attach_workspace:
@@ -48,7 +49,7 @@ jobs:
           path: README.md
 
   website:
-    <<: *defaults
+    executor: node-executor
     working_directory: ~/nusmods/website
     environment:
       NODE_ENV: production
@@ -86,7 +87,7 @@ jobs:
             set -e
             yarn test:integration --runInBand
       - run:
-          name: Build web page
+          name: Build
           command: yarn build
       - store_test_results:
           path: reports/junit
@@ -94,7 +95,6 @@ jobs:
           path: dist
 
 workflows:
-  version: 2
   build_and_test:
     jobs:
       - checkout


### PR DESCRIPTION
Spun out of #3092 as it'll get messier.

1. Use new executors key.

2. Also: "workflows no longer have a version number. Make sure to take
   the version key out of your workflows section or bad things will
   happen. The only version key in 2.1 is the top-level key."
   -- discuss.circleci.com/t/circleci-2-1-config-overview/26057

No change in functionality.