### PR TITLE
Point /website timetable export button to Vercel serverless function

### DIFF
--- a/export/.env.example
+++ b/export/.env.example
@@ -1,6 +1,6 @@
 # For explanation about these values, refer to config.js
 # ACADEMIC_YEAR=2020-2021
-PAGE=http://localhost:8081
+PAGE=https://nusmods.vercel.app/timetable-only
 SENTRY_DSN=https://37215374a3fd42a198c7b144c8886335@sentry.io/265295
 # CHROME_EXECUTABLE=
 # MODULE_DATA=

--- a/website/src/apis/export.ts
+++ b/website/src/apis/export.ts
@@ -9,7 +9,7 @@ export type ExportOptions = {
   pixelRatio?: number;
 };
 
-const baseUrl = '/export';
+const baseUrl = 'https://export.nusmods.com/api/export';
 
 function serializeState(
   semester: Semester,


### PR DESCRIPTION
#3098.

1. The export buttons on /website now always work, because they use the export service running in prod :D
1. This allows the export server to operate independently of a local instance of /website.

URLs in the exported timetables point to a very long Vercel URL, but that's because the `PAGE` env var in prod isn't pointing to `nusmods.com` yet.

This is the last step before we can point nusmods.com to Vercel. We'll probably want to do a thorough test now :)