### PR TITLE
Add subject to NBSP errors

### DIFF
--- a/scrapers/nus-v2/src/services/logger/SentryStream.ts
+++ b/scrapers/nus-v2/src/services/logger/SentryStream.ts
@@ -39,7 +39,7 @@ function getSentryLevel(record: BunyanRecord): Sentry.Severity {
 }
 
 /**
- * Error deserialiazing function. Bunyan serialize the error to object
+ * Error deserializing function. Bunyan serializes the error to object
  * https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js#L1089
  * @param  {object} data serialized Bunyan
  * @return {Error}       the deserialiazed error

--- a/scrapers/nus-v2/src/tasks/GetSemesterModules.ts
+++ b/scrapers/nus-v2/src/tasks/GetSemesterModules.ts
@@ -77,7 +77,8 @@ export default class GetSemesterModules extends BaseTask implements Task<Input, 
           (module) =>
             !!containsNbsps(module.Description) &&
             this.logger.error(
-              `Bad data. Module description for ${module.CatalogNumber} contains non-breaking spaces`,
+              { moduleCode: `${module.Subject}${module.CatalogNumber}` },
+              `${module.Subject}${module.CatalogNumber}: Module description contains non-breaking spaces`,
             ),
         );
 

--- a/website/src/apis/github.ts
+++ b/website/src/apis/github.ts
@@ -9,7 +9,7 @@ import { VenueLocationMap } from 'types/venues';
 // school sharing a single IP address
 const baseUrl = 'https://github.nusmods.com';
 
-const contributorBlacklist = new Set([
+const ignoredContributors = new Set([
   // Renovate used to report outdated dependencies as a user via the GitHub API,
   // hence we need to filter it out by its GitHub user ID.
   25180681,
@@ -28,7 +28,7 @@ export function getContributors(): Promise<Contributor[]> {
     .get<Contributor[]>(url)
     .then((response) =>
       response.data.filter(
-        (contributor) => contributor.type === 'User' && !contributorBlacklist.has(contributor.id),
+        (contributor) => contributor.type === 'User' && !ignoredContributors.has(contributor.id),
       ),
     );
 }

--- a/website/src/bootstrapping/sentry.ts
+++ b/website/src/bootstrapping/sentry.ts
@@ -19,7 +19,7 @@ if (loadRaven) {
       return event;
     },
 
-    blacklistUrls: [
+    denyUrls: [
       // Local file system
       /^file:\/\//i,
       // Chrome and Firefox extensions

--- a/website/src/reducers/index.ts
+++ b/website/src/reducers/index.ts
@@ -30,7 +30,7 @@ const defaultState = ({} as unknown) as State;
 const undoReducer = createUndoReducer<State>({
   limit: 1,
   actionsToWatch: [REMOVE_MODULE, SET_TIMETABLE],
-  whitelist: ['timetables', 'theme.colors'],
+  storedKeyPaths: ['timetables', 'theme.colors'],
 });
 
 export default function reducers(state: State = defaultState, action: Actions): State {

--- a/website/src/reducers/undoHistory.test.ts
+++ b/website/src/reducers/undoHistory.test.ts
@@ -48,7 +48,7 @@ const mutatedState = produce(state, (draft) => {
 
 const config: UndoHistoryConfig = {
   actionsToWatch: [WATCHED_ACTION],
-  whitelist: ['data.toMutate.numbers', 'data.toMutate.string'],
+  storedKeyPaths: ['data.toMutate.numbers', 'data.toMutate.string'],
 };
 
 describe('#computeUndoStacks()', () => {
@@ -76,17 +76,17 @@ describe('#computeUndoStacks()', () => {
     expect(hist0.past).toHaveLength(0);
     expect(hist0.present).toBeUndefined(); // Present did not exist
     expect(hist1.past).toHaveLength(1);
-    expect(hist1.past[0]).toEqual(pick(state, config.whitelist));
+    expect(hist1.past[0]).toEqual(pick(state, config.storedKeyPaths));
 
     // Set new present
-    const present1 = pick(mutatedState, config.whitelist);
+    const present1 = pick(mutatedState, config.storedKeyPaths);
     expect(hist1.present).toEqual(present1);
-    expect(hist1.present).not.toEqual(pick(state, config.whitelist)); // Just make sure both states are different
+    expect(hist1.present).not.toEqual(pick(state, config.storedKeyPaths)); // Just make sure both states are different
 
     // Add present to past if present exists
     expect(hist2.past).toHaveLength(2);
     expect(hist2.past[1]).toEqual(present1);
-    expect(hist2.present).toEqual(pick(state, config.whitelist));
+    expect(hist2.present).toEqual(pick(state, config.storedKeyPaths));
   });
 
   test('should undo', () => {

--- a/website/src/reducers/undoHistory.ts
+++ b/website/src/reducers/undoHistory.ts
@@ -7,7 +7,7 @@ import { Actions } from 'types/actions';
 export type UndoHistoryConfig = {
   limit?: number;
   actionsToWatch: string[];
-  whitelist: string[];
+  storedKeyPaths: string[];
 };
 
 // Update undo history using the action and app states
@@ -31,12 +31,12 @@ export function computeUndoStacks<T extends { undoHistory: UndoHistoryState<T> }
   if (config.actionsToWatch.includes(action.type)) {
     // Append actual present to past, and drop history past config.limit
     // Limit only enforced here since undo/redo only shift the history around without adding new history
-    const appendedPast = [...past, pick(previousAppState, config.whitelist)];
+    const appendedPast = [...past, pick(previousAppState, config.storedKeyPaths)];
     const newPast = 'limit' in config ? takeRight(appendedPast, config.limit) : appendedPast;
 
     return {
       past: newPast,
-      present: pick(presentAppState, config.whitelist),
+      present: pick(presentAppState, config.storedKeyPaths),
       future: [],
     };
   }
@@ -105,7 +105,7 @@ export default function createUndoReducer<T extends { undoHistory: UndoHistorySt
     // Applies updatedHistory.present to state if action.type === {UNDO,REDO}
     // Assumes updatedHistory.present is the final present state
     if ((action.type === UNDO || action.type === REDO) && updatedHistory.present) {
-      return mergePresent(updatedState, updatedHistory.present, config.whitelist);
+      return mergePresent(updatedState, updatedHistory.present, config.storedKeyPaths);
     }
     return updatedState;
   };


### PR DESCRIPTION
1. Add subject to NBSP errors. Samples: [before](https://sentry.io/share/issue/80969148baba45fd97117394b9f6c77b/), [after](https://sentry.io/share/issue/a9dc08fc4b4f4ea5aa3f36bb0a4f941a/)

	We do not generally prepend the module code to other errors because we'll get flooded with hundreds of "Lesson has no start and/or end time".

2. Minor code changes: fix typos, and replace blacklist/whitelist. `blacklistUrls` was deprecated by Sentry.