### PR TITLE
Truncate long exam duration string

### DIFF
--- a/website/src/utils/modules.test.ts
+++ b/website/src/utils/modules.test.ts
@@ -168,6 +168,7 @@ describe(renderExamDuration, () => {
     [45, '45 mins'],
     [60, '1 hr'],
     [90, '1.5 hrs'],
+    [70, '1.166 hrs'],
     [120, '2 hrs'],
     [180, '3 hrs'],
   ])('%s to equal %s', (duration, expected) =>

--- a/website/src/utils/modules.test.ts
+++ b/website/src/utils/modules.test.ts
@@ -168,7 +168,7 @@ describe(renderExamDuration, () => {
     [45, '45 mins'],
     [60, '1 hr'],
     [90, '1.5 hrs'],
-    [70, '1.166 hrs'],
+    [70, '70 mins'],
     [120, '2 hrs'],
     [180, '3 hrs'],
   ])('%s to equal %s', (duration, expected) =>

--- a/website/src/utils/modules.ts
+++ b/website/src/utils/modules.ts
@@ -83,11 +83,11 @@ export function renderMCs(moduleCredits: number | string) {
 }
 
 export function renderExamDuration(examDuration: number) {
-  if (examDuration < 60) {
+  if (examDuration < 60 || examDuration % 30 !== 0) {
     return noBreak(`${examDuration} mins`);
   }
-  const hours = (examDuration / 60).toString().substr(0, 5);
-  return noBreak(`${hours} ${hours === '1' ? 'hr' : 'hrs'}`);
+  const hours = examDuration / 60;
+  return noBreak(`${hours} ${hours === 1 ? 'hr' : 'hrs'}`);
 }
 
 export function subtractAcadYear(acadYear: string): string {

--- a/website/src/utils/modules.ts
+++ b/website/src/utils/modules.ts
@@ -83,11 +83,11 @@ export function renderMCs(moduleCredits: number | string) {
 }
 
 export function renderExamDuration(examDuration: number) {
-  const hours = examDuration / 60;
-  if (hours < 1) {
+  if (examDuration < 60) {
     return noBreak(`${examDuration} mins`);
   }
-  return noBreak(`${hours} ${hours === 1 ? 'hr' : 'hrs'}`);
+  const hours = (examDuration / 60).toString().substr(0, 5);
+  return noBreak(`${hours} ${hours === '1' ? 'hr' : 'hrs'}`);
 }
 
 export function subtractAcadYear(acadYear: string): string {


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Long repeating decimals in exam duration e.g. https://nusmods.com/modules/LC1025/singapore-law-in-context
![image](https://user-images.githubusercontent.com/31354724/103406387-81832d00-4b95-11eb-955a-209fab573b72.png)

Some exams are 70 or 100 minutes, which produce repeating decimals when divided by 60. Fortunately there are only 4 of these:
```
curl -X GET "https://api.nusmods.com/v2/2020-2021/moduleInfo.json" | jq '[ .[] | .semesterData | .[] | .examDuration | select(. != null and (. == 70 or . == 100)) ]' | jq length

4
```

After truncating (5 chars is rather arbitary, we can always change it):
![image](https://user-images.githubusercontent.com/31354724/103406559-0cfcbe00-4b96-11eb-985a-85ba63cd2d87.png)


## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

## Other Information
happy new year LOL