### PR TITLE
Add Sentry performance monitoring and environments

### DIFF
--- a/website/jest.common.config.js
+++ b/website/jest.common.config.js
@@ -22,6 +22,8 @@ module.exports = {
     VERSION_STR: '',
     DISPLAY_COMMIT_HASH: '',
     DEBUG_SERVICE_WORKER: false,
+    VERCEL_ENV: '',
+    VERCEL_GIT_COMMIT_REF: '',
   },
   // Allow us to directly use enzyme wrappers for snapshotting
   // Usage: expect(enzyme.shallow(<div/>)).toMatchSnapshot();

--- a/website/package.json
+++ b/website/package.json
@@ -131,6 +131,7 @@
     "@material/fab": "0.40.1",
     "@material/snackbar": "0.40.1",
     "@sentry/browser": "5.29.2",
+    "@sentry/tracing": "5.29.2",
     "@tippy.js/react": "3.1.1",
     "axios": "0.21.0",
     "bootstrap": "4.5.3",

--- a/website/src/.eslintrc.js
+++ b/website/src/.eslintrc.js
@@ -110,5 +110,7 @@ module.exports = {
     VERSION_STR: 'readonly',
     DISPLAY_COMMIT_HASH: 'readonly',
     DEBUG_SERVICE_WORKER: 'readonly',
+    VERCEL_ENV: 'readonly',
+    VERCEL_GIT_COMMIT_REF: 'readonly',
   },
 };

--- a/website/src/bootstrapping/sentry.ts
+++ b/website/src/bootstrapping/sentry.ts
@@ -1,5 +1,6 @@
 import { get } from 'lodash';
 import * as Sentry from '@sentry/browser';
+import { Integrations } from '@sentry/tracing';
 
 import { isBrowserSupported } from './browser';
 
@@ -23,6 +24,9 @@ if (loadRaven) {
     dsn: 'https://4b4fe71954424fd39ac88a4f889ffe20@sentry.io/213986',
 
     release: VERSION_STR || 'UNKNOWN_RELEASE',
+
+    integrations: [new Integrations.BrowserTracing()],
+    tracesSampleRate: 1.0,
 
     environment: sentryEnv(),
 

--- a/website/src/bootstrapping/sentry.ts
+++ b/website/src/bootstrapping/sentry.ts
@@ -3,6 +3,19 @@ import * as Sentry from '@sentry/browser';
 
 import { isBrowserSupported } from './browser';
 
+// Decide Sentry environment based on some basic heuristics.
+function sentryEnv(): string | undefined {
+  if (VERCEL_ENV === 'preview') return 'preview';
+  if (VERCEL_ENV === 'production') {
+    if (VERCEL_GIT_COMMIT_REF === 'production') return 'production';
+    if (window.location.host === 'nusmods.com') return 'production';
+    if (VERCEL_GIT_COMMIT_REF === 'master') return 'staging';
+    // Don't expect Vercel production deployments to be made from other
+    // branches.
+  }
+  return 'development';
+}
+
 // Configure Raven - the client for Sentry, which we use to handle errors
 const loadRaven = !__DEV__ && !__TEST__;
 if (loadRaven) {
@@ -10,6 +23,8 @@ if (loadRaven) {
     dsn: 'https://4b4fe71954424fd39ac88a4f889ffe20@sentry.io/213986',
 
     release: VERSION_STR || 'UNKNOWN_RELEASE',
+
+    environment: sentryEnv(),
 
     beforeSend(event, hint) {
       const message = get(hint, ['originalException', 'message']);

--- a/website/src/types/global.d.ts
+++ b/website/src/types/global.d.ts
@@ -6,6 +6,8 @@ declare const DATA_API_BASE_URL: string | undefined;
 declare const VERSION_STR: string | undefined;
 declare const DISPLAY_COMMIT_HASH: string | undefined;
 declare const DEBUG_SERVICE_WORKER: boolean;
+declare const VERCEL_ENV: string;
+declare const VERCEL_GIT_COMMIT_REF: string;
 /* eslint-enable no-underscore-dangle */
 
 /**

--- a/website/webpack/webpack.config.dev.js
+++ b/website/webpack/webpack.config.dev.js
@@ -22,6 +22,8 @@ const developmentConfig = merge([
         VERSION_STR: JSON.stringify(parts.appVersion().versionStr),
         DEBUG_SERVICE_WORKER: !!process.env.DEBUG_SERVICE_WORKER,
         DATA_API_BASE_URL: JSON.stringify(process.env.DATA_API_BASE_URL),
+        VERCEL_ENV: JSON.stringify(process.env.VERCEL_ENV),
+        VERCEL_GIT_COMMIT_REF: JSON.stringify(process.env.VERCEL_GIT_COMMIT_REF),
       }),
     ],
   },

--- a/website/webpack/webpack.config.prod.js
+++ b/website/webpack/webpack.config.prod.js
@@ -29,6 +29,8 @@ const productionConfig = ({ browserWarningPath }) =>
           VERSION_STR: JSON.stringify(parts.appVersion().versionStr),
           DEBUG_SERVICE_WORKER: !!process.env.DEBUG_SERVICE_WORKER,
           DATA_API_BASE_URL: JSON.stringify(process.env.DATA_API_BASE_URL),
+          VERCEL_ENV: JSON.stringify(process.env.VERCEL_ENV),
+          VERCEL_GIT_COMMIT_REF: JSON.stringify(process.env.VERCEL_GIT_COMMIT_REF),
         }),
       ],
     },

--- a/website/webpack/webpack.config.timetable-only.js
+++ b/website/webpack/webpack.config.timetable-only.js
@@ -13,7 +13,7 @@ const __DEV__ = process.env.NODE_ENV === 'development';
 
 const source = (file) => path.join('entry/export', file);
 
-const productionConfig = merge([
+const timetableOnlyConfig = merge([
   {
     plugins: [
       new webpack.DefinePlugin({
@@ -23,6 +23,8 @@ const productionConfig = merge([
         VERSION_STR: JSON.stringify(parts.appVersion().versionStr),
         DEBUG_SERVICE_WORKER: !!process.env.DEBUG_SERVICE_WORKER,
         DATA_API_BASE_URL: JSON.stringify(process.env.DATA_API_BASE_URL),
+        VERCEL_ENV: JSON.stringify(process.env.VERCEL_ENV),
+        VERCEL_GIT_COMMIT_REF: JSON.stringify(process.env.VERCEL_GIT_COMMIT_REF),
       }),
     ],
   },
@@ -62,4 +64,4 @@ const productionConfig = merge([
   parts.devServer(),
 ]);
 
-module.exports = productionConfig;
+module.exports = timetableOnlyConfig;

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1361,6 +1361,17 @@
     "@sentry/types" "5.29.2"
     tslib "^1.9.3"
 
+"@sentry/tracing@5.29.2":
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.29.2.tgz#6012788547d2ab7893799d82c4941bda145dcd47"
+  integrity sha512-iumYbVRpvoU3BUuIooxibydeaOOjl5ysc+mzsqhRs2NGW/C3uKAsFXdvyNfqt3bxtRQwJEhwJByLP2u3pLThpw==
+  dependencies:
+    "@sentry/hub" "5.29.2"
+    "@sentry/minimal" "5.29.2"
+    "@sentry/types" "5.29.2"
+    "@sentry/utils" "5.29.2"
+    tslib "^1.9.3"
+
 "@sentry/types@5.29.2":
   version "5.29.2"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.29.2.tgz#ac87383df1222c2d9b9f8f9ed7a6b86ea41a098a"


### PR DESCRIPTION
1. Performance tracing: adds the basic Sentry performance setup. The most valuable data here is the web vitals stuff, but it'll also be the foundation of future tracing for the new GraphQL server as well.

	I've added a [`Timing-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin) header to api.nusmods.com so that we can see timing info for it in our traces.

	Sentry do provide a [React integration](https://docs.sentry.io/platforms/javascript/guides/react/) that can log basic React lifecycle info for components wrapped in a `withProfiler` HoC. However, lifecycle info (i.e. mount, render, update, unmount) for single components isn't very useful, and you'll need to wrap each component of interest individually. I think it may be more useful to build our own React tracer using the [user timing marks I helped add to React](https://github.com/facebook/react/pull/19223), which are [enabled](https://github.com/facebook/react/blob/50393dc3a0c59cfefd349d31992256efd6f8c261/packages/shared/ReactFeatureFlags.js#L18-L20) in experimental profiling builds of React, which will be able to provide timing information on React state updates, suspends, etc, as well as info on effect execution and render and commit phases.

1. Environments: adds some heuristics to determine an environment.

## Screenshots

All links are internal-only.

### Environments

![image](https://user-images.githubusercontent.com/12784593/103407859-12103c00-4b9b-11eb-9b7b-3c7e8a6350c5.png)

### [Performance tab](https://sentry.io/organizations/nusmods/performance/?project=213986&statsPeriod=24h)

![image](https://user-images.githubusercontent.com/12784593/103407708-97472100-4b9a-11eb-9a21-510e32c08dcc.png)

### [Transaction details](https://sentry.io/organizations/nusmods/performance/v3:ee47fcc92e3441afa8835dd87bde1e3b/?environment=development&project=213986&query=event.type%3Atransaction+transaction.duration%3A%3C15m&statsPeriod=24h&transaction=%2Ftimetable%2Fsem-2&unselectedSeries=p100%28%29)

![image](https://user-images.githubusercontent.com/12784593/103407680-7bdc1600-4b9a-11eb-900e-4644b035c220.png)
