### PR TITLE
Force version string date to be in SGT

### DIFF
--- a/website/webpack/webpack.parts.js
+++ b/website/webpack/webpack.parts.js
@@ -171,6 +171,19 @@ exports.devServer = () => ({
 });
 
 /**
+ * Returns the current Singapore date, but with the time zone changed to the
+ * local machine's. E.g. if it is 1965-08-09 0000hrs SGT, this function
+ * returns 1965-08-09 0000hrs local time.
+ *
+ * Port of `toSingaporeTime` from timify.ts.
+ */
+function singaporeTime() {
+  const SGT_OFFSET = -8 * 60;
+  const localDate = new Date();
+  return new Date(localDate.getTime() + (localDate.getTimezoneOffset() - SGT_OFFSET) * 60 * 1000);
+}
+
+/**
  * Generates an app version string using the git commit hash and current date.
  *
  * @returns Object with keys `commitHash` and `versionStr`.
@@ -186,7 +199,7 @@ exports.appVersion = () => {
   }
   // Version format: <yyyyMMdd date>-<7-char hash substring>
   const versionStr =
-    commitHash && `${format(new Date(), 'yyyyMMdd')}-${commitHash.substring(0, 7)}`;
+    commitHash && `${format(singaporeTime(), 'yyyyMMdd')}-${commitHash.substring(0, 7)}`;
   return { commitHash, versionStr };
 };
 


### PR DESCRIPTION
`new Date()` returns the current date in the build machine's local time
zone. This used to be fine for us as the production builds of NUSMods
was always produced in Singapore. However, now that NUSMods is built on
Vercel, there's no guaranteed on what the machine's time zone will be.
It is also [not possible](https://vercel.com/docs/environment-variables#reserved-environment-variables) to pass in a custom `TZ` env var to the build
runner.

Solution: use the existing SGT transformer to always produce SGT dates.