### PR TITLE
Correct Sentry env derivation from VERCEL_ENV

### DIFF
--- a/website/src/bootstrapping/sentry.ts
+++ b/website/src/bootstrapping/sentry.ts
@@ -6,13 +6,10 @@ import { isBrowserSupported } from './browser';
 
 // Decide Sentry environment based on some basic heuristics.
 function sentryEnv(): string | undefined {
-  if (VERCEL_ENV === 'preview') return 'preview';
-  if (VERCEL_ENV === 'production') {
-    if (VERCEL_GIT_COMMIT_REF === 'production') return 'production';
-    if (window.location.host === 'nusmods.com') return 'production';
+  if (VERCEL_ENV === 'production') return 'production';
+  if (VERCEL_ENV === 'preview') {
     if (VERCEL_GIT_COMMIT_REF === 'master') return 'staging';
-    // Don't expect Vercel production deployments to be made from other
-    // branches.
+    return 'preview';
   }
   return 'development';
 }


### PR DESCRIPTION
#3106 added Sentry environments, but we didn't use the correct `VERCEL_ENV` values, leading to latest.nusmods.com events being categorized under the "preview" env even though it's deployed from the master branch.

This PR corrects the logic, following the Vercel env definitions https://vercel.com/docs/environment-variables#environments.