### PR TITLE
Fix tsconfig path lookup for IntelliJ

### DIFF
--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
 
   parserOptions: {
-    project: './tsconfig.json',
+    project: __dirname + '/tsconfig.json',
   },
 
   root: true,


### PR DESCRIPTION
IntelliJ's ESLint plugin suffers from a weird bug - it tries to resolve relative paths from the file that it is reading, even if the path is inherited from a config from another file. 

<img width="921" alt="Screen Shot 2021-01-02 at 3 18 40 PM" src="https://user-images.githubusercontent.com/445650/103468440-cfbb3c00-4d0d-11eb-8825-01db77d791fe.png">


I don't know if this is the correct behavior, and ESLint is just better at resolving upwards for tsconfig.json, but either way using __dirname changes the path to an absolute path which fixes the error 

