### PR TITLE
Limit Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,10 @@
     "config:base",
     "schedule:weekends",
     "group:babelMonorepo",
+    "group:linters",
     ":automergePr",
-    ":automergeRequireAllStatusChecks",
     ":automergeMinor",
-    ":prConcurrentLimit10",
+    ":prHourlyLimit2",
     ":label(dependencies)",
     ":timezone(Asia/Singapore)"
   ],
@@ -20,25 +20,12 @@
     {
       "description": "Group Webpack-related packages together",
       "packagePatterns": ["-loader$", "webpack"],
-      "excludePackagePatterns": ["react-hot-loader"],
       "groupName": "webpack"
     },
     {
       "description": "Group mapbox packages together",
       "packagePatterns": ["^(leaflet|mapbox)"],
       "groupName": "mapbox"
-    },
-    {
-      "description": "Group eslint packages together",
-      "packagePatterns": ["eslint"],
-      "excludePackageNames": ["eslint-loader"],
-      "groupName": "eslint"
-    },
-    {
-      "description": "Group stylelint packages together",
-      "packagePatterns": ["stylelint"],
-      "excludePackageNames": ["stylelint-webpack-plugin"],
-      "groupName": "stylelint"
     },
     {
       "extends": "monorepo:jest",
@@ -93,5 +80,5 @@
     }
   ],
   "ignorePaths": [".nvmrc"],
-  "prHourlyLimit": 0
+  "prConcurrentLimit": 2
 }


### PR DESCRIPTION
Yesterday, Renovate opened so many PRs that we hit our Vercel limit of
100 deployments/day. This commit limits Renovate so that we don't have
this issue again.

- Reduces concurrent no. PRs from 10 to 2. As failing PRs will be
  rebased, they'll rapidly accumulate deployments. E.g. if there are 9
  failing PRs, and each new 10th PR triggers 20 deployments.
- Adds limit of 2 PRs/hour. Renovate would previously spray e.g. 10 (or
  now 2) PRs, then merge each PR individually. Each merge also causes
  all remaining PRs to be rebased, *and* a new PR may be created to
  reach the concurrent limit. This resulted in x*20 + 18 + 16 + ... + 2
  deployments.
- Replaces eslint and stylelint groups with the group:linter preset.
- Remove react-hot-loader rule as we don't use it anymore.