### PR TITLE
website: css: Add fallbacks for props using env()

### DIFF
--- a/website/src/styles/layout/site.scss
+++ b/website/src/styles/layout/site.scss
@@ -32,6 +32,7 @@ a {
 
 .main-container {
   flex: 1 auto;
+  padding: 0; // For Microsoft Edge 18
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom)
     env(safe-area-inset-left);
 

--- a/website/src/views/AppShell.scss
+++ b/website/src/views/AppShell.scss
@@ -14,6 +14,7 @@ $logo-vert-padding: 0.875rem;
   display: flex;
   justify-content: space-between;
   height: $navbar-height;
+  padding: 0; // For Microsoft Edge 18
   padding: 0 env(safe-area-inset-right) 0 env(safe-area-inset-left);
   background: var(--gray-lightest);
 }

--- a/website/src/views/layout/Footer.scss
+++ b/website/src/views/layout/Footer.scss
@@ -2,6 +2,7 @@
 
 .footer {
   composes: text-muted from global;
+  padding: 4rem 0 4rem 0; // For Microsoft Edge 18
   padding: 4rem env(safe-area-inset-right) calc(env(safe-area-inset-bottom) + 4rem) env(safe-area-inset-left);
   margin-top: 4rem;
   font-size: 0.85rem;
@@ -32,10 +33,12 @@
   }
 
   @include media-breakpoint-up(md) {
+    padding-left: #{$side-nav-width-md}; // For Microsoft Edge 18
     padding-left: calc(env(safe-area-inset-left) + #{$side-nav-width-md});
   }
 
   @include media-breakpoint-up(xl) {
+    padding-left: #{$side-nav-width-lg}; // For Microsoft Edge 18
     padding-left: calc(env(safe-area-inset-left) + #{$side-nav-width-lg});
   }
 }

--- a/website/src/views/venues/VenuesContainer.scss
+++ b/website/src/views/venues/VenuesContainer.scss
@@ -40,6 +40,7 @@ $venue-list-width: 16rem;
 
   .venuesList {
     width: $venue-list-width;
+    padding-bottom: 0; // For Microsoft Edge 18
     padding-bottom: env(safe-area-inset-bottom);
     border-right: 1px solid var(--gray-lighter);
 
@@ -47,8 +48,11 @@ $venue-list-width: 16rem;
   }
 
   .venueDetail {
+    right: 0; // For Microsoft Edge 18
     right: env(safe-area-inset-right);
+    left: calc(#{$venue-list-width + $side-nav-width-md} + #{$gutter}); // For Microsoft Edge 18
     left: calc(env(safe-area-inset-left) + #{$venue-list-width + $side-nav-width-md} + #{$gutter});
+    padding: 0 $gutter 0 $gutter; // For Microsoft Edge 18
     padding: 0 $gutter env(safe-area-inset-bottom) $gutter;
   }
 }


### PR DESCRIPTION
Pre-Chromium Microsoft Edge (<= v18) does not have support for
the env() function. Add fallbacks for the properties that use it.

Fixes #3146

<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
Added fallbacks to all CSS properties which use the `env()` function.
I believe that the `env(safe-inset-area-*)` calls resolve to 0 on any device using Windows and Microsoft Edge. Hence, the fallbacks should be functionally equivalent to the originals.

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
