### PR TITLE
webpack/babel: Properly transpile spread operator in react-leaflet

### DIFF
--- a/website/webpack/webpack.config.common.js
+++ b/website/webpack/webpack.config.common.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const parts = require('./webpack.parts');
 
 const commonConfig = {
@@ -46,10 +48,11 @@ const commonConfig = {
         test: /\.[j|t]sx?$/,
         include: [
           parts.PATHS.src,
-          // React Leaflet's MapContainer destructures an object using the ...
-          // operator, which isn't supported on Mobile Safari <= 11.2.
-          // TODO: Remove after we drop support for iOS <= 11.2
-          /node_modules\/react-leaflet/,
+          // React Leaflet's MapContainer and withPane destructures an object using the ...
+          // operator, which isn't supported on Mobile Safari <= 11.2 and Microsoft Edge 18.
+          // TODO: Remove after we drop support for iOS <= 11.2 and Microsoft Edge 18.
+          path.join(parts.PATHS.root, parts.PATHS.node, 'react-leaflet'),
+          path.join(parts.PATHS.root, parts.PATHS.node, '@react-leaflet'),
         ],
         use: ['babel-loader'],
       },


### PR DESCRIPTION
react-leaflet currently does not work on Microsoft Edge 18 (and possibly
Mobile Safari 11.2). A fix was attempted in commit 8e7d591af825e53b1cb199a9b59458264c4fc1a3.

However, the fix was incomplete for a few reasons:
1. The stated path did not reference the correct directory for
   react-leaflet.
2. There are 2 react-leaflet directories (react-leaflet and
   @react-leaflet) which use the spread operator.

Properly fix the issue by including the full path to both directories.

Note:
An alternate fix is to use regex again (e.g. /../node_modules\/react-leaflet/).
However, I used absolute paths according to the best practices stated in [1].

[1]: https://webpack.js.org/configuration/#:~:text=//%20-%20Use%20arrays%20of%20absolute%20paths%20in%20include%20and%20exclude%20to%20match%20the%20full%20path

Fixes #3147

<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
