### PR TITLE
Enable CORS on /api redirect

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -31,8 +31,17 @@
       ]
     }
   ],
+  "rewrites": [
+    {
+      "source": "/api(/.*)?",
+      "destination": "https://api.nusmods.com$1"
+    }
+  ],
   "redirects": [
-    { "source": "/api(/.*)?", "destination": "https://api.nusmods.com$1", "permanent": false },
-    { "source": "/news(/.*)?", "destination": "https://blog.nusmods.com$1", "permanent": false }
+    {
+      "source": "/news(/.*)?",
+      "destination": "https://blog.nusmods.com$1",
+      "permanent": false
+    }
   ]
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -8,6 +8,27 @@
           "value": "public, max-age=2629800, immutable"
         }
       ]
+    },
+    {
+      "source": "/api(/.*)?",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Credentials",
+          "value": "true"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET,OPTIONS,PATCH,DELETE,POST,PUT"
+        },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
+        }
+      ]
     }
   ],
   "redirects": [


### PR DESCRIPTION
Fixes v2.nusmods.com, old deploy previews, and other old clients by changing the nusmods.com/api 307 temporary redirect to a 301 and adding CORS headers. I had to use 301 instead of 307 to fix CORS errors.

Header config copied from [Vercel docs](https://vercel.com/knowledge/how-to-enable-cors#enabling-cors-using-vercel.json).

### Test

- [test-cors.org with nusmods.com/api](https://www.test-cors.org/#?client_method=GET&client_credentials=false&server_url=https%3A%2F%2Fnusmods.com%2Fapi%2F&server_enable=true&server_status=200&server_credentials=false&server_tabs=remote): fails to load due to missing CORS headers
- [test-cors.org with deploy preview /api](https://www.test-cors.org/#?client_method=GET&client_credentials=false&server_url=https%3A%2F%2Fnusmods-website-git-eliang-api-redirect-cors.nusmodifications.vercel.app%2Fapi&server_enable=true&server_status=200&server_credentials=false&server_tabs=remote): loads