### PR TITLE
Increase /assets/* cache max-age from 1 month to 1 year

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=2629800, immutable"
+          "value": "public, max-age=31536000, immutable"
         }
       ]
     },


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

As discussed https://github.com/nusmodifications/nusmods/pull/3092#discussion_r550374859. This will cache resources on Cloudflare for 1 year even if Vercel's CDN is purged by deploys.