### PR TITLE
Navbar: shift center block left

### DIFF
--- a/website/src/views/layout/Navbar.scss
+++ b/website/src/views/layout/Navbar.scss
@@ -30,14 +30,12 @@ $logo-vert-padding: 0.875rem;
 .brandLogo {
   // Explicit width so the logo will not expand
   // to occupy the entire navbar
-  width: 11rem; // Eyeballed number
+  max-width: 11rem; // Eyeballed number
   height: 100%;
-  padding: $logo-vert-padding $grid-gutter-width/2 $logo-vert-padding $grid-gutter-width;
+  padding: $logo-vert-padding $grid-gutter-width/2 $logo-vert-padding $grid-gutter-width/2;
 }
 
 .navLeft {
-  display: flex;
-  flex: 1 0 0;
   height: $navbar-height;
 }
 
@@ -50,7 +48,7 @@ $logo-vert-padding: 0.875rem;
   flex: 1 0 0;
   justify-content: flex-end;
   height: $navbar-height;
-  padding-right: $grid-gutter-width;
+  padding-right: $grid-gutter-width / 2;
 }
 
 .weekText {
@@ -67,7 +65,6 @@ $logo-vert-padding: 0.875rem;
   }
 
   .navLeft {
-    flex: unset;
     order: 0;
   }
 

--- a/website/src/views/layout/Navtabs.scss
+++ b/website/src/views/layout/Navtabs.scss
@@ -13,7 +13,7 @@
   flex-grow: 1;
   justify-content: center;
   align-items: center;
-  width: 4rem;
+  min-width: 3rem;
   margin: 0 0.2rem;
   border-top: 0.2rem solid transparent;
   border-bottom: 0.2rem solid transparent;

--- a/website/src/views/today/TodayContainer/TodayContainer.scss
+++ b/website/src/views/today/TodayContainer/TodayContainer.scss
@@ -1,7 +1,7 @@
 @import '~styles/utils/modules-entry';
 
 $schedule-width: 25rem;
-$gutter: 0.75rem;
+$gutter: 0.9375rem; // 15px; aligns with $grid-gutter-width / 2.
 
 .todayPage {
   composes: page-container from global;


### PR DESCRIPTION
## Context

The navbar links being at the centre made it look very uneven, especially with the search bar expanding to take up space on the right. This commit shifts the navbar links to the left, and aligns the padding of the navbar with the Today, Venues and Timetable components on the medium viewport widths.


## Other Information
Here are screenshots of the timetable view at 2 different viewport breakpoints.

### Large viewport
![image](https://user-images.githubusercontent.com/813865/107935780-cab00480-6fbc-11eb-8f64-ee5d9bb236fc.png)

### Medium viewport
![image](https://user-images.githubusercontent.com/813865/107935799-d1d71280-6fbc-11eb-972f-26e9f93bbfa3.png)



