### PR TITLE
Add missing s for contraction in "It's recess week!"

### DIFF
--- a/website/src/views/today/EmptyLessonGroup.tsx
+++ b/website/src/views/today/EmptyLessonGroup.tsx
@@ -60,7 +60,7 @@ function renderType(type: EmptyGroupType) {
       return (
         <>
           <ParkIcon />
-          <p>It&apos; recess week!</p>
+          <p>It&apos;s recess week!</p>
         </>
       );
 


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
In https://nusmods.com/today, the "It's recess week!" notice is missing an s for the contraction "It's"
<img width="412" alt="image" src="https://user-images.githubusercontent.com/39089453/108024633-e7514880-705f-11eb-9405-28d74db98147.png">


## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
This PR is just a quick fix to add the 's' where it should be
