### PR TITLE
Add support for MPE attributes

### DIFF
--- a/scrapers/nus-v2/src/tasks/GetSemesterData.ts
+++ b/scrapers/nus-v2/src/tasks/GetSemesterData.ts
@@ -57,6 +57,12 @@ const attributeMap: { [attribute: string]: keyof NUSModuleAttributes } = {
   // MPE handled separately as it maps to multiple attributes
 };
 
+const mpeValueMap: { [attribute: string]: (keyof NUSModuleAttributes)[] } = {
+  S1: ['mpes1'],
+  S2: ['mpes2'],
+  'S1&S2': ['mpes1', 'mpes2'],
+};
+
 export function mapAttributes(
   attributes: ModuleAttributeEntry[],
   logger: Logger,
@@ -65,23 +71,16 @@ export function mapAttributes(
 
   for (const entry of attributes) {
     if (entry.CourseAttribute === 'MPE') {
-      switch (entry.CourseAttributeValue) {
-        case 'S1':
-          nusAttributes.mpes1 = true;
-          break;
-        case 'S2':
-          nusAttributes.mpes2 = true;
-          break;
-        case 'S1&S2':
-          nusAttributes.mpes1 = true;
-          nusAttributes.mpes2 = true;
-          break;
-        default:
-          logger.warn(
-            { value: entry.CourseAttributeValue, key: entry.CourseAttribute },
-            'Non-standard course attribute value',
-          );
-          break;
+      const mappedAttributes = mpeValueMap[entry.CourseAttributeValue];
+      if (!mappedAttributes) {
+        logger.warn(
+          { value: entry.CourseAttributeValue, key: entry.CourseAttribute },
+          'Non-standard course attribute value',
+        );
+      } else {
+        for (const attr of mappedAttributes) {
+          nusAttributes[attr] = true;
+        }
       }
       continue;
     }

--- a/scrapers/nus-v2/src/tasks/GetSemesterData.ts
+++ b/scrapers/nus-v2/src/tasks/GetSemesterData.ts
@@ -54,6 +54,7 @@ const attributeMap: { [attribute: string]: keyof NUSModuleAttributes } = {
   LABB: 'lab',
   ISM: 'ism',
   HFYP: 'fyp',
+  // MPE handled separately as it maps to multiple attributes
 };
 
 export function mapAttributes(
@@ -63,6 +64,28 @@ export function mapAttributes(
   const nusAttributes: NUSModuleAttributes = {};
 
   for (const entry of attributes) {
+    if (entry.CourseAttribute === 'MPE') {
+      switch (entry.CourseAttributeValue) {
+        case 'S1':
+          nusAttributes.mpes1 = true;
+          break;
+        case 'S2':
+          nusAttributes.mpes2 = true;
+          break;
+        case 'S1&S2':
+          nusAttributes.mpes1 = true;
+          nusAttributes.mpes2 = true;
+          break;
+        default:
+          logger.warn(
+            { value: entry.CourseAttributeValue, key: entry.CourseAttribute },
+            'Non-standard course attribute value',
+          );
+          break;
+      }
+      continue;
+    }
+
     if (!attributeMap[entry.CourseAttribute]) continue;
 
     if (entry.CourseAttributeValue === 'YES' || entry.CourseAttributeValue === 'HT') {

--- a/scrapers/nus-v2/src/types/api.ts
+++ b/scrapers/nus-v2/src/types/api.ts
@@ -47,6 +47,7 @@ export type ModuleAcademicGroup = Readonly<{
 // ISM - Independent Study Module
 // HFYP - Honours/Final Year Project (value is 'HT', not 'YES' like the other attributes)
 // GRDY - GD modules eligible for SU
+// MPE - Module is included in a particular semester's MPE. Value is 'S1' (sem 1), 'S2', or 'S1&2' (both sem 1 and 2)
 export type ModuleAttributeEntry = Readonly<{
   CourseAttributeValue: string;
   CourseAttribute: string;

--- a/scrapers/nus-v2/src/types/modules.ts
+++ b/scrapers/nus-v2/src/types/modules.ts
@@ -99,6 +99,8 @@ export type NUSModuleAttributes = Partial<{
   ism: boolean; // Independent study
   urop: boolean; // Undergraduate Research Opportunities Program
   fyp: boolean; // Honours / Final Year Project
+  mpes1: boolean; // Included in Semester 1's Module Preference Exercise
+  mpes2: boolean; // Included in Semester 2's Module Preference Exercise
 }>;
 
 // Information for a module for a particular academic year.

--- a/website/src/types/modules.ts
+++ b/website/src/types/modules.ts
@@ -100,6 +100,8 @@ type AttributeMap = {
   ism: boolean; // Independent study
   urop: boolean; // Undergraduate Research Opportunities Program
   fyp: boolean; // Honours / Final Year Project
+  mpes1: boolean; // Included in Semester 1's Module Preference Exercise
+  mpes2: boolean; // Included in Semester 2's Module Preference Exercise
 };
 
 export type NUSModuleAttributes = Partial<AttributeMap>;
@@ -114,6 +116,8 @@ export const attributeDescription: { [key in keyof AttributeMap]: string } = {
   ism: 'Independent study module',
   urop: 'Undergraduate Research Opportunities Program',
   fyp: 'Honours / Final Year Project',
+  mpes1: "Included in Semester 1's Module Preference Exercise",
+  mpes2: "Included in Semester 2's Module Preference Exercise",
 };
 
 // RawLesson is a lesson time slot obtained from the API.


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

#3035

Following this email sent from NUSIT to @chuabingquan:

![image](https://user-images.githubusercontent.com/12784593/108065127-82661480-7098-11eb-927d-dc7c8ef962ca.png)

This PR adds support for the MPE course attribute to /scraper and /website.

cc @alissayarmantho

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

Though the MPE attribute has multiple possible values, I've flattened them into multiple separate boolean attributes in our API. Definitely not an ideal solution, but I think our Elasticsearch index expects the attributes to be a [list of strings](https://github.com/nusmodifications/nusmods/blob/4f8cf0cef3fd296021bd0d00f21f40481bce1a71/scrapers/nus-v2/src/services/io/elastic.ts#L144).

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->

Not tested because it seems like no module in the NUS API has the MPE course attribute yet, so the new code isn't executed. @chuabingquan @alissayarmantho do yall know when NUS plans to add these attributes?