### PR TITLE
Expose MPE attributes to mpeModules endpoint

### DIFF
--- a/scrapers/nus-v2/src/services/io/__mocks__/elastic.ts
+++ b/scrapers/nus-v2/src/services/io/__mocks__/elastic.ts
@@ -7,6 +7,8 @@ export default class MockedElasticPersist implements Persist {
 
   moduleInformation = () => Promise.resolve();
 
+  mpeModules = () => Promise.resolve();
+
   moduleAliases = () => Promise.resolve();
 
   facultyDepartments = () => Promise.resolve();

--- a/scrapers/nus-v2/src/services/io/elastic.ts
+++ b/scrapers/nus-v2/src/services/io/elastic.ts
@@ -211,6 +211,10 @@ export default class ElasticPersist implements Persist {
     return Promise.resolve();
   }
 
+  mpeModules() {
+    return Promise.resolve();
+  }
+
   semesterData() {
     return Promise.resolve();
   }

--- a/scrapers/nus-v2/src/services/io/fs.ts
+++ b/scrapers/nus-v2/src/services/io/fs.ts
@@ -21,7 +21,7 @@ import { Venue, VenueInfo } from '../../types/venues';
 import { Cache, Persist } from '../../types/persist';
 import config from '../../config';
 import { CacheExpiredError } from '../../utils/errors';
-import { MPEModule } from 'types/mpe';
+import type { MPEModule } from 'types/mpe';
 
 const defaultExpiry = 24 * 60; // 1 day
 

--- a/scrapers/nus-v2/src/services/io/fs.ts
+++ b/scrapers/nus-v2/src/services/io/fs.ts
@@ -21,6 +21,7 @@ import { Venue, VenueInfo } from '../../types/venues';
 import { Cache, Persist } from '../../types/persist';
 import config from '../../config';
 import { CacheExpiredError } from '../../utils/errors';
+import { MPEModule } from 'types/mpe';
 
 const defaultExpiry = 24 * 60; // 1 day
 
@@ -100,6 +101,10 @@ export function getFileSystemWriter(academicYear: string): Persist {
     // List of partial module info for module finder
     moduleInfo: (data: ModuleInformation[]) =>
       fs.outputJSON(path.join(yearRoot, 'moduleInfo.json'), data, writeOptions),
+
+    // List of modules that are participating in NUS's module planning exercise (MPE)
+    mpeModules: (data: MPEModule[]) =>
+      fs.outputJSON(path.join(yearRoot, 'mpeModules.json'), data, writeOptions),
 
     // DEPRECATED. TODO: Remove after AY19/20 starts.
     // List of partial module info for module finder

--- a/scrapers/nus-v2/src/services/io/fs.ts
+++ b/scrapers/nus-v2/src/services/io/fs.ts
@@ -7,6 +7,7 @@
 import * as fs from 'fs-extra';
 import path from 'path';
 
+import type { MPEModule } from '../../types/mpe';
 import {
   Aliases,
   Module,
@@ -21,7 +22,6 @@ import { Venue, VenueInfo } from '../../types/venues';
 import { Cache, Persist } from '../../types/persist';
 import config from '../../config';
 import { CacheExpiredError } from '../../utils/errors';
-import type { MPEModule } from 'types/mpe';
 
 const defaultExpiry = 24 * 60; // 1 day
 

--- a/scrapers/nus-v2/src/services/io/index.ts
+++ b/scrapers/nus-v2/src/services/io/index.ts
@@ -9,6 +9,7 @@ import type {
   Semester,
   SemesterData,
 } from '../../types/modules';
+import { MPEModule } from '../../types/mpe';
 import type { Venue, VenueInfo } from '../../types/venues';
 
 import { getFileSystemWriter } from './fs';
@@ -34,6 +35,10 @@ export class CombinedPersist implements Persist {
 
   async moduleInfo(data: ModuleInformation[]) {
     await Promise.all(this.writers.map((writer) => writer.moduleInfo(data)));
+  }
+
+  async mpeModules(data: MPEModule[]) {
+    await Promise.all(this.writers.map((writer) => writer.mpeModules(data)));
   }
 
   async moduleInformation(data: ModuleInformation[]) {

--- a/scrapers/nus-v2/src/services/io/index.ts
+++ b/scrapers/nus-v2/src/services/io/index.ts
@@ -9,7 +9,7 @@ import type {
   Semester,
   SemesterData,
 } from '../../types/modules';
-import { MPEModule } from '../../types/mpe';
+import type { MPEModule } from '../../types/mpe';
 import type { Venue, VenueInfo } from '../../types/venues';
 
 import { getFileSystemWriter } from './fs';

--- a/scrapers/nus-v2/src/tasks/CollateModules.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.ts
@@ -118,10 +118,15 @@ const getModuleCondensed = ({
   moduleCode,
   title,
   semesterData,
+  attributes,
 }: ModuleWithoutTree): ModuleCondensed => ({
   moduleCode,
   title,
   semesters: semesterData.map((semester) => semester.semester),
+  // Flag that marks if module is included in Semester 1's Module Preference Exercise
+  mpes1: attributes?.mpes1 ?? false,
+  // Flag that marks if module is included in Semester 2's Module Preference Exercise
+  mpes2: attributes?.mpes2 ?? false,
 });
 
 // Avoid using _.pick here because it is not type safe

--- a/scrapers/nus-v2/src/tasks/CollateModules.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.ts
@@ -9,7 +9,7 @@ import {
   SemesterModuleData,
 } from '../types/mapper';
 import { Module, ModuleCode, ModuleCondensed, ModuleInformation } from '../types/modules';
-import { MPEModule } from '../types/mpe';
+import type { MPEModule } from '../types/mpe';
 
 import BaseTask from './BaseTask';
 import config from '../config';
@@ -225,7 +225,7 @@ export default class CollateModules extends BaseTask implements Task<Input, Outp
 
     await Promise.all([
       this.io.moduleList(moduleCondensed),
-      this.io.mpeModules(moduleInfo),
+      this.io.mpeModules(mpeModules),
       this.io.moduleInfo(moduleInfo),
       this.io.moduleAliases(combinedAliases),
     ]);

--- a/scrapers/nus-v2/src/types/modules.ts
+++ b/scrapers/nus-v2/src/types/modules.ts
@@ -99,8 +99,8 @@ export type NUSModuleAttributes = Partial<{
   ism: boolean; // Independent study
   urop: boolean; // Undergraduate Research Opportunities Program
   fyp: boolean; // Honours / Final Year Project
-  mpes1: boolean; // Included in Semester 1's Module Preference Exercise
-  mpes2: boolean; // Included in Semester 2's Module Preference Exercise
+  mpes1: boolean; // Included in Semester 1's Module Planning Exercise
+  mpes2: boolean; // Included in Semester 2's Module Planning Exercise
 }>;
 
 // Information for a module for a particular academic year.

--- a/scrapers/nus-v2/src/types/modules.ts
+++ b/scrapers/nus-v2/src/types/modules.ts
@@ -138,6 +138,10 @@ export type ModuleCondensed = Readonly<{
   moduleCode: ModuleCode;
   title: ModuleTitle;
   semesters: number[];
+  // Flag that marks if module is included in Semester 1's Module Preference Exercise
+  mpes1: boolean;
+  // Flag that marks if module is included in Semester 2's Module Preference Exercise
+  mpes2: boolean;
 }>;
 
 // This format is returned from the module information endpoint

--- a/scrapers/nus-v2/src/types/modules.ts
+++ b/scrapers/nus-v2/src/types/modules.ts
@@ -138,10 +138,6 @@ export type ModuleCondensed = Readonly<{
   moduleCode: ModuleCode;
   title: ModuleTitle;
   semesters: number[];
-  // Flag that marks if module is included in Semester 1's Module Preference Exercise
-  mpes1: boolean;
-  // Flag that marks if module is included in Semester 2's Module Preference Exercise
-  mpes2: boolean;
 }>;
 
 // This format is returned from the module information endpoint

--- a/scrapers/nus-v2/src/types/mpe.ts
+++ b/scrapers/nus-v2/src/types/mpe.ts
@@ -1,0 +1,8 @@
+import { ModuleCode } from './modules';
+
+// This format is returned from the MPE modules endpoint.
+export type MPEModule = Readonly<{
+  moduleCode: ModuleCode;
+  inS1MPE?: boolean;
+  inS2MPE?: boolean;
+}>;

--- a/scrapers/nus-v2/src/types/persist.ts
+++ b/scrapers/nus-v2/src/types/persist.ts
@@ -8,7 +8,7 @@ import {
   Semester,
   SemesterData,
 } from './modules';
-import { MPEModule } from './mpe';
+import type { MPEModule } from './mpe';
 import { Venue, VenueInfo } from './venues';
 
 /**

--- a/scrapers/nus-v2/src/types/persist.ts
+++ b/scrapers/nus-v2/src/types/persist.ts
@@ -8,6 +8,7 @@ import {
   Semester,
   SemesterData,
 } from './modules';
+import { MPEModule } from './mpe';
 import { Venue, VenueInfo } from './venues';
 
 /**
@@ -19,6 +20,9 @@ export interface Persist {
 
   // List of partial module info for module finder
   moduleInfo: (data: ModuleInformation[]) => Promise<void>;
+
+  // List of MPE module info for NUS's module planning exercise
+  mpeModules: (data: MPEModule[]) => Promise<void>;
 
   // DEPRECATED. TODO: Remove after AY19/20 starts.
   // List of partial module info for module finder

--- a/scrapers/nus-v2/src/utils/mpe.ts
+++ b/scrapers/nus-v2/src/utils/mpe.ts
@@ -1,0 +1,6 @@
+import { Module } from '../types/modules';
+
+// eslint-disable-next-line import/prefer-default-export
+export function isModuleInMPE({ attributes }: Module): boolean {
+  return !!attributes?.mpes1 || !!attributes?.mpes2;
+}

--- a/website/src/types/modules.ts
+++ b/website/src/types/modules.ts
@@ -149,10 +149,6 @@ export type ModuleCondensed = Readonly<{
   moduleCode: ModuleCode;
   title: ModuleTitle;
   semesters: readonly number[];
-  // Flag that marks if module is included in Semester 1's Module Preference Exercise
-  mpes1?: boolean;
-  // Flag that marks if module is included in Semester 2's Module Preference Exercise
-  mpes2?: boolean;
 }>;
 
 // This format is returned from the module information endpoint

--- a/website/src/types/modules.ts
+++ b/website/src/types/modules.ts
@@ -149,6 +149,10 @@ export type ModuleCondensed = Readonly<{
   moduleCode: ModuleCode;
   title: ModuleTitle;
   semesters: readonly number[];
+  // Flag that marks if module is included in Semester 1's Module Preference Exercise
+  mpes1?: boolean;
+  // Flag that marks if module is included in Semester 2's Module Preference Exercise
+  mpes2?: boolean;
 }>;
 
 // This format is returned from the module information endpoint


### PR DESCRIPTION
Follow up of #3241.

MPE frontend requires filtering of all modules by whether they are participating in MPE for that semester. The way the frontend currently fetches module data means that we only know if the MPE attributes are present only after we view the module's detail page.

<s>
This PR exposes the MPE attributes to the `moduleList` endpoint, so that the frontend can fetch the MPE attributes of every module from the API.

Note: This is not ideal. This couples our `moduleList` endpoint to MPE, which is a NUS-specific thing. Might need further clean up in the future to extract the MPE data to:
1. A separate endpoint on the scraper
</s>

This PR creates a new endpoint  `mpeModules` which exposes only the modules that are participating in MPE, along with the semesters they are participating in.