### PR TITLE
Add title and module credit to MPE endpoint

### DIFF
--- a/scrapers/nus-v2/src/tasks/CollateModules.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.ts
@@ -126,8 +126,15 @@ const getModuleCondensed = ({
   semesters: semesterData.map((semester) => semester.semester),
 });
 
-const getModuleMPEParticipation = ({ moduleCode, attributes }: ModuleWithoutTree): MPEModule => ({
+const getModuleMPEParticipation = ({
+  title,
   moduleCode,
+  moduleCredit,
+  attributes,
+}: ModuleWithoutTree): MPEModule => ({
+  title,
+  moduleCode,
+  moduleCredit,
   inS1MPE: attributes?.mpes1,
   inS2MPE: attributes?.mpes2,
 });

--- a/scrapers/nus-v2/src/types/mpe.ts
+++ b/scrapers/nus-v2/src/types/mpe.ts
@@ -1,8 +1,10 @@
-import { ModuleCode } from './modules';
+import { ModuleCode, ModuleTitle } from './modules';
 
 // This format is returned from the MPE modules endpoint.
 export type MPEModule = Readonly<{
+  title: ModuleTitle;
   moduleCode: ModuleCode;
+  moduleCredit: string;
   inS1MPE?: boolean;
   inS2MPE?: boolean;
 }>;

--- a/scrapers/nus-v2/src/utils/mpe.ts
+++ b/scrapers/nus-v2/src/utils/mpe.ts
@@ -2,5 +2,5 @@ import { Module } from '../types/modules';
 
 // eslint-disable-next-line import/prefer-default-export
 export function isModuleInMPE({ attributes }: Module): boolean {
-  return !!attributes?.mpes1 || !!attributes?.mpes2;
+  return Boolean(attributes?.mpes1 || attributes?.mpes2);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

Since the only thing we need for the frontend are the module title and the number of MCs we can push all these data into the list to simplify the frontend. We are loading the module title twice - might be a good idea to look it up via moduleList on the frontend instead? Might not be worth it if it makes the frontend more complicated though 

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
