### PR TITLE
Improve intended MCs input field empty state

### DIFF
--- a/website/src/views/mpe/form/ModuleCard.scss
+++ b/website/src/views/mpe/form/ModuleCard.scss
@@ -79,7 +79,6 @@
     flex-direction: column;
     align-self: center;
     padding-left: 0;
-    align-self: center;
   }
 
   .moduleType {

--- a/website/src/views/mpe/form/ModuleCard.scss
+++ b/website/src/views/mpe/form/ModuleCard.scss
@@ -78,6 +78,7 @@
   .container {
     flex-direction: column;
     padding-left: 0;
+    align-self: center;
   }
 
   .moduleType {

--- a/website/src/views/mpe/form/ModuleForm.tsx
+++ b/website/src/views/mpe/form/ModuleForm.tsx
@@ -115,12 +115,8 @@ const ModuleForm: React.FC<Props> = ({
     });
   };
 
-  // TODO: Remove leading/padded zero for the intended MCs to take field.
   const updateIntendedMCs = (moduleCredits: number) => {
-    if (Number.isNaN(moduleCredits)) {
-      return;
-    }
-
+    if (Number.isNaN(moduleCredits)) return;
     updateSubmission({
       intendedMCs: moduleCredits,
       preferences,
@@ -164,7 +160,7 @@ const ModuleForm: React.FC<Props> = ({
             min="0"
             inputMode="numeric"
             className="form-control"
-            value={intendedMCs}
+            defaultValue={intendedMCs}
             onChange={(e) => updateIntendedMCs(parseInt(e.target.value, 10))}
           />
         </div>

--- a/website/src/views/mpe/form/ModuleForm.tsx
+++ b/website/src/views/mpe/form/ModuleForm.tsx
@@ -35,6 +35,9 @@ const ModuleForm: React.FC<Props> = ({
   const [intendedMCs, setIntendedMCs] = useState<MpeSubmission['intendedMCs']>(
     initialSubmission.intendedMCs,
   );
+  const [intendedMCsInput, setIntendedMCsInput] = useState<string>(
+    initialSubmission.intendedMCs.toString(),
+  );
   const [preferences, setPreferences] = useState<MpePreference[]>(initialSubmission.preferences);
   const [isUpdating, setIsUpdating] = useState(false);
   const [updateError, setUpdateError] = useState<Error>();
@@ -160,8 +163,14 @@ const ModuleForm: React.FC<Props> = ({
             min="0"
             inputMode="numeric"
             className="form-control"
-            defaultValue={intendedMCs}
-            onChange={(e) => updateIntendedMCs(parseInt(e.target.value, 10))}
+            value={intendedMCsInput}
+            onChange={(e) => {
+              setIntendedMCsInput(e.target.value);
+              const moduleCredits = parseInt(e.target.value, 10);
+              if (Number.isNaN(moduleCredits)) return;
+              updateIntendedMCs(moduleCredits);
+            }}
+            onBlur={() => setIntendedMCsInput(intendedMCs.toString())}
           />
         </div>
       </label>


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->
## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
In the existing intended MCs input field, there will always be at least one digit left to ensure that autosave would update with at least a numerical value. However, this constraint has caused some frustrating experience, e.g. if the current value in the input is `1`, someone who wants to type in `20` MCs would have to add `20` after `1` first (resulting in `120`), then navigate backwards to remove `1`.

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
A new state is introduced to maintain the intended MCs input field state separately. When user backspaces all the way in the field, the field will reflect the changes but not trigger the autosave. If a user enters a valid numerical value however, the main `intendedMCs` state will be updated, along with the API call that follows. If a user leaves the input field empty and clicks elsewhere, the input field will automatically repopulate their latest intended MCs count from the `intendedMCs` state.

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
NIL
