### PR TITLE
Rename misnamed variable from `prereq` to `dependent`

### DIFF
--- a/website/src/views/modules/ModuleTree.scss
+++ b/website/src/views/modules/ModuleTree.scss
@@ -111,7 +111,7 @@ $connector-size: 0.75rem;
   }
 }
 
-.prereqBranch {
+.dependentBranch {
   &::before,
   &::after {
     right: 0;
@@ -119,7 +119,7 @@ $connector-size: 0.75rem;
   }
 }
 
-.prereqNode {
+.dependentNode {
   margin: 0 $connector-size 1px 0;
 
   &::before {

--- a/website/src/views/modules/ModuleTree.tsx
+++ b/website/src/views/modules/ModuleTree.tsx
@@ -17,7 +17,7 @@ type Props = {
 interface TreeDisplay {
   layer: number;
   node: PrereqTree;
-  isPrereq?: boolean;
+  isDependent?: boolean;
 }
 
 const formatConditional = (name: string) => (name === 'or' ? 'one of' : 'all of');
@@ -38,7 +38,7 @@ const Branch: React.FC<{ nodes: PrereqTree[]; layer: number }> = (props) => (
 );
 
 const Tree: React.FC<TreeDisplay> = (props) => {
-  const { layer, node, isPrereq } = props;
+  const { layer, node, isDependent } = props;
 
   const isConditional = typeof node !== 'string';
   const name = nodeName(node);
@@ -49,7 +49,7 @@ const Tree: React.FC<TreeDisplay> = (props) => {
         className={classnames(styles.node, {
           [`hoverable color-${layer}`]: !isConditional,
           [styles.conditional]: isConditional,
-          [styles.prereqNode]: isPrereq,
+          [styles.dependentNode]: isDependent,
         })}
       >
         {isConditional ? (
@@ -76,9 +76,9 @@ const ModuleTree: React.FC<Props> = (props) => {
               {fulfillRequirements.map((fulfilledModule) => (
                 <li
                   key={fulfilledModule}
-                  className={classnames(styles.branch, styles.prereqBranch)}
+                  className={classnames(styles.branch, styles.dependentBranch)}
                 >
-                  <Tree layer={0} node={fulfilledModule} isPrereq />
+                  <Tree layer={0} node={fulfilledModule} isDependent />
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
In the "Prerequisite Tree/ Module Tree" portion of the code, the "dependent" modules (i.e. possible modules that one can take **after** taking the specified module) are misnamed as `prereq`s

## Implementation
Rename `prereq` to `dependent`.



## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->

The actual prerequisite tree is correctly named prerequisite tree.
