### PR TITLE
Pr/reverse prereq tree

### DIFF
--- a/website/src/views/modules/ModuleTree.scss
+++ b/website/src/views/modules/ModuleTree.scss
@@ -42,12 +42,12 @@ $connector-size: 0.75rem;
   justify-content: center;
   align-items: center;
   padding: 0.125rem 0.25rem;
-  margin: 0 0 1px $connector-size;
+  margin: 0 $connector-size 1px $connector-size;
   border-radius: $btn-border-radius;
 
-  &::before {
-    top: 50%;
-    left: -$connector-size;
+  &::after {
+    bottom: 50%;
+    right: -$connector-size;
     width: $connector-size;
     height: 1px;
   }
@@ -64,6 +64,7 @@ $connector-size: 0.75rem;
 }
 
 .node::before,
+.node::after,
 .conditional::after,
 .branch::before,
 .branch::after {
@@ -77,9 +78,9 @@ $connector-size: 0.75rem;
   margin-right: $connector-size;
   border: 0;
 
-  &::after {
-    top: 50%;
-    right: -$connector-size;
+  &::before {
+    bottom: 50%;
+    left: -$connector-size;
     width: $connector-size;
     height: 1px;
   }
@@ -92,7 +93,7 @@ $connector-size: 0.75rem;
 
   &::before,
   &::after {
-    left: 0;
+    right: 0;
     width: 1px;
     height: 50%;
   }
@@ -114,16 +115,18 @@ $connector-size: 0.75rem;
 .prereqBranch {
   &::before,
   &::after {
-    right: 0;
+    right: auto;
     left: auto;
   }
 }
 
 .prereqNode {
-  margin: 0 $connector-size 1px 0;
+  margin: 0 0 1px $connector-size;
 
-  &::before {
-    right: -$connector-size;
-    left: auto;
+  &::after {
+    bottom: 50%;
+    left: -$connector-size;
+    width: $connector-size;
+    height: 1px;
   }
 }

--- a/website/src/views/modules/ModuleTree.scss
+++ b/website/src/views/modules/ModuleTree.scss
@@ -5,10 +5,11 @@ $connector-size: 0.75rem;
 .container {
   display: flex;
   overflow-y: auto;
+  justify-content: left;
   align-items: center;
   // Leave some space for the tooltip
   padding: 3rem 0;
-  justify-content: left;
+  
 
   @include media-breakpoint-up(sm) {
     justify-content: center;
@@ -30,10 +31,10 @@ $connector-size: 0.75rem;
 
 .tree,
 .prereqTree {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  position: relative;
   list-style: none;
   width: max-content;
   padding: 0;
@@ -56,8 +57,8 @@ $connector-size: 0.75rem;
   border-radius: $btn-border-radius;
 
   &::after {
-    bottom: 50%;
     right: -$connector-size;
+    bottom: 50%;
     width: $connector-size;
     height: 1px;
   }
@@ -131,8 +132,8 @@ $connector-size: 0.75rem;
 }
 
 .prereqNode {
-  margin: 0.5px 0 0.5px $connector-size;
   flex: 0 0 5rem;
+  margin: 0.5px 0 0.5px $connector-size;
 
   &::after {
     bottom: 50%;

--- a/website/src/views/modules/ModuleTree.scss
+++ b/website/src/views/modules/ModuleTree.scss
@@ -8,6 +8,7 @@ $connector-size: 0.75rem;
   align-items: center;
   // Leave some space for the tooltip
   padding: 3rem 0;
+  justify-content: left;
 
   @include media-breakpoint-up(sm) {
     justify-content: center;
@@ -20,7 +21,8 @@ $connector-size: 0.75rem;
     margin: 0;
     font-size: 1.1rem;
 
-    &::before {
+    &::before,
+    &::after {
       display: none;
     }
   }
@@ -28,11 +30,19 @@ $connector-size: 0.75rem;
 
 .tree,
 .prereqTree {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   position: relative;
   list-style: none;
+  width: max-content;
   padding: 0;
   margin: 0.125rem 0;
   text-align: center;
+
+  &.prereqTree {
+    align-items: flex-start;
+  }
 }
 
 .node {
@@ -42,7 +52,7 @@ $connector-size: 0.75rem;
   justify-content: center;
   align-items: center;
   padding: 0.125rem 0.25rem;
-  margin: 0 $connector-size 1px $connector-size;
+  margin: 0.5px $connector-size;
   border-radius: $btn-border-radius;
 
   &::after {
@@ -121,7 +131,8 @@ $connector-size: 0.75rem;
 }
 
 .prereqNode {
-  margin: 0 0 1px $connector-size;
+  margin: 0.5px 0 0.5px $connector-size;
+  flex: 0 0 5rem;
 
   &::after {
     bottom: 50%;

--- a/website/src/views/modules/ModuleTree.tsx
+++ b/website/src/views/modules/ModuleTree.tsx
@@ -20,7 +20,7 @@ interface TreeDisplay {
   isPrereq?: boolean;
 }
 
-const formatConditional = (name: string) => (name === 'or' ? 'one of' : 'all of');
+const formatConditional = (name: string) => (name === 'or' ? 'any' : 'all');
 
 const nodeName = (node: PrereqTree) => (typeof node === 'string' ? node : Object.keys(node)[0]);
 
@@ -42,6 +42,7 @@ const Tree: React.FC<TreeDisplay> = (props) => {
 
   const isConditional = typeof node !== 'string';
   const name = nodeName(node);
+  const isConditionalAllOf = name === 'and';
 
   return (
     <>
@@ -51,6 +52,7 @@ const Tree: React.FC<TreeDisplay> = (props) => {
           [`hoverable color-${layer}`]: !isConditional,
           [styles.conditional]: isConditional,
           [styles.prereqNode]: isPrereq,
+          [styles.allOf]: isConditionalAllOf,
         })}
       >
         {isConditional ? (
@@ -66,8 +68,6 @@ const Tree: React.FC<TreeDisplay> = (props) => {
 const ModuleTree: React.FC<Props> = (props) => {
   const { fulfillRequirements, prereqTree, moduleCode } = props;
 
-  console.log(prereqTree);
-
   return (
     <>
       <div className={styles.container}>
@@ -82,10 +82,10 @@ const ModuleTree: React.FC<Props> = (props) => {
           </li>
         </ul>
 
-        <div className={classnames(styles.node, styles.conditional)}>needs</div>
-
         {fulfillRequirements && fulfillRequirements.length > 0 && (
           <>
+            <div className={classnames(styles.node, styles.conditional)}>is needed for</div>
+
             <ul className={styles.prereqTree}>
               {fulfillRequirements.map((fulfilledModule) => (
                 <li

--- a/website/src/views/modules/ModuleTree.tsx
+++ b/website/src/views/modules/ModuleTree.tsx
@@ -45,6 +45,7 @@ const Tree: React.FC<TreeDisplay> = (props) => {
 
   return (
     <>
+      {isConditional && <Branch nodes={unwrapLayer(node)} layer={layer + 1} />}
       <div
         className={classnames(styles.node, {
           [`hoverable color-${layer}`]: !isConditional,
@@ -58,8 +59,6 @@ const Tree: React.FC<TreeDisplay> = (props) => {
           <LinkModuleCodes className={styles.link}>{name}</LinkModuleCodes>
         )}
       </div>
-
-      {isConditional && <Branch nodes={unwrapLayer(node)} layer={layer + 1} />}
     </>
   );
 };
@@ -67,9 +66,24 @@ const Tree: React.FC<TreeDisplay> = (props) => {
 const ModuleTree: React.FC<Props> = (props) => {
   const { fulfillRequirements, prereqTree, moduleCode } = props;
 
+  console.log(prereqTree);
+
   return (
     <>
       <div className={styles.container}>
+        <ul className={classnames(styles.tree, styles.root)}>
+          <li className={classnames(styles.branch)}>
+            {prereqTree && <Branch nodes={[prereqTree]} layer={2} />}
+          </li>
+        </ul>
+        <ul className={classnames(styles.tree, styles.root)}>
+          <li className={classnames(styles.branch)}>
+            <Tree layer={1} node={moduleCode} />
+          </li>
+        </ul>
+
+        <div className={classnames(styles.node, styles.conditional)}>needs</div>
+
         {fulfillRequirements && fulfillRequirements.length > 0 && (
           <>
             <ul className={styles.prereqTree}>
@@ -82,18 +96,8 @@ const ModuleTree: React.FC<Props> = (props) => {
                 </li>
               ))}
             </ul>
-
-            <div className={classnames(styles.node, styles.conditional)}>needs</div>
           </>
         )}
-
-        <ul className={classnames(styles.tree, styles.root)}>
-          <li className={classnames(styles.branch)}>
-            <Tree layer={1} node={moduleCode} />
-
-            {prereqTree && <Branch nodes={[prereqTree]} layer={2} />}
-          </li>
-        </ul>
       </div>
 
       <p className="alert alert-warning">

--- a/website/src/views/modules/__snapshots__/ModuleTree.test.tsx.snap
+++ b/website/src/views/modules/__snapshots__/ModuleTree.test.tsx.snap
@@ -6,90 +6,23 @@ Array [
     class="container"
   >
     <ul
-      class="prereqTree"
-    >
-      <li
-        class="branch prereqBranch"
-      >
-        <div
-          class="node hoverable color-0 prereqNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            CS5242
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch prereqBranch"
-      >
-        <div
-          class="node hoverable color-0 prereqNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            CS5339
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch prereqBranch"
-      >
-        <div
-          class="node hoverable color-0 prereqNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            CS6281
-          </mockedlink>
-        </div>
-      </li>
-    </ul>
-    <div
-      class="node conditional"
-    >
-      needs
-    </div>
-    <ul
       class="tree root"
     >
       <li
         class="branch"
       >
-        <div
-          class="node hoverable color-1"
-        >
-          <mockedlink
-            class="link"
-          >
-            CS3244
-          </mockedlink>
-        </div>
         <ul
           class="tree"
         >
           <li
             class="branch"
           >
-            <div
-              class="node conditional"
-            >
-              all of
-            </div>
             <ul
               class="tree"
             >
               <li
                 class="branch"
               >
-                <div
-                  class="node conditional"
-                >
-                  one of
-                </div>
                 <ul
                   class="tree"
                 >
@@ -146,15 +79,15 @@ Array [
                     </div>
                   </li>
                 </ul>
+                <div
+                  class="node conditional"
+                >
+                  any
+                </div>
               </li>
               <li
                 class="branch"
               >
-                <div
-                  class="node conditional"
-                >
-                  one of
-                </div>
                 <ul
                   class="tree"
                 >
@@ -237,15 +170,15 @@ Array [
                     </div>
                   </li>
                 </ul>
+                <div
+                  class="node conditional"
+                >
+                  any
+                </div>
               </li>
               <li
                 class="branch"
               >
-                <div
-                  class="node conditional"
-                >
-                  one of
-                </div>
                 <ul
                   class="tree"
                 >
@@ -289,15 +222,15 @@ Array [
                     </div>
                   </li>
                 </ul>
+                <div
+                  class="node conditional"
+                >
+                  any
+                </div>
               </li>
               <li
                 class="branch"
               >
-                <div
-                  class="node conditional"
-                >
-                  one of
-                </div>
                 <ul
                   class="tree"
                 >
@@ -341,10 +274,85 @@ Array [
                     </div>
                   </li>
                 </ul>
+                <div
+                  class="node conditional"
+                >
+                  any
+                </div>
               </li>
             </ul>
+            <div
+              class="node conditional allOf"
+            >
+              all
+            </div>
           </li>
         </ul>
+      </li>
+    </ul>
+    <ul
+      class="tree root"
+    >
+      <li
+        class="branch"
+      >
+        <div
+          class="node hoverable color-1"
+        >
+          <mockedlink
+            class="link"
+          >
+            CS3244
+          </mockedlink>
+        </div>
+      </li>
+    </ul>
+    <div
+      class="node conditional"
+    >
+      is needed for
+    </div>
+    <ul
+      class="prereqTree"
+    >
+      <li
+        class="branch prereqBranch"
+      >
+        <div
+          class="node hoverable color-0 prereqNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            CS5242
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch prereqBranch"
+      >
+        <div
+          class="node hoverable color-0 prereqNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            CS5339
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch prereqBranch"
+      >
+        <div
+          class="node hoverable color-0 prereqNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            CS6281
+          </mockedlink>
+        </div>
       </li>
     </ul>
   </div>,
@@ -361,6 +369,35 @@ Array [
   <div
     class="container"
   >
+    <ul
+      class="tree root"
+    >
+      <li
+        class="branch"
+      />
+    </ul>
+    <ul
+      class="tree root"
+    >
+      <li
+        class="branch"
+      >
+        <div
+          class="node hoverable color-1"
+        >
+          <mockedlink
+            class="link"
+          >
+            ACC1002
+          </mockedlink>
+        </div>
+      </li>
+    </ul>
+    <div
+      class="node conditional"
+    >
+      is needed for
+    </div>
     <ul
       class="prereqTree"
     >
@@ -543,28 +580,6 @@ Array [
             class="link"
           >
             FIN4115
-          </mockedlink>
-        </div>
-      </li>
-    </ul>
-    <div
-      class="node conditional"
-    >
-      needs
-    </div>
-    <ul
-      class="tree root"
-    >
-      <li
-        class="branch"
-      >
-        <div
-          class="node hoverable color-1"
-        >
-          <mockedlink
-            class="link"
-          >
-            ACC1002
           </mockedlink>
         </div>
       </li>


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
Fixes #3202 
<!-- Or provide a brief explanation about the problem -->
This issue requests the reversal of the orientation of the prerequisite tree in the module page.

## Implementation
<!-- Explain how your solution solves the problem -->
I have edited moduletree.tsx and moduletree.scss to reverse the order of the prerequisite tree. Then, I changed some of the words used to make the new format clearer. Finally, I updated the snapshots in moduletree.test.tsx to reflect the change in UI.
<!-- If it affects UI, an image or gif is greatly encouraged. -->
**For a single mod, with no prerequisite or dependant:**
![image](https://user-images.githubusercontent.com/71116618/123500770-fdf15700-d672-11eb-9d58-f26053774cfa.png)

**For mods with only dependants:**
![image](https://user-images.githubusercontent.com/71116618/123500789-20837000-d673-11eb-9c80-f594ce42b945.png)

**For mods with one layer of prerequisites and dependants:**
![image](https://user-images.githubusercontent.com/71116618/123500805-3f820200-d673-11eb-8ae9-665e7daee172.png)

**For mods with two layers of prerequisites:**
![image](https://user-images.githubusercontent.com/71116618/123500823-5f192a80-d673-11eb-8053-53811d73279d.png)

**For mods with uneven layers of prerequisites:**
![image](https://user-images.githubusercontent.com/71116618/123500850-81ab4380-d673-11eb-9748-fbc9f8f7903e.png)

**For mods with uneven letters in prerequisites:**
![image](https://user-images.githubusercontent.com/71116618/123500936-2594ef00-d674-11eb-934b-6864b6428d49.png)


## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
Hello, I think the code works in most cases that I've managed to test, both on desktop and mobile. However, I feel that there should be a way to 'fix' the uneven nodes featured in the last picture. Do you have any suggestions?

This is my first issue and pull request by the way, so I do apologize for any mistake on my part. Thank you for taking the time to read through it.