### PR TITLE
Fix query parameters being removed on module search retry

### DIFF
--- a/website/src/views/errors/ApiError.tsx
+++ b/website/src/views/errors/ApiError.tsx
@@ -3,6 +3,8 @@ import classnames from 'classnames';
 
 import RandomKawaii from 'views/components/RandomKawaii';
 import Title from 'views/components/Title';
+import { breakpointUp } from 'utils/css';
+
 import styles from './ErrorPage.scss';
 
 type Props = {
@@ -46,6 +48,17 @@ export default class ApiError extends React.PureComponent<Props> {
           </h1>
 
           <p>This could be because your device is offline or NUSMods is down :(</p>
+          {/* TODO: Remove hacky message after we figure out what is wrong with Elastic Search. */}
+          {dataName === 'module information' && (
+            <>
+              <strong>Module search might be having issues at the moment. 😟</strong>
+              <p>
+                If it isn't working, please try the module search{' '}
+                {window.innerWidth < breakpointUp('md').minWidth && 'on a desktop browser '}on the
+                top right corner of the page instead.
+              </p>
+            </>
+          )}
 
           {retry && (
             <div>

--- a/website/src/views/errors/ModuleFinderApiError.test.tsx
+++ b/website/src/views/errors/ModuleFinderApiError.test.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SearchkitManager } from 'searchkit';
+
+import renderWithRouterMatch from 'test-utils/renderWithRouterMatch';
+import ModuleFinderApiError from './ModuleFinderApiError';
+
+jest.mock('views/components/RandomKawaii');
+
+const mockedUrl = 'https://someEsUrl.com';
+const CANONICAL = '/modules?q=GER1000&sem[0]=1&sem[1]=2&sem[2]=3&sem[3]=4';
+
+const searchkit = new SearchkitManager(mockedUrl, {
+  searchUrlPath: '_search?track_total_hits=true',
+});
+
+describe(ModuleFinderApiError, () => {
+  test('should render', async () => {
+    const { container } = render(<ModuleFinderApiError searchkit={searchkit} />);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should render with url', async () => {
+    const { view } = renderWithRouterMatch(<ModuleFinderApiError searchkit={searchkit} />, {
+      path: '/modules',
+      location: CANONICAL,
+    });
+    const { container } = view;
+    expect(container).toMatchSnapshot();
+  });
+
+  test('should have unchanged url when search is retried', async () => {
+    const { history, view } = renderWithRouterMatch(
+      <ModuleFinderApiError searchkit={searchkit} />,
+      {
+        path: '/modules',
+        location: CANONICAL,
+      },
+    );
+    expect(history.location.pathname).toBe('/modules');
+    expect(history.location.search).toBe('?q=GER1000&sem[0]=1&sem[1]=2&sem[2]=3&sem[3]=4');
+
+    const { getByRole } = view;
+    searchkit.history = {
+      push: jest.fn(),
+    };
+    const tryAgainButton = getByRole('button');
+    userEvent.click(tryAgainButton);
+    expect(searchkit.history.push).toHaveBeenCalled();
+    expect(history.location.pathname).toBe('/modules');
+    expect(history.location.search).toBe('?q=GER1000&sem[0]=1&sem[1]=2&sem[2]=3&sem[3]=4');
+  });
+});

--- a/website/src/views/errors/ModuleFinderApiError.test.tsx
+++ b/website/src/views/errors/ModuleFinderApiError.test.tsx
@@ -29,6 +29,7 @@ describe(ModuleFinderApiError, () => {
     expect(container).toMatchSnapshot();
   });
 
+  // TODO: Tech Debt - Check if this test can correctly perform an assertion on `history`
   test('should have unchanged url when search is retried', async () => {
     const { history, view } = renderWithRouterMatch(
       <ModuleFinderApiError searchkit={searchkit} />,

--- a/website/src/views/errors/ModuleFinderApiError.tsx
+++ b/website/src/views/errors/ModuleFinderApiError.tsx
@@ -1,15 +1,13 @@
-import * as React from 'react';
+import React from 'react';
+import { SearchkitManager } from 'searchkit';
 import ApiError from './ApiError';
 
-// Should be defined in Searchkit, but it isn't exported.
-// https://github.com/searchkit/searchkit/blob/016c899c97f72ea3ad5afc017345e41c9003172a/packages/searchkit/src/components/search/hits/src/NoHitsErrorDisplay.tsx#L6
-// import { NoHitsErrorDisplayProps } from 'searchkit';
-type NoHitsErrorDisplayProps = {
-  resetSearchFn: () => void;
+type ModuleFinderApiErrorProps = {
+  searchkit: SearchkitManager;
 };
 
-const ModuleFinderApiError: React.FC<NoHitsErrorDisplayProps> = ({ resetSearchFn }) => (
-  <ApiError dataName="module information" retry={resetSearchFn} />
+const ModuleFinderApiError: React.FC<ModuleFinderApiErrorProps> = ({ searchkit }) => (
+  <ApiError dataName="module information" retry={() => searchkit.reloadSearch()} />
 );
 
 export default ModuleFinderApiError;

--- a/website/src/views/errors/__snapshots__/ModuleFinderApiError.test.tsx.snap
+++ b/website/src/views/errors/__snapshots__/ModuleFinderApiError.test.tsx.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModuleFinderApiError should render 1`] = `
+<div>
+  <div>
+    <div
+      class="container"
+    >
+      <div
+        class="header"
+      >
+        <div
+          data-testid="RandomKawaii component"
+        />
+      </div>
+      <h1
+        class="h3 header"
+      >
+        <span
+          class="expr"
+        >
+          Oh no...
+        </span>
+         
+        We can't load the module information
+      </h1>
+      <p>
+        This could be because your device is offline or NUSMods is down :(
+      </p>
+      <div>
+        <button
+          class="btn btn-primary btn-lg"
+          type="button"
+        >
+          Click to try again
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ModuleFinderApiError should render with url 1`] = `
+<div>
+  <div>
+    <div
+      class="container"
+    >
+      <div
+        class="header"
+      >
+        <div
+          data-testid="RandomKawaii component"
+        />
+      </div>
+      <h1
+        class="h3 header"
+      >
+        <span
+          class="expr"
+        >
+          Oh no...
+        </span>
+         
+        We can't load the module information
+      </h1>
+      <p>
+        This could be because your device is offline or NUSMods is down :(
+      </p>
+      <div>
+        <button
+          class="btn btn-primary btn-lg"
+          type="button"
+        >
+          Click to try again
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/website/src/views/errors/__snapshots__/ModuleFinderApiError.test.tsx.snap
+++ b/website/src/views/errors/__snapshots__/ModuleFinderApiError.test.tsx.snap
@@ -27,6 +27,14 @@ exports[`ModuleFinderApiError should render 1`] = `
       <p>
         This could be because your device is offline or NUSMods is down :(
       </p>
+      <strong>
+        Module search might be having issues at the moment. 😟
+      </strong>
+      <p>
+        If it isn't working, please try the module search
+         
+        on the top right corner of the page instead.
+      </p>
       <div>
         <button
           class="btn btn-primary btn-lg"
@@ -66,6 +74,14 @@ exports[`ModuleFinderApiError should render with url 1`] = `
       </h1>
       <p>
         This could be because your device is offline or NUSMods is down :(
+      </p>
+      <strong>
+        Module search might be having issues at the moment. 😟
+      </strong>
+      <p>
+        If it isn't working, please try the module search
+         
+        on the top right corner of the page instead.
       </p>
       <div>
         <button

--- a/website/src/views/modules/ModuleFinderContainer/ModuleFinderContainer.tsx
+++ b/website/src/views/modules/ModuleFinderContainer/ModuleFinderContainer.tsx
@@ -90,7 +90,7 @@ const ModuleFinderContainer: React.FC = () => (
             <NoHits
               suggestionsField="title"
               component={ModuleFinderNoHits}
-              errorComponent={ModuleFinderApiError}
+              errorComponent={<ModuleFinderApiError searchkit={searchkit} />}
             />
           </div>
 


### PR DESCRIPTION
## Context

Closes #3288

searchkit provided a default resetSearchFn for our ES modules search to reset the search. However, we used the resetSearchFn to retry the search instead, which is incorrect. This causes the query params to be cleared when the user attempts to retry the search.

Did this with @alissayarmantho - we were debugging together so the commits are tagged with her too!

## Implementation

We fix this by using the actual searchkit function to retry the search.