### PR TITLE
Fix module aliases false-positives in scraper

### DIFF
--- a/scrapers/nus-v2/README.md
+++ b/scrapers/nus-v2/README.md
@@ -49,7 +49,7 @@ We use ElasticSearch for our module search page. For local development it is not
 Run these through `yarn scrape` in production or `yarn dev` in development piped through `yarn bunyan` for formatting - eg. `yarn dev test | yarn bunyan`. You can also run `yarn dev help` to see a list of all commands.
 
 - `test` - run some simple API requests to check you have set everything up correctly
-- `department` - download department and faculty codes
+- `departments` - download department and faculty codes
 - `semester [sem]` - download module and timetable data for the given semester
 - `venue [sem]` - collate venue data into the shape needed by the frontend
 - `combine` - combine the module data for all four semesters together

--- a/scrapers/nus-v2/src/index.ts
+++ b/scrapers/nus-v2/src/index.ts
@@ -32,7 +32,8 @@ function run(fn: (...args: any[]) => Promise<any>) {
 
 const parameters: Record<string, yargs.Options> = {
   sem: {
-    choices: Semesters.map(String),
+    type: 'number',
+    choices: Semesters,
   },
   year: {
     type: 'string',
@@ -65,7 +66,7 @@ yargs
     handler: run(({ year }) => new GetFacultyDepartment(year).run()),
   })
   .command({
-    command: 'semester [year] <sem>',
+    command: 'semester <sem> [year]',
     describe: 'download all data for the given semester',
     builder: {
       sem: parameters.sem,

--- a/scrapers/nus-v2/src/tasks/CollateVenues.ts
+++ b/scrapers/nus-v2/src/tasks/CollateVenues.ts
@@ -9,7 +9,7 @@ import { Cache } from '../types/persist';
 import BaseTask from './BaseTask';
 import config from '../config';
 import { getTimeRange } from '../utils/time';
-import { mergeDualCodedModules } from '../utils/data';
+import { mergeDualCodedModules, modulesToAvoidMerging } from '../utils/data';
 import { union } from '../utils/set';
 
 /**
@@ -120,9 +120,10 @@ export default class CollateVenues extends BaseTask implements Task<Input, Outpu
         // Merge the alias mappings
         for (const [moduleCode, alias] of entries(aliases)) {
           // Only add the modules as alias if they have the same title
+          // and are not part of the avoid-list
           const title = moduleCodeToTitle[moduleCode];
           const filteredAliases = Array.from(alias).filter(
-            (module) => title === moduleCodeToTitle[module],
+            (module) => !modulesToAvoidMerging.has(title) && title === moduleCodeToTitle[module],
           );
 
           if (filteredAliases.length) {

--- a/scrapers/nus-v2/src/utils/data.ts
+++ b/scrapers/nus-v2/src/utils/data.ts
@@ -201,6 +201,12 @@ export const activityLessonType: Record<string, LessonType> = {
   ...unrecognizedLessonTypes,
 };
 
+export const modulesToAvoidMerging = new Set<string>([
+  'Programming Methodology',
+  'Data Structures and Algorithms',
+  'Graduate Research Seminar',
+]);
+
 export function isModuleOffered(module: {
   semesterData: (SemesterData | SemesterDataCondensed)[];
 }): boolean {

--- a/scrapers/nus-v2/src/utils/data.ts
+++ b/scrapers/nus-v2/src/utils/data.ts
@@ -201,6 +201,14 @@ export const activityLessonType: Record<string, LessonType> = {
   ...unrecognizedLessonTypes,
 };
 
+/**
+ * In COVID-19 times, there were many classes that had the same venues (E-Learn_A,
+ * E-Learn_B, E-Learn_C). This confused our algorithm to merge dual-coded modules
+ * and created lots of false positives for module aliases. This avoid-list specifies
+ * the names of the modules that should not be aliased with each other.
+ *
+ * See https://github.com/nusmodifications/nusmods/pull/3322
+ */
 export const modulesToAvoidMerging = new Set<string>([
   'Programming Methodology',
   'Data Structures and Algorithms',


### PR DESCRIPTION
## Context

Closes #2995 

This PR adds an avoid list for merging of dual-coded modules.

Yeah, I know this looks kind of hacky and isn't really a rule-based solution. Let me explain.

Currently, how the merging of dual coded module works is as follows:
1. Find modules with some classes with similar timings and **venues**
2. Check if these modules have the same name, if yes, merge them as dual coded modules

This breaks down slightly in today's E-Learning world because a lot of modules have the same venue (E-Learn_A, E-Learn_B, or E-Learn_C), and causes a lot of false-positives.

One way to avoid this is by excluding E-Learning modules from this merging algorithm, but I tried that and it gave me a lot of false-negatives (a lot of E-Learning modules also legitimately require merging). This is the implementation I tried:

![Screenshot 2021-07-07 at 9 36 57 PM](https://user-images.githubusercontent.com/4933577/124779370-4dd5f500-df74-11eb-9a7a-dc852aac4d68.png)

and the diff of the aliases.json: https://hastebin.com/goruralafi.shell (these are the aliases that got removed)

A lot of legitimate aliases ended up being removed.

## Current Implementation

But from the diff above, it helped me to sift through to see which are the mods that shouldn't be merged, and hence it helped me to arrive to this.

Note: To figure out if a mod should or shouldn't be aliased with another mod, I used 2019-2020 data as the "ground truth".

After this PR, these false-positive aliases will be removed: https://hastebin.com/satunekase.shell

Tested locally.
