### PR TITLE
Update Elasticsearch endpoint

### DIFF
--- a/website/src/config/app-config.json
+++ b/website/src/config/app-config.json
@@ -3,7 +3,7 @@
   "defaultDescription": "NUSMods is a timetable builder and knowledge platform, providing students with a better way to plan their school timetable and useful module-related information that are community-driven.",
   "academicYear": "2021/2022",
   "apiBaseUrl": "https://api.nusmods.com",
-  "elasticsearchBaseUrl": "https://382c4d616054428291bc86fdf4001a6e.ap-southeast-1.aws.found.io:9243",
+  "elasticsearchBaseUrl": "https://nusmods-search.es.ap-southeast-1.aws.found.io:9243",
   "semester": 1,
   "disqusShortname": "nusmods-prod",
   "venueFeedbackApi": "https://mediumdeviation.lib.id/nusmods-venue-github-hook@0.0.8/",

--- a/website/src/views/components/notfications/Announcements.tsx
+++ b/website/src/views/components/notfications/Announcements.tsx
@@ -17,6 +17,7 @@ const enableAnnouncements = true;
  * dismissible, set the key to null. Otherwise, set it to a string.
  *
  * Previous keys:
+ * - 'ay202122-2107-search-outage' - Module search outage apology
  * - 'ay202122-new-data' - AY2021/22 data is available
  * - 'ay202021-new-data' - AY2020/21 data is available
  * - 'ay201920-new-data' - AY2019/20 data is available


### PR DESCRIPTION
Now that our new ES deployment seems to be more stable than the previous one after a few days of monitoring (during ModReg round 1 which started on Thurs), and the previous one cannot be easily recovered - Elastic Cloud support says they were `unable to get it back up via force restarts or running what we call a 'no-op' plan (basically a reset) due to there being an issue with selecting a master node`, we will now only use the new deployment, and deprecate the old one.

Some stats from the new ES instance:
![image](https://user-images.githubusercontent.com/4933577/126837851-c67e3920-f381-401b-9ca8-b675928bd4c0.png)

The previous deployment had CPU usage constantly at > 100%, so this looks a lot healthier.

This should mean that the module search page will be a lot more stable.