### PR TITLE
Expand 'Coll.' abbrieviation in scraper

### DIFF
--- a/scrapers/nus-v2/src/tasks/GetFacultyDepartment.test.ts
+++ b/scrapers/nus-v2/src/tasks/GetFacultyDepartment.test.ts
@@ -12,6 +12,9 @@ describe(cleanNames, () => {
   test('should expand abbreviations', () => {
     expect(cleanNames('Sci Eng Mgmt')).toEqual('Science Engineering Management');
     expect(cleanNames('Arts & Social Sciences')).toEqual('Arts and Social Sciences');
+    expect(cleanNames('Coll. of Humanities & Sciences')).toEqual(
+      'College of Humanities and Sciences',
+    );
   });
 
   test('should not double expand', () => {

--- a/scrapers/nus-v2/src/tasks/GetFacultyDepartment.ts
+++ b/scrapers/nus-v2/src/tasks/GetFacultyDepartment.ts
@@ -22,10 +22,12 @@ const abbreviationMap = {
   Grad: 'Graduate',
   DO: "Dean's Office",
   Stud: 'Studies',
+  'Coll.': 'College',
 };
 
 const abbreviationRegex = map(abbreviationMap, (expanded, abbr): [RegExp, string] => [
-  new RegExp(`\\b${escapeRegExp(abbr)}\\b`, 'gi'),
+  // (?!\S) instead of \b because \b (word boundary) doesn't account for the . in "Coll."
+  new RegExp(`\\b${escapeRegExp(abbr)}(?!\\S)`, 'gi'),
   expanded,
 ]);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4933577/128642068-1a197a54-ce4d-4830-aa2c-064224c8e14d.png)

Currently CHS's name is written as "Coll. of Humanities and Sciences", because` The "College" is shorten due to length restriction.` (from RO staff over email).

This PR expands that abbrieviation.