### PR TITLE
Increase ModReg Notification's z-index to be over navtabs'

### DIFF
--- a/website/src/styles/constants.scss
+++ b/website/src/styles/constants.scss
@@ -184,7 +184,7 @@ $venue-map-z-index: 760;
 $venue-detail-z-index: 750;
 $side-menu-z-index: 700;
 $side-menu-overlay-z-index: 690;
-$modreg-notification-z-index: 500;
+$modreg-notification-z-index: 910;
 $timetable-warning-z-index: 200;
 $timetable-scolled-day-z-index: 120;
 $timetable-selected-cell-z-index: 110;


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
The currently-deployed NUSMods (https://github.com/nusmodifications/nusmods/commit/ebb5cf52b6f50b9a4179e1ede05b965668d40dd5) has an issue whereby the ModReg notification banner's z-index is incompatible with the side navigation tabs. It appears to be "sandwich"ed by the navigation tabs text and the timetable cells.
<img width="361" alt="image" src="https://user-images.githubusercontent.com/39089453/129067692-ef7e17da-7dc6-4654-9d6a-cdc4b1947835.png">

## Implementation
This PR resolves it by increasing the z-index of the ModReg Notification banner, specifically I have chosen a value that is slightly over the `$navtabs-z-index` variable. 

![image](https://user-images.githubusercontent.com/39089453/129071419-da744d6b-9342-48d8-ba2e-e5013f4478ea.png)

Attached is a video of the fixed version:
https://user-images.githubusercontent.com/39089453/129068200-7b75ba67-f69e-4e4b-b296-5660ae81c0c6.mp4

A slight point of discussion is that in the old version, the Navbar(?) z-index seems to be higher than the notifications:
OLD version:
<img width="389" alt="image" src="https://user-images.githubusercontent.com/39089453/129068413-afbf3125-dfee-4ca5-8111-cb89abe968f7.png">

This PR:
<img width="395" alt="image" src="https://user-images.githubusercontent.com/39089453/129070084-529b1b12-c9f0-4246-bf66-419faea8ae51.png">


I think in terms of UX, it might be unlikely that users would minimise the screen to an extent that the ModReg Notification banner reaches the top Navbar. Furthermore, I think either one might actually work. However, I am open to comments from the developers if the ModReg Notification Banner is intended to be covered by the Navbar.


## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
I'm not very proficient in frontend, but I was wondering how I could see the z-index of this component from the devtools?

I tried opening the devtools in Firefox and could not find the z-index CSS:
<img width="1162" alt="image" src="https://user-images.githubusercontent.com/39089453/129069339-d5bb9bb0-aae6-45c3-8374-c959ac3caf96.png">

I resolved this by finding the correct React component in the source code, and studying how this component is styled by its class, noticing that there is a `z-index` field for the `container`:
https://github.com/nusmodifications/nusmods/blob/ebb5cf52b6f50b9a4179e1ede05b965668d40dd5/website/src/views/components/notfications/ModRegNotification.scss#L5

Any help would be appreciated! Thank you very much.
