### PR TITLE
Prevent overscroll-behavior in scrollable timetable

### DIFF
--- a/website/src/views/timetable/TimetableContent.scss
+++ b/website/src/views/timetable/TimetableContent.scss
@@ -9,6 +9,7 @@
 .timetableWrapper {
   composes: scrollable from global;
   margin-bottom: 1rem;
+  overscroll-behavior: none;
 
   @include media-breakpoint-down(sm) {
     // Maximize the space taken by the timetable by overflowing into the grid gutters


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

https://user-images.githubusercontent.com/21200681/129133919-57191023-72bd-42c7-b11c-12f644f2ad89.mp4

In the TimeTable view, when there are multiple classes to be chosen for a certain module, exceeding the scroll boundary of the TimeTable causes to:
    1) navigate to the previous page (for scrolling in x-direction)
    2) triggering pull-to-refresh behavior on mobile phones (for scrolling in y-direction).

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

Set `overscroll-behavior` to be `none` so there is no scroll chaining to neighbouring scrolling areas. (ref: https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior).

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->

Can be tested with modules such as: `GEQ1000`.