### PR TITLE
Reduce Code Duplication in utils/ical

### DIFF
--- a/website/src/__mocks__/modules/CS1010S.json
+++ b/website/src/__mocks__/modules/CS1010S.json
@@ -12,6 +12,7 @@
     {
       "semester": 2,
       "examDate": "2018-05-07T17:00+0800",
+      "examDuration": 120,
       "timetable": [
         {
           "classNo": "1",
@@ -405,6 +406,7 @@
     {
       "semester": 1,
       "examDate": "2017-11-29T17:00+0800",
+      "examDuration": 120,
       "timetable": [
         {
           "classNo": "1",

--- a/website/src/utils/ical.ts
+++ b/website/src/utils/ical.ts
@@ -5,6 +5,7 @@ import { addDays, addMinutes, addWeeks, isValid } from 'date-fns';
 import {
   consumeWeeks,
   EndTime,
+  LessonTime,
   Module,
   NumericWeeks,
   RawLesson,
@@ -17,7 +18,7 @@ import { SemTimetableConfigWithLessons } from 'types/timetables';
 import config from 'config';
 import academicCalendar from 'data/academic-calendar';
 import { getModuleSemesterData } from 'utils/modules';
-import { parseDate } from './timify';
+import { getLessonTimeHours, getLessonTimeMinutes, parseDate } from './timify';
 
 const SG_UTC_TIME_DIFF_MS = 8 * 60 * 60 * 1000;
 export const RECESS_WEEK = -1;
@@ -34,8 +35,8 @@ function dayIndex(weekday: string) {
 /**
  * Parse out the hour component from a time string in the format of hhmm
  */
-export function getTimeHour(time: string) {
-  return parseInt(time.slice(0, 2), 10) + parseInt(time.slice(2), 10) / 60;
+export function getTimeHour(time: LessonTime) {
+  return getLessonTimeHours(time) + getLessonTimeMinutes(time) / 60;
 }
 
 function addLessonOffset(date: Date, hourOffset: number): Date {

--- a/website/src/utils/ical.ts
+++ b/website/src/utils/ical.ts
@@ -17,7 +17,7 @@ import { SemTimetableConfigWithLessons } from 'types/timetables';
 
 import config from 'config';
 import academicCalendar from 'data/academic-calendar';
-import { getModuleSemesterData } from 'utils/modules';
+import { getExamDate, getExamDuration } from 'utils/modules';
 import { getLessonTimeHours, getLessonTimeMinutes, parseDate } from './timify';
 
 const SG_UTC_TIME_DIFF_MS = 8 * 60 * 60 * 1000;
@@ -44,10 +44,7 @@ function addLessonOffset(date: Date, hourOffset: number): Date {
 }
 
 export function iCalEventForExam(module: Module, semester: Semester): EventOption | null {
-  const semesterData = getModuleSemesterData(module, semester);
-  if (!semesterData) return null;
-
-  const { examDate, examDuration } = semesterData;
+  const examDate = getExamDate(module, semester);
   if (!examDate) return null;
 
   const start = new Date(examDate);
@@ -55,7 +52,7 @@ export function iCalEventForExam(module: Module, semester: Semester): EventOptio
 
   return {
     start,
-    end: addMinutes(start, examDuration || DEFAULT_EXAM_DURATION),
+    end: addMinutes(start, getExamDuration(module, semester) || DEFAULT_EXAM_DURATION),
     summary: `${module.moduleCode} Exam`,
     description: module.title,
   };

--- a/website/src/utils/modules.test.ts
+++ b/website/src/utils/modules.test.ts
@@ -15,6 +15,7 @@ import {
   subtractAcadYear,
   isGraduateModule,
   renderExamDuration,
+  getExamDuration,
 } from 'utils/modules';
 import { noBreak } from 'utils/react';
 
@@ -101,9 +102,14 @@ test('formatExamDate should format an exam date string correctly', () => {
   expect(formatExamDate('2016-01-03T00:01:00.000Z')).toBe('03-Jan-2016 8:01 AM');
 });
 
-test('getModuleExamDate should return the correct exam date if it exists', () => {
+test('getExamDate should return the correct exam date if it exists', () => {
   expect(getExamDate(CS1010S, 1)).toBe('2017-11-29T17:00+0800');
   expect(getExamDate(CS3216, 2)).toBeFalsy();
+});
+
+test('getExamDuration should return the correct exam duration if it exists', () => {
+  expect(getExamDuration(CS1010S, 1)).toBe(120);
+  expect(getExamDuration(CS3216, 2)).toBeFalsy();
 });
 
 test('getFormattedModuleExamDate should return the correctly formatted exam timing if it exists', () => {

--- a/website/src/utils/modules.test.ts
+++ b/website/src/utils/modules.test.ts
@@ -109,7 +109,7 @@ test('getExamDate should return the correct exam date if it exists', () => {
 
 test('getExamDuration should return the correct exam duration if it exists', () => {
   expect(getExamDuration(CS1010S, 1)).toBe(120);
-  expect(getExamDuration(CS3216, 2)).toBeFalsy();
+  expect(getExamDuration(CS3216, 2)).toBe(null);
 });
 
 test('getFormattedModuleExamDate should return the correctly formatted exam timing if it exists', () => {

--- a/website/src/utils/modules.ts
+++ b/website/src/utils/modules.ts
@@ -57,6 +57,10 @@ export function getExamDate(module: Module, semester: Semester): string | null {
   return _.get(getModuleSemesterData(module, semester), 'examDate') || null;
 }
 
+export function getExamDuration(module: Module, semester: Semester): number | null {
+  return _.get(getModuleSemesterData(module, semester), 'examDuration') || null;
+}
+
 export function getFormattedExamDate(module: Module, semester: Semester): string {
   const examDate = getExamDate(module, semester);
   return formatExamDate(examDate);

--- a/website/src/utils/timify.test.ts
+++ b/website/src/utils/timify.test.ts
@@ -16,19 +16,17 @@ import {
 
 describe('getLessonTimeHours', () => {
   test('calculates hours correctly', () => {
-    for (let hour = 0; hour < 24; hour += 1) {
-      const time = `${hour.toString().padStart(2, '0')}00`;
-      expect(getLessonTimeHours(time)).toBe(hour);
-    }
+    expect(getLessonTimeHours('0059')).toBe(0);
+    expect(getLessonTimeHours('0100')).toBe(1);
+    expect(getLessonTimeHours('2300')).toBe(23);
   });
 });
 
 describe('getLessonTimeMinutes', () => {
-  test('calculates hours correctly', () => {
-    for (let minute = 0; minute < 60; minute += 1) {
-      const time = `00${minute.toString().padStart(2, '0')}`;
-      expect(getLessonTimeMinutes(time)).toBe(minute);
-    }
+  test('calculates minutes correctly', () => {
+    expect(getLessonTimeMinutes('0000')).toBe(0);
+    expect(getLessonTimeMinutes('0001')).toBe(1);
+    expect(getLessonTimeMinutes('0059')).toBe(59);
   });
 });
 

--- a/website/src/utils/timify.test.ts
+++ b/website/src/utils/timify.test.ts
@@ -10,7 +10,27 @@ import {
   DEFAULT_EARLIEST_TIME,
   DEFAULT_LATEST_TIME,
   parseDate,
+  getLessonTimeHours,
+  getLessonTimeMinutes,
 } from './timify';
+
+describe('getLessonTimeHours', () => {
+  test('calculates hours correctly', () => {
+    for (let hour = 0; hour < 24; hour += 1) {
+      const time = `${hour.toString().padStart(2, '0')}00`;
+      expect(getLessonTimeHours(time)).toBe(hour);
+    }
+  });
+});
+
+describe('getLessonTimeMinutes', () => {
+  test('calculates hours correctly', () => {
+    for (let minute = 0; minute < 60; minute += 1) {
+      const time = `00${minute.toString().padStart(2, '0')}`;
+      expect(getLessonTimeMinutes(time)).toBe(minute);
+    }
+  });
+});
 
 describe('convertTimeToIndex', () => {
   test('convert time string to index', () => {

--- a/website/src/utils/timify.ts
+++ b/website/src/utils/timify.ts
@@ -14,18 +14,14 @@ import {
 import { TimePeriod } from 'types/venues';
 import { Lesson } from 'types/timetables';
 
-const HOURS_START_INDEX = 0;
-const MINUTES_START_INDEX = 2;
-const DECIMAL_RADIX = 10;
-
 const SGT_OFFSET = -8 * 60;
 
 export function getLessonTimeHours(time: LessonTime): number {
-  return parseInt(time.substring(HOURS_START_INDEX, MINUTES_START_INDEX), DECIMAL_RADIX);
+  return parseInt(time.substring(0, 2), 10);
 }
 
 export function getLessonTimeMinutes(time: LessonTime): number {
-  return parseInt(time.substring(MINUTES_START_INDEX), DECIMAL_RADIX);
+  return parseInt(time.substring(2), 10);
 }
 
 // Converts a 24-hour format time string to an index.

--- a/website/src/utils/timify.ts
+++ b/website/src/utils/timify.ts
@@ -14,15 +14,27 @@ import {
 import { TimePeriod } from 'types/venues';
 import { Lesson } from 'types/timetables';
 
+const HOURS_START_INDEX = 0;
+const MINUTES_START_INDEX = 2;
+const DECIMAL_RADIX = 10;
+
 const SGT_OFFSET = -8 * 60;
+
+export function getLessonTimeHours(time: LessonTime): number {
+  return parseInt(time.substring(HOURS_START_INDEX, MINUTES_START_INDEX), DECIMAL_RADIX);
+}
+
+export function getLessonTimeMinutes(time: LessonTime): number {
+  return parseInt(time.substring(MINUTES_START_INDEX), DECIMAL_RADIX);
+}
 
 // Converts a 24-hour format time string to an index.
 // Each index corresponds to one cell of each timetable row.
 // Each row may not start from index 0, it depends on the config's starting time.
 // 0000 -> 0, 0030 -> 1, 0100 -> 2, ...
 export function convertTimeToIndex(time: LessonTime): number {
-  const hour = parseInt(time.substring(0, 2), 10);
-  const minute = parseInt(time.substring(2), 10);
+  const hour = getLessonTimeHours(time);
+  const minute = getLessonTimeMinutes(time);
 
   // TODO: Expose incorrect offsets to user via UI
   // Currently we round up in half hour blocks, but the actual time is not shown


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

This fixes #726 which addresses code duplication in the following modules. 
1. `src/utils/ical.ts`
2. `src/utils/timify.ts`
3. `src/utils/modules.ts`

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

Currently, there exists duplicate code in the 3 modules mentioned above. Such as retrieving the number 
of hours and minutes from `LessonTime` and the retrieval of exam date and duration from a module given the 
current semester. 

As a result, there have been a few new utility functions implemented to address this issue. 

1. `src/utils/timify` 
  a. `getLessonTimeHours` to retrieve the number of hours from `LessonTime` 
  b. `getLessonTimeMinutes` to retrieve the number of minutes from `LessonTime` 
  
2. `src/utils/modules`
  a. `getExamDuration` to retrieve the exam duration of a module given the semester. 

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->

This is as far as to what I have implemented thus far, do let me know if there are any critical 
changes needed to be made, thank you! :smile: 