### PR TITLE
Fix vertical overscroll behavior

### DIFF
--- a/website/src/views/timetable/TimetableContent.scss
+++ b/website/src/views/timetable/TimetableContent.scss
@@ -9,7 +9,8 @@
 .timetableWrapper {
   composes: scrollable from global;
   margin-bottom: 1rem;
-  overscroll-behavior: none;
+  // Disable horizontal overscroll only to prevent navigating to previous page
+  overscroll-behavior-x: none;
 
   @include media-breakpoint-down(sm) {
     // Maximize the space taken by the timetable by overflowing into the grid gutters


### PR DESCRIPTION
#3342 broke vertical scrolling on mobile, because scrolling in the timetable now doesn't scroll the entire page.

We will change this to only disable horizontal overscroll - the main purpose here is to not trigger the browser's default back/forward mechanism when you scroll to the left or right, inside the timetable.
