### PR TITLE
Make vertically displayed day names centred

### DIFF
--- a/website/src/views/timetable/TimetableDay.scss
+++ b/website/src/views/timetable/TimetableDay.scss
@@ -57,13 +57,13 @@
 
     .dayNameText {
       // On small screens, display the day names vertically
+      display: flex;
+      justify-content: center;
       width: 0.6rem;
       font-size: $font-size-s;
       line-height: 1.1;
-      word-break: break-all;
-      display: flex;
-      justify-content: center;
       text-align: center;
+      word-break: break-all;
     }
   }
 

--- a/website/src/views/timetable/TimetableDay.scss
+++ b/website/src/views/timetable/TimetableDay.scss
@@ -61,6 +61,9 @@
       font-size: $font-size-s;
       line-height: 1.1;
       word-break: break-all;
+      display: flex;
+      justify-content: center;
+      text-align: center;
     }
   }
 


### PR DESCRIPTION



<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
On narrow screens, the vertical day names are left-justified. This makes it aesthetically displeasing in a variable-width font, especially for wide letters such as 'W'.
![before](https://user-images.githubusercontent.com/59951032/135343946-afada35b-0293-4918-8d90-b64600a1552d.png)


## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
Make them centred to look better.
![after](https://user-images.githubusercontent.com/59951032/135344000-5ced4e2d-dcdf-4f88-bb72-08636c7c7748.png)



## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
I guess this might be too trivial to spam an issue for it, so I did not open one :rofl: 

I am new to the entire thing, and my apologies in advance if the fix is erroneous in some way.