### PR TITLE
Enable MPE data attributes scraping

### DIFF
--- a/scrapers/nus-v2/src/services/io/__mocks__/elastic.ts
+++ b/scrapers/nus-v2/src/services/io/__mocks__/elastic.ts
@@ -7,6 +7,8 @@ export default class MockedElasticPersist implements Persist {
 
   moduleInformation = () => Promise.resolve();
 
+  mpeModules = () => Promise.resolve();
+
   moduleAliases = () => Promise.resolve();
 
   facultyDepartments = () => Promise.resolve();

--- a/scrapers/nus-v2/src/services/io/elastic.ts
+++ b/scrapers/nus-v2/src/services/io/elastic.ts
@@ -211,6 +211,10 @@ export default class ElasticPersist implements Persist {
     return Promise.resolve();
   }
 
+  mpeModules() {
+    return Promise.resolve();
+  }
+
   semesterData() {
     return Promise.resolve();
   }

--- a/scrapers/nus-v2/src/services/io/fs.ts
+++ b/scrapers/nus-v2/src/services/io/fs.ts
@@ -7,6 +7,7 @@
 import * as fs from 'fs-extra';
 import path from 'path';
 
+import type { MPEModule } from '../../types/mpe';
 import {
   Aliases,
   Module,
@@ -100,6 +101,10 @@ export function getFileSystemWriter(academicYear: string): Persist {
     // List of partial module info for module finder
     moduleInfo: (data: ModuleInformation[]) =>
       fs.outputJSON(path.join(yearRoot, 'moduleInfo.json'), data, writeOptions),
+
+    // List of modules that are participating in NUS's module planning exercise (MPE)
+    mpeModules: (data: MPEModule[]) =>
+      fs.outputJSON(path.join(yearRoot, 'mpeModules.json'), data, writeOptions),
 
     // DEPRECATED. TODO: Remove after AY19/20 starts.
     // List of partial module info for module finder

--- a/scrapers/nus-v2/src/services/io/index.ts
+++ b/scrapers/nus-v2/src/services/io/index.ts
@@ -9,6 +9,7 @@ import type {
   Semester,
   SemesterData,
 } from '../../types/modules';
+import type { MPEModule } from '../../types/mpe';
 import type { Venue, VenueInfo } from '../../types/venues';
 
 import { getFileSystemWriter } from './fs';
@@ -34,6 +35,10 @@ export class CombinedPersist implements Persist {
 
   async moduleInfo(data: ModuleInformation[]) {
     await Promise.all(this.writers.map((writer) => writer.moduleInfo(data)));
+  }
+
+  async mpeModules(data: MPEModule[]) {
+    await Promise.all(this.writers.map((writer) => writer.mpeModules(data)));
   }
 
   async moduleInformation(data: ModuleInformation[]) {

--- a/scrapers/nus-v2/src/tasks/CollateModules.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.ts
@@ -9,6 +9,7 @@ import {
   SemesterModuleData,
 } from '../types/mapper';
 import { Module, ModuleCode, ModuleCondensed, ModuleInformation } from '../types/modules';
+import type { MPEModule } from '../types/mpe';
 
 import BaseTask from './BaseTask';
 import config from '../config';
@@ -16,6 +17,7 @@ import { Logger } from '../services/logger';
 import generatePrereqTree from '../services/requisite-tree';
 import { union } from '../utils/set';
 import { isModuleOffered } from '../utils/data';
+import { isModuleInMPE } from '../utils/mpe';
 
 interface Input {
   semesterData: SemesterModuleData[][];
@@ -124,6 +126,19 @@ const getModuleCondensed = ({
   semesters: semesterData.map((semester) => semester.semester),
 });
 
+const getModuleMPEParticipation = ({
+  title,
+  moduleCode,
+  moduleCredit,
+  attributes,
+}: ModuleWithoutTree): MPEModule => ({
+  title,
+  moduleCode,
+  moduleCredit,
+  inS1MPE: attributes?.mpes1,
+  inS2MPE: attributes?.mpes2,
+});
+
 // Avoid using _.pick here because it is not type safe
 const getModuleInfo = ({
   moduleCode,
@@ -207,10 +222,17 @@ export default class CollateModules extends BaseTask implements Task<Input, Outp
     // Save condensed versions of the same information for searching. For module list we only save
     // offered modules so that they don't go into the add module dropdown
     const moduleCondensed = modules.filter(isModuleOffered).map(getModuleCondensed);
+
+    const mpeModules = modules
+      .filter(isModuleOffered)
+      .filter(isModuleInMPE)
+      .map(getModuleMPEParticipation);
+
     const moduleInfo = modules.map(getModuleInfo);
 
     await Promise.all([
       this.io.moduleList(moduleCondensed),
+      this.io.mpeModules(mpeModules),
       this.io.moduleInfo(moduleInfo),
       this.io.moduleAliases(combinedAliases),
     ]);

--- a/scrapers/nus-v2/src/types/mpe.ts
+++ b/scrapers/nus-v2/src/types/mpe.ts
@@ -1,0 +1,10 @@
+import { ModuleCode, ModuleTitle } from './modules';
+
+// This format is returned from the MPE modules endpoint.
+export type MPEModule = Readonly<{
+  title: ModuleTitle;
+  moduleCode: ModuleCode;
+  moduleCredit: string;
+  inS1MPE?: boolean;
+  inS2MPE?: boolean;
+}>;

--- a/scrapers/nus-v2/src/types/persist.ts
+++ b/scrapers/nus-v2/src/types/persist.ts
@@ -8,6 +8,7 @@ import {
   Semester,
   SemesterData,
 } from './modules';
+import type { MPEModule } from './mpe';
 import { Venue, VenueInfo } from './venues';
 
 /**
@@ -19,6 +20,9 @@ export interface Persist {
 
   // List of partial module info for module finder
   moduleInfo: (data: ModuleInformation[]) => Promise<void>;
+
+  // List of MPE module info for NUS's module planning exercise
+  mpeModules: (data: MPEModule[]) => Promise<void>;
 
   // DEPRECATED. TODO: Remove after AY19/20 starts.
   // List of partial module info for module finder


### PR DESCRIPTION
This PR reverts #3259.

MPE for Term 2120 (AY21/22 S2) can make use of existing scraper code
that we have written to scrape MPE attributes as the upcoming MPE is
still within the same AY. That is, we do not need to be concerned about
modules only offered in another AY, hence we can just make use of the
MPE scraping code we have previously written.

This reverts commit b085737a350d63c975395921f4491d56ce04469a.