### PR TITLE
Update MPE UI strings for term 2120

### DIFF
--- a/website/src/views/mpe/MpeContainer.tsx
+++ b/website/src/views/mpe/MpeContainer.tsx
@@ -80,7 +80,7 @@ const MpeContainer: React.FC = () => {
             and there is no guarantee that you will be allocated the selected modules during the
             ModReg Exercise.
           </p>
-          <p>The MPE for this round will be from 1 Mar to 14 Mar 2021.</p>
+          <p>The MPE for this round will be from 11 Oct to 25 Oct 2021.</p>
           <p>
             Participation in the MPE will be used as <strong>one of the tie-breakers</strong> during
             the ModReg Exercise, in cases where the demand exceeds the available quota and students

--- a/website/src/views/mpe/constants.ts
+++ b/website/src/views/mpe/constants.ts
@@ -1,3 +1,3 @@
 export const MAX_MODULES = 7;
-export const MPE_SEMESTER = 1;
+export const MPE_SEMESTER: 1 | 2 = 2;
 export const MPE_AY = '2021/2022';


### PR DESCRIPTION
This updates the UI strings for the upcoming MPE in AY21/22 S1.

Changes are live at https://mpe-staging.nusmods.com/mpe (note: this uses test data and not production data)