### PR TITLE
Adjust timetable corner styles (#3340)

### DIFF
--- a/website/src/views/timetable/TimetableDay.scss
+++ b/website/src/views/timetable/TimetableDay.scss
@@ -1,5 +1,7 @@
 @import './_variables.scss';
 
+$btn-inner-border-radius: calc(#{$btn-border-radius} - 1px);
+
 .day {
   position: relative;
   display: flex;
@@ -8,16 +10,29 @@
   border-bottom: $timetable-border;
 
   &:first-child {
+    > .currentDay {
+      border-top-left-radius: $btn-inner-border-radius;
+      border-top-right-radius: $btn-inner-border-radius;
+    }
     > .dayName {
       border-top-left-radius: $btn-border-radius;
+    }
+    > .dayRows {
+      border-top-right-radius: $btn-inner-border-radius;
     }
   }
 
   &:last-child {
     border-bottom: 0;
-
+    > .currentDay {
+      border-bottom-left-radius: $btn-inner-border-radius;
+      border-bottom-right-radius: $btn-inner-border-radius;
+    }
     > .dayName {
       border-bottom-left-radius: $btn-border-radius;
+    }
+    > .dayRows {
+      border-bottom-right-radius: $btn-inner-border-radius;
     }
   }
 


### PR DESCRIPTION
## Context
Hello there.

This changeset is intended to resolve #3340 in which a minor visual issue was noted about the corners of the timetable.

## Implementation
It was simply a matter of adding styles to the elements which weren't having their corners rounded.

![image](https://user-images.githubusercontent.com/43751307/136568190-da4db76d-efb0-483d-a570-2599f78e8400.png)

I also found that the element which served to highlight the current day also needed some adjustment. This particular problem only manifests if the current day is the first or last day, corresponding to the top-most and bottom-most rows in the timetable respectively.

## Other Information
None.