### PR TITLE
Send HTTP 401 for invalid NUS auth token

### DIFF
--- a/website/src/serverless/nus-auth.ts
+++ b/website/src/serverless/nus-auth.ts
@@ -102,7 +102,9 @@ export const verifyLogin = (next: Handler): Handler => async (req, res): Promise
     } else if (err.message === errors.noTokenSupplied) {
       errResp.message = 'No token is supplied';
     } else {
-      throw err;
+      errResp.message = 'Invalid authentication, please login again';
+      // eslint-disable-next-line no-console
+      console.error(err);
     }
 
     res.status(401).json(errResp);


### PR DESCRIPTION
Some clients still have an outdated auth token that uses the old ADFS certificate in it's metadata. This causes our serverless functions to parse the outdated token and we get `ERROR_UNMATCH_CERTIFICATE_DECLARATION_IN_METADATA`.

However this error isn't specifically handled properly: the error is just thrown and we don't send a 401 at the moment. This PR makes sure a 401 is sent when there are uncaught auth errors.