### PR TITLE
Fix wrong API doc of `semesterData` key in `Module`

### DIFF
--- a/scrapers/nus-v2/swagger.yaml
+++ b/scrapers/nus-v2/swagger.yaml
@@ -635,7 +635,9 @@ components:
           type: 'string'
           example: 'CS2100'
         semesterData:
-          $ref: '#/components/schemas/SemesterData'
+          type: 'array'
+          items:
+            $ref: '#/components/schemas/SemesterData'
         prereqTree:
           $ref: '#/components/schemas/PrereqTree'
         fulfillRequirements:


### PR DESCRIPTION


<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
In `#/components/schemas/Module`, `semesterData` key is documented as one single object of type `#/components/schemas/SemesterData`, while it should be an array of objects of such type, as per the actual 200 response of endpoint `/{acadYear}/modules/{moduleCode}.json` (including modules that are only available in one semester).

```shell
$ curl -sL "https://api.nusmods.com/v2/2019-2020/modules/CG1111.json" | jq '.semesterData | type, length'
"array"
1
```

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
Change `semesterData` key in `#/components/schemas/Module` to be an array of `#/components/schemas/SemesterData`s to match the actual API response.

This should have no impact on anything else since the only change is in the OpenAPI documentation.