### PR TITLE
Fix timetable-only build HtmlWebpackPlugin JS injection

### DIFF
--- a/website/webpack/webpack.config.timetable-only.js
+++ b/website/webpack/webpack.config.timetable-only.js
@@ -28,6 +28,7 @@ const timetableOnlyConfig = merge([
     },
     plugins: [
       new HtmlWebpackPlugin({
+        scriptLoading: 'blocking',
         template: path.join(parts.PATHS.src, source('index.html')),
         inject: true,
       }),


### PR DESCRIPTION
## Context

Timetable export wasn't working because https://nusmods.com/timetable-only wasn't rendering the timetable, so puppeteer couldn't screenshot it. This also caused the serverless function to timeout.

This regression is caused by #3376.

On investigation, the output HTML files generated by webpack before and after #3376 is different.

**Before:** Copy paste `view-source:https://nusmods-website-9k4pwqc12-nusmodifications.vercel.app/timetable-only`
 - Bundle JS is loaded in `<body>`, and hence would be blocking

**After:** Copy paste `view-source:https://nusmods-website-9dyvagl9e-nusmodifications.vercel.app/timetable-only`
 - Bundle JS is loaded in `<head>`, and hence would be deferred

This gives timetable export trouble due to https://github.com/nusmodifications/nusmods/blob/bf368cb3979943ef846ccff93a808edd29216174/website/src/entry/export/main.tsx#L53
which expects the bundle to have been loaded and rendered.

## Implementation

On looking at the webpack configs for timetable-only export, `html-webpack-plugin` seems to have caused the above change.

Looking at https://github.com/jantimon/html-webpack-plugin/blob/main/CHANGELOG.md#500-2021-02-03, the default script injection behaviour has changed: `Entry javascript resources are now beeing loaded deferred in the <head> tag to improve the page load performance by default - You can set the scriptLoading option to 'blocking' to keep the previous behaviour`

Cross referencing https://github.com/jantimon/html-webpack-plugin#options, we get the fix.
