### PR TITLE
Improve copy for reading/examination week

### DIFF
--- a/website/src/types/views.ts
+++ b/website/src/types/views.ts
@@ -76,7 +76,8 @@ export type EmptyGroupType =
   | 'weekend'
   | 'holiday'
   | 'recess'
-  | 'reading';
+  | 'reading'
+  | 'examination';
 
 /* views/notifications/ModRegNotification */
 export interface RegPeriodView extends RegPeriod {

--- a/website/src/views/today/EmptyLessonGroup.tsx
+++ b/website/src/views/today/EmptyLessonGroup.tsx
@@ -68,7 +68,15 @@ function renderType(type: EmptyGroupType) {
       return (
         <>
           <BooksIcon />
-          <p>Time to study for your exams!</p>
+          <p>It's reading week!</p>
+        </>
+      );
+
+    case 'examination':
+      return (
+        <>
+          <BooksIcon />
+          <p>It's examination week. Hang in there!</p>
         </>
       );
 

--- a/website/src/views/today/TodayContainer/TodayContainer.tsx
+++ b/website/src/views/today/TodayContainer/TodayContainer.tsx
@@ -89,8 +89,9 @@ const DAYS = 7;
 function getDayType(date: Date, weekInfo: AcadWeekInfo): EmptyGroupType {
   switch (weekInfo.type) {
     case 'Reading':
-    case 'Examination':
       return 'reading';
+    case 'Examination':
+      return 'examination';
     case 'Orientation':
       return 'orientation';
     case 'Recess':


### PR DESCRIPTION
## Context
We want to avoid giving everyone a fake scare about non-existent exams with our current wording "Time to study for your exams!"

![Screen Shot 2022-04-29 at 22 58 49](https://user-images.githubusercontent.com/14850387/166093613-80c5f575-f59e-4459-b682-45d693a7e20b.png)

I ran a poll and it seems we have overall support for "It's x week!" structure.

## Implementation
![Screen Shot 2022-04-29 at 22 56 03](https://user-images.githubusercontent.com/14850387/166093641-ed8a2e81-4b1c-4aa1-a4d3-a1c8c963cafb.png)

## Other Information
📚 