### PR TITLE
Add announcement for maintenance

### DIFF
--- a/website/src/views/components/notfications/Announcements.tsx
+++ b/website/src/views/components/notfications/Announcements.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useCallback } from 'react';
 import classnames from 'classnames';
-import { Heart } from 'react-feather';
+import { Info } from 'react-feather';
 
 import storage from 'storage';
 import { announcementKey } from 'storage/keys';
@@ -10,13 +10,15 @@ import styles from './Announcements.scss';
 /**
  * If false, hides announcement.
  */
-const enableAnnouncements = false;
+const enableAnnouncements = true;
 
 /**
  * Unique key for the current announcement. If the announcement is not
  * dismissible, set the key to null. Otherwise, set it to a string.
  *
  * Previous keys:
+ * - 'vercel-migration-120522' - Announcement for possible outage for
+ *                               migration out of Vercel team plan
  * - 'ay202122-2107-search-outage' - Module search outage apology
  * - 'ay202122-new-data' - AY2021/22 data is available
  * - 'ay202021-new-data' - AY2020/21 data is available
@@ -26,7 +28,7 @@ const enableAnnouncements = false;
  * - 'ay201819-new-data' - AY2018/19 data is available
  * - 'ay201819-s2-new-data' - S2 data available
  */
-const key = announcementKey('ay202122-new-data');
+const key = announcementKey('vercel-migration-120522');
 
 const Announcements = memo(() => {
   const [isOpen, setIsOpen] = useState(() => {
@@ -47,18 +49,18 @@ const Announcements = memo(() => {
   return (
     <div
       className={classnames(
-        'alert alert-success no-export',
+        'alert alert-info no-export',
         styles.announcement,
         // styles.wrapButtons, // Uncomment if needed
       )}
     >
-      <Heart className={styles.backgroundIcon} />
+      <Info className={styles.backgroundIcon} />
 
       <div className={styles.body}>
-        <h3>AY2021/22 modules now available!</h3>
+        <h3>Scheduled maintenance on 12 May 2022 &ndash; 12am to 4am</h3>
         <p className={styles.bodyElement}>
-          NUSMods now has AY2021/22 module information available. The data is accurate but subject
-          to changes. Happy new academic year!
+          NUSMods will be undergoing a scheduled maintenance on Thursday 12 May 2022, from 12am to
+          4am. NUSMods might be intermittently accessible or might be down during this time period.
         </p>
       </div>
 


### PR DESCRIPTION
## Context

Migrating hosting plans from Vercel Team plan. Might have **possible** downtime. This PR adds an announcement banner to notify users that are still using NUSMods now (even though the sem has ended) that there might be downtime.
