### PR TITLE
Show message to check exam timetable for ST2 from prev AY

### DIFF
--- a/website/src/config/app-config.json
+++ b/website/src/config/app-config.json
@@ -22,6 +22,8 @@
     "3": "ST I",
     "4": "ST II"
   },
+  "showSt2ExamTimetable": true,
+  "st2ExamTimetableUrl": "https://myportal.nus.edu.sg/studentportal/academics/all/special-term-part-2.html",
   "contact": {
     "blog": "https://blog.nusmods.com",
     "email": "nusmods@googlegroups.com",

--- a/website/src/config/index.ts
+++ b/website/src/config/index.ts
@@ -42,6 +42,15 @@ export type Config = {
 
   semesterNames: { [semester: string]: string };
   shortSemesterNames: { [semester: string]: string };
+
+  /*
+   * Toggle to show a notice for ST2 modules to refer to NUS's timetable.
+   * Added because ModReg Round 0 (next AY data) overlaps with ST2 (prev AY)
+   * data, and NUSMods rotates complete AYs.
+   */
+  showSt2ExamTimetable: boolean;
+  st2ExamTimetableUrl: string;
+
   archiveYears: string[];
   examAvailability: Semester[];
   examAvailabilitySet: Set<Semester>;

--- a/website/src/views/components/module-info/ModuleSemesterInfo.scss
+++ b/website/src/views/components/module-info/ModuleSemesterInfo.scss
@@ -37,6 +37,10 @@
     margin-bottom: 0;
     font-weight: bold;
     font-size: $font-size-sm;
+
+    &.specialTermExam {
+      margin-top: 1rem;
+    }
   }
 
   .moduleExam p {
@@ -53,4 +57,3 @@
     margin-bottom: 2rem;
   }
 }
-

--- a/website/src/views/components/module-info/ModuleSemesterInfo.tsx
+++ b/website/src/views/components/module-info/ModuleSemesterInfo.tsx
@@ -3,6 +3,7 @@ import { Component } from 'react';
 import { ModuleCode, Semester, SemesterDataCondensed } from 'types/modules';
 
 import { getFirstAvailableSemester } from 'utils/modules';
+import config from 'config';
 import SemesterPicker from './SemesterPicker';
 import ModuleExamClash from './ModuleExamClash';
 import ModuleExamInfo from './ModuleExamInfo';
@@ -54,6 +55,33 @@ export default class ModuleSemesterInfo extends Component<Props, State> {
             <section className={styles.moduleExam}>
               <h4>Exam</h4>
               <ModuleExamInfo semesterData={semester} />
+
+              {/* Added because ST2 exams rely on previous AY's data due to
+              ModReg R0, which is difficult for us to get, so we show a link instead. */}
+              {config.showSt2ExamTimetable && semester.semester === 4 && (
+                <>
+                  <h4 className={styles.specialTermExam}>
+                    AY
+                    {config.archiveYears
+                      .slice(-1)?.[0]
+                      ?.split('/')
+                      ?.map((x) => x.substring(2, 4))
+                      ?.join('/')}{' '}
+                    Exam
+                  </h4>
+                  <p>
+                    Please visit{' '}
+                    <a
+                      href={config.st2ExamTimetableUrl}
+                      target="_blank"
+                      rel="noopener noreferrer nofollow"
+                    >
+                      the exam timetable
+                    </a>{' '}
+                    instead.
+                  </p>
+                </>
+              )}
 
               <ModuleExamClash
                 semester={semester.semester}

--- a/website/src/views/modules/ModulePageContent.tsx
+++ b/website/src/views/modules/ModulePageContent.tsx
@@ -46,6 +46,12 @@ const SIDE_MENU_LABELS = {
 
 const SIDE_MENU_ITEMS = mapValues(SIDE_MENU_LABELS, kebabCase);
 
+const prevAYShortName = config.archiveYears
+  .slice(-1)?.[0]
+  ?.split('/')
+  ?.map((x) => x.substring(2, 4))
+  ?.join('/');
+
 const ModulePageContent: React.FC<Props> = ({ module, archiveYear }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -202,6 +208,29 @@ const ModulePageContent: React.FC<Props> = ({ module, archiveYear }) => {
                     />
                   </div>
                 ))}
+
+                {/* Added because ST2 exams rely on previous AY's data due to
+                  ModReg R0, which is difficult for us to get, so we show a
+                  link instead. */}
+                {config.showSt2ExamTimetable &&
+                  module.semesterData.find((semester) => semester.semester === 4) && (
+                    <div className={styles.exam}>
+                      <h3 className={styles.descriptionHeading}>
+                        AY{prevAYShortName} Special Term II Exam
+                      </h3>
+                      <p>
+                        Please visit{' '}
+                        <a
+                          href={config.st2ExamTimetableUrl}
+                          target="_blank"
+                          rel="noopener noreferrer nofollow"
+                        >
+                          the exam timetable
+                        </a>{' '}
+                        instead.
+                      </p>
+                    </div>
+                  )}
 
                 {!isArchive && offered && (
                   <div className={styles.addToTimetable}>


### PR DESCRIPTION
NUSMods is designed around rotating entire AYs. This used to be a very valid assumption to design around until ModReg Round 0 was introduced last AY (and this problem only surfaced this AY).

The problem being, ModReg Round 0 is a very early "protected bidding round" for non-freshmen, which requires next AY data. It happens WHILE ST2 is still ongoing, which uses previous AY's data.

The "proper fixes" here is to:
1. ask NUS to publish prev AY ST2 data as current AY ST2 data or;
2. make the scraper scrape both the current and previous AYs data, merge them, save them and commit them to elasticsearch so that we can access previous AY's data in the module search page and module info page
3. additionally make it such that somehow the ST2 timetable with prev AY data is still accessible even when most people are on the current semester timetable.

(2) and (3) is a lot of engineering work which I do not have the capacity for at the moment. 

So the fix for now will be to just to direct ST2 exams to NUS's official exam timetable.

NUS wants this now so I will push this to production first when CI passes, but I'd still like this to be reviewed.