### PR TITLE
fix: negative MC being valid when creating custom mod in planner

### DIFF
--- a/website/src/views/planner/CustomModuleForm.tsx
+++ b/website/src/views/planner/CustomModuleForm.tsx
@@ -36,8 +36,8 @@ export const CustomModuleFormComponent: React.FC<Props> = (props) => {
     const inputTitleCurrent = inputTitle.current;
     const title = inputTitleCurrent && inputTitleCurrent.value;
 
-    // Module credit is required
-    if (moduleCredit == null) return;
+    // Module credit is required, module credit cannot be negative
+    if (moduleCredit == null || parseInt(moduleCredit, 10) < 0) return;
 
     props.addCustomModule(props.moduleCode, {
       moduleCredit: +moduleCredit,

--- a/website/src/views/planner/CustomModuleForm.tsx
+++ b/website/src/views/planner/CustomModuleForm.tsx
@@ -82,6 +82,7 @@ export const CustomModuleFormComponent: React.FC<Props> = (props) => {
             className="form-control"
             defaultValue={moduleCredit ? String(moduleCredit) : ''}
             required
+            min="0"
           />
         </div>
         <div className="col-md-9">


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
create custom module form can save negative modular credits.

resolves issue #3402 

## Implementation
prevents create custom module form from saving if there is a negative number for modular credit

## Screenshots
<details>
<summary>before</summary>

https://user-images.githubusercontent.com/102740235/180600847-1490f612-530f-423e-98d7-53aa4ebcc990.mp4
</details>


<details>
<summary>after</summary>

https://user-images.githubusercontent.com/102740235/180600820-21034cea-d749-4491-a07f-450037b81077.mp4
</details>

