### PR TITLE
Change type when downloading as iCal to text/calendar

### DIFF
--- a/website/src/actions/export.ts
+++ b/website/src/actions/export.ts
@@ -42,7 +42,7 @@ export function downloadAsIcal(semester: Semester) {
           events,
         });
 
-        const blob = new Blob([cal.toString()], { type: 'text/plain' });
+        const blob = new Blob([cal.toString()], { type: 'text/calendar' });
         downloadUrl(blob, 'nusmods_calendar.ics');
       })
       .catch(captureException);


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
Resolves #3405. 

<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

## Implementation
Changes content type from `text/plain` to `text/calendar`, since according to [this](https://apple.stackexchange.com/questions/227113/safari-automatically-appends-txt-extension-to-ino-files/239319), appending `.txt` is intentional. 
