### PR TITLE
Fix export serverless functions on Node 14

### DIFF
--- a/export/package.json
+++ b/export/package.json
@@ -20,7 +20,7 @@
     "@sentry/node": "5.30.0",
     "axios": "0.21.2",
     "bunyan": "1.8.15",
-    "chrome-aws-lambda": "5.5.0",
+    "chrome-aws-lambda": "~6.0.0",
     "fs-extra": "9.1.0",
     "http-graceful-shutdown": "2.3.2",
     "koa": "2.13.1",
@@ -39,13 +39,13 @@
     "@types/lodash": "4.14.170",
     "@types/node": "14.14.22",
     "@types/pug": "2.0.4",
-    "@types/puppeteer": "5.4.2",
+    "@types/puppeteer": "^5.4.7",
     "@vercel/node": "1.9.0",
     "cross-env": "7.0.3",
     "dotenv": "8.2.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.2.1",
-    "puppeteer": "5.5.0",
+    "puppeteer": "~6.0.0",
     "typescript": "4.1.3"
   }
 }

--- a/export/yarn.lock
+++ b/export/yarn.lock
@@ -259,10 +259,10 @@
   resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.4.tgz#8772fcd0418e3cd2cc171555d73007415051f4b2"
   integrity sha1-h3L80EGOPNLMFxVV1zAHQVBR9LI=
 
-"@types/puppeteer@5.4.2":
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-5.4.2.tgz#80f3a1f54dedbbf750779716de81401549062072"
-  integrity sha512-yjbHoKjZFOGqA6bIEI2dfBE5UPqU0YGWzP+ipDVP1iGzmlhksVKTBVZfT3Aj3wnvmcJ2PQ9zcncwOwyavmafBw==
+"@types/puppeteer@^5.4.7":
+  version "5.4.7"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-5.4.7.tgz#b8804737c62c6e236de0c03fa74f91c174bf96b6"
+  integrity sha512-JdGWZZYL0vKapXF4oQTC5hLVNfOgdPrqeZ1BiQnGk5cB7HeE91EWUiTdVSdQPobRN8rIcdffjiOgCYJ/S8QrnQ==
   dependencies:
     "@types/node" "*"
 
@@ -565,12 +565,12 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
-chrome-aws-lambda@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/chrome-aws-lambda/-/chrome-aws-lambda-5.5.0.tgz#5b011d1596020b6ab4b92b010e427da1be6fc628"
-  integrity sha512-nYSDzTsVEVsvIFaUUAUN53ulXBLKSRXFS+eVYZOLZD5SA1If59rqBAiy4raMgorQwXWqjSsjK1SF4As+qzPLqA==
+chrome-aws-lambda@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/chrome-aws-lambda/-/chrome-aws-lambda-6.0.0.tgz#e0966a5759e6b57c24584c2511fb72738b6209ff"
+  integrity sha512-XnFo6AaE5ZYpHYmOmMoj1yCYFeRTx6uFCpJnVuDREWzXevzZvo3gzkyQ6qSKsPW91VGWeQI7wQgnOpW50e+Dzg==
   dependencies:
-    lambdafs "^2.0.0"
+    lambdafs "^2.0.2"
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -810,6 +810,11 @@ devtools-protocol@0.0.818844:
   version "0.0.818844"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.818844.tgz#d1947278ec85b53e4c8ca598f607a28fa785ba9e"
   integrity sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==
+
+devtools-protocol@0.0.842839:
+  version "0.0.842839"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.842839.tgz#dfdb49a74fabe80256b91e878e561a1ad2a24352"
+  integrity sha512-iI3v9uuGUW02vPUXTvxl4ijnCPL/RGRVR9I+U8s7+9OG9An/bvExjQ0KrXE9V0QBLra7wANhZctB00FKBSn1gw==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -1533,10 +1538,10 @@ koa@2.13.1:
     type-is "^1.6.16"
     vary "^1.1.2"
 
-lambdafs@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/lambdafs/-/lambdafs-2.0.1.tgz#ddbee479e8e204dc17f1a43307ec3ae1df9ea485"
-  integrity sha512-RNb7Si2XPvU6pPiE6S0eDfH1W3n+OQaxpclSPJD0hnNFA5z+U1Ntr4sgUEE9xSxVu932ufh1iwtBcIxpEM9bOw==
+lambdafs@^2.0.2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/lambdafs/-/lambdafs-2.1.1.tgz#4bf8d3037b6c61bbb4a22ab05c73ee47964c25ed"
+  integrity sha512-x5k8JcoJWkWLvCVBzrl4pzvkEHSgSBqFjg3Dpsc4AcTMq7oUMym4cL/gRTZ6VM4mUMY+M0dIbQ+V1c1tsqqanQ==
   dependencies:
     tar-fs "^2.1.1"
 
@@ -2154,15 +2159,15 @@ puppeteer-core@5.5.0:
     unbzip2-stream "^1.3.3"
     ws "^7.2.3"
 
-puppeteer@5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.5.0.tgz#331a7edd212ca06b4a556156435f58cbae08af00"
-  integrity sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==
+puppeteer@~6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-6.0.0.tgz#6b73d7ba63c12abbb5080c2ffc14b55857cc62e2"
+  integrity sha512-LqDbNC7rp0JNH7BRTPjE3lCzGYD2tFqWBvRNukW4PjRP2YotWZWeLfFMTGrDHDFY5xjOceKBEbf8h45Xn6DFdw==
   dependencies:
     debug "^4.1.0"
-    devtools-protocol "0.0.818844"
+    devtools-protocol "0.0.842839"
     extract-zip "^2.0.0"
-    https-proxy-agent "^4.0.0"
+    https-proxy-agent "^5.0.0"
     node-fetch "^2.6.1"
     pkg-dir "^4.2.0"
     progress "^2.0.1"


### PR DESCRIPTION
Closes #3415

## Context

Vercel deprecated Node 12. We then migrated to Node 16 in #3414 if not the site doesn't build on Vercel. In the process, there was a regression with the export service, because `chrome-aws-lambda` and `puppeteer`, in their older versions, do not work with Node v14/v16.

This PR bumps their versions slightly to v6.0.0, which allows it to work with Node 14.

Note that this isn't the latest `chrome-aws-lambda` nor the latest `puppeteer`, because the APIs for puppeteer have changed a lot since and it takes more effort for us to migrate it to the latest API.

These changes have also not been tested with Node 16 yet. I just lowered the build target to Node 14 first so that we minimise any environment API changes while fixing this issue.

This PR has been tested to fix the issue, and the fix has now been manually promoted to production on Vercel.

To test, click on [this link to download my timetable](https://export.nusmods.com/api/export/image?data=%7B%22semester%22%3A1%2C%22timetable%22%3A%7B%22CS1010%22%3A%7B%22Tutorial%22%3A%2207%22%2C%22Laboratory%22%3A%22D05%22%2C%22Sectional%20Teaching%22%3A%221%22%7D%2C%22CS3216%22%3A%7B%22Lecture%22%3A%221%22%7D%2C%22CS4212%22%3A%7B%22Lecture%22%3A%221%22%7D%2C%22GEH1016%22%3A%7B%22Tutorial%22%3A%22E2%22%2C%22Lecture%22%3A%221%22%7D%7D%2C%22colors%22%3A%7B%22CS1010%22%3A6%2C%22CS3216%22%3A0%2C%22CS4212%22%3A4%2C%22GEH1016%22%3A7%7D%2C%22hidden%22%3A%5B%5D%2C%22theme%22%3A%7B%22id%22%3A%22eighties%22%2C%22timetableOrientation%22%3A%22HORIZONTAL%22%2C%22showTitle%22%3Afalse%2C%22_persist%22%3A%7B%22version%22%3A-1%2C%22rehydrated%22%3Atrue%7D%7D%2C%22settings%22%3A%7B%22mode%22%3A%22LIGHT%22%7D%7D&pixelRatio=1.8181818181818181).