### PR TITLE
Update maintenance docs to include env var step

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -10,8 +10,8 @@ Create a new issue on GitHub with this checklist after the finals every semester
 - [ ] Update `website/src/data/academic-calendar.json` with data for the new academic year
 - [ ] Add announcement to website
 - [ ] Update academic year in `scrapers/nus-v2/src/config.ts`
-- [ ] Ensure that scraper is scraping next AY's data
-- [ ] On server: Update academic year in `export/.env`
+- [ ] Ensure that scraper is scraping next AY's data. You can do so by checking the locally published JSON files, or visiting `https://api.nusmods.com/v2/20XX-20XX/` (e.g. [https://api.nusmods.com/v2/2022-2023/](https://api.nusmods.com/v2/2022-2023/))
+- [ ] On Vercel or `.env`: Update academic year in export service's environment variables
 - [ ] Deploy! :tada: :tada:
 - [ ] Monitor Sentry and Messenger for issues
 
@@ -22,4 +22,4 @@ Reference PRs: [PR #3286](https://github.com/nusmodifications/nusmods/pull/3286)
 - [ ] Update semester in `website/src/config/app-config.json`
 - [ ] In `app-config.json`, add semester to `examAvailability` to indicate exam information is available for the semester
 - [ ] Update the ModReg schedule in `website/src/data/modreg-schedule-ayXXXX-semXX.json`, and point to the new version in `website/src/config/index.ts`  
-      Reference PR: [PR #2764](https://github.com/nusmodifications/nusmods/pull/2764)
+       - Reference PR: [PR #2764](https://github.com/nusmodifications/nusmods/pull/2764)


### PR DESCRIPTION
## Context

Previously, there was a bug where the export service wasn't screenshotting timetables from the correct AY. This is due to the step in the docs where the env var for the export service isn't appropriately changed. This PR updates the docs to more accurately reflect that.
