### PR TITLE
fix: color selection dropdown overlaps the sidebar

### DIFF
--- a/website/src/styles/constants.scss
+++ b/website/src/styles/constants.scss
@@ -178,7 +178,9 @@ $venue-detail-expanded-z-index: 920;
 $navtabs-z-index: 900;
 $navbar-z-index: 890;
 $module-finder-search-z-index-md: 850;
-$zindex-dropdown: 820; // Bootstrap override
+
+// navtabs and navbar should never overlap the dropdown
+$zindex-dropdown: 910; // Bootstrap override
 $fab-z-index: 800;
 $venue-map-z-index: 760;
 $venue-detail-z-index: 750;


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context

The following change is meant to address and resolve issue #3422 where colour selection dropdown overlaps the sidebar.

Before:
<img width="285" alt="image" src="https://user-images.githubusercontent.com/49022571/213113342-04aa9254-9fe6-48ee-ba1f-ba2505f836cf.png">

After: 
<img width="320" alt="image" src="https://user-images.githubusercontent.com/49022571/213113457-3a2437a5-7630-47cf-a066-a76386757028.png">


<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

## Implementation
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/49022571/213113092-feceac00-e018-40c3-9495-efd30a85b256.png">
the z-index for dropdown should be some number greater than the navtabs.
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
