### PR TITLE
Show new prerequisite and grading basis strings on website

### DIFF
--- a/website/src/types/modules.ts
+++ b/website/src/types/modules.ts
@@ -197,8 +197,12 @@ export type Module = {
 
   // Requsites
   prerequisite?: string;
+  prerequisiteRule?: string;
+  prerequisiteAdvisory?: string;
   corequisite?: string;
+  corequisiteRule?: string;
   preclusion?: string;
+  preclusionRule?: string;
 
   // Semester data
   semesterData: readonly SemesterData[];

--- a/website/src/types/modules.ts
+++ b/website/src/types/modules.ts
@@ -194,6 +194,7 @@ export type Module = {
   workload?: Workload;
   aliases?: ModuleCode[];
   attributes?: NUSModuleAttributes;
+  gradingBasisDescription?: string;
 
   // Requsites
   prerequisite?: string;

--- a/website/src/views/modules/ModulePageContent.scss
+++ b/website/src/views/modules/ModulePageContent.scss
@@ -116,6 +116,14 @@ $sticky-top: $navbar-height;
   }
 }
 
+.gradingBasisDescription {
+  margin-bottom: 1rem;
+
+  p {
+    margin-bottom: 0;
+  }
+}
+
 .addToTimetable {
   margin-bottom: 1rem;
 }

--- a/website/src/views/modules/ModulePageContent.tsx
+++ b/website/src/views/modules/ModulePageContent.tsx
@@ -146,6 +146,15 @@ const ModulePageContent: React.FC<Props> = ({ module, archiveYear }) => {
                     </>
                   )}
 
+                  {module.prerequisiteAdvisory && (
+                    <>
+                      <dt>Prerequisite Advisory</dt>
+                      <dd>
+                        <LinkModuleCodes>{module.prerequisiteAdvisory}</LinkModuleCodes>
+                      </dd>
+                    </>
+                  )}
+
                   {module.corequisite && (
                     <>
                       <dt>Corequisite</dt>

--- a/website/src/views/modules/ModulePageContent.tsx
+++ b/website/src/views/modules/ModulePageContent.tsx
@@ -254,7 +254,10 @@ const ModulePageContent: React.FC<Props> = ({ module, archiveYear }) => {
             </section>
           </div>
 
-          <section className={styles.section} id={SIDE_MENU_ITEMS.prerequisites}>
+          {/* Disabled for now because a new parser needs to be written to
+          process the new updated requisite string. */}
+
+          {/* <section className={styles.section} id={SIDE_MENU_ITEMS.prerequisites}>
             <h2 className={styles.sectionHeading}>Prerequisite Tree</h2>
             <ErrorBoundary>
               <ModuleTree
@@ -263,6 +266,14 @@ const ModulePageContent: React.FC<Props> = ({ module, archiveYear }) => {
                 fulfillRequirements={module.fulfillRequirements}
               />
             </ErrorBoundary>
+          </section> */}
+
+          <section className={styles.section} id={SIDE_MENU_ITEMS.prerequisites}>
+            <h2 className={styles.sectionHeading}>Prerequisite Tree</h2>
+            <p>
+              The prerequisite tree is now being improved to support the new (and more accurate)
+              prerequisite information provided by NUS. It will be back soon!
+            </p>
           </section>
 
           <section className={styles.section} id={SIDE_MENU_ITEMS.timetable}>

--- a/website/src/views/modules/ModulePageContent.tsx
+++ b/website/src/views/modules/ModulePageContent.tsx
@@ -201,6 +201,10 @@ const ModulePageContent: React.FC<Props> = ({ module, archiveYear }) => {
               </div>
 
               <div className="col-sm-4">
+                <div className={styles.gradingBasisDescription}>
+                  <h3 className={styles.descriptionHeading}>Grading Basis</h3>
+                  <p>{module.gradingBasisDescription ?? 'Information not available.'}</p>
+                </div>
                 {sortBy(module.semesterData, (semester) => semester.semester).map((semester) => (
                   <div key={semester.semester} className={styles.exam}>
                     <h3 className={styles.descriptionHeading}>


### PR DESCRIPTION
This PR is the frontend counterpart to https://github.com/nusmodifications/nusmods/pull/3427.

An example of how the new changes look like can be found at https://uat.nusmods.com/modules/EE4502/electric-drives-control

Note: This disables the prerequisite tree for now, because we now need to write a new parser to parse the new prerequisite rules (this will eventually result in an accurate prerequisite tree).