### PR TITLE
Enable MPE for 23/24 S1

### DIFF
--- a/website/src/apis/mpe.ts
+++ b/website/src/apis/mpe.ts
@@ -58,7 +58,7 @@ export const getLoginState = (location: Location, history: History): boolean => 
 
 export const fetchMpeModuleList = (): Promise<MpeModule[]> =>
   // Using MPE_AY instead to fetch from the respective AY's scraper
-  axios.get<MpeModule[]>(NUSModsApi.mpeModuleListUrl(MPE_AY)).then((resp) => resp.data);
+  axios.get<MpeModule[]>(NUSModsApi.mpeModuleListUrl()).then((resp) => resp.data);
 
 export const getSSOLink = (): Promise<string> =>
   mpe

--- a/website/src/apis/nusmods.js
+++ b/website/src/apis/nusmods.js
@@ -78,12 +78,11 @@ class NUSModsApi {
   }
 
   /**
-   * List of modules available for MPE for the entire acad year.
-   * @param {string} academicYear
+   * List of modules available for MPE.
    * @returns {string}
    */
-  static mpeModuleListUrl(academicYear = config.academicYear) {
-    return `${NUSModsApi.baseUrl(academicYear)}/mpeModules.json`;
+  static mpeModuleListUrl() {
+    return `${NUSModsApi.baseUrl('')}mpeModules.json`;
   }
 }
 

--- a/website/src/featureFlags.ts
+++ b/website/src/featureFlags.ts
@@ -8,4 +8,4 @@
 export const enableShortUrl = false;
 
 /** Enable Module Planning Exercise */
-export const enableMpe = false;
+export const enableMpe = true;

--- a/website/src/views/mpe/MpeContainer.tsx
+++ b/website/src/views/mpe/MpeContainer.tsx
@@ -80,7 +80,7 @@ const MpeContainer: React.FC = () => {
             and there is no guarantee that you will be allocated the selected modules during the
             ModReg Exercise.
           </p>
-          <p>The MPE for this round will be from 10 Oct to 14 Oct 2022.</p>
+          <p>The MPE for this round will be from 06 Mar to 10 Mar 2023.</p>
           <p>
             Participation in the MPE will be used as <strong>one of the tie-breakers</strong> during
             the ModReg Exercise, in cases where the demand exceeds the available quota and students

--- a/website/src/views/mpe/constants.ts
+++ b/website/src/views/mpe/constants.ts
@@ -1,3 +1,3 @@
 export const MAX_MODULES = 7;
-export const MPE_SEMESTER: 1 | 2 = 2;
-export const MPE_AY = '2022/2023';
+export const MPE_SEMESTER: 1 | 2 = 1;
+export const MPE_AY = '2023/2024';


### PR DESCRIPTION
## Context

This PR enables MPE for 23/24 S1.

This PR also now points NUSMods to the new mpeModules.json file that is generated by the new MPE scraper.