### PR TITLE
Exclude certain venues from 'Find Free Rooms' feature

### DIFF
--- a/website/src/__mocks__/venueInformation.json
+++ b/website/src/__mocks__/venueInformation.json
@@ -914,5 +914,141 @@
       "classes": [],
       "availability": {}
     }
+  ],
+  "AS6-0333": [
+    {
+      "day": "Monday",
+      "classes": [
+        {
+          "classNo": "1",
+          "startTime": "1800",
+          "endTime": "2100",
+          "weeks": [2, 3, 4, 5, 6, 7, 8],
+          "day": "Monday",
+          "lessonType": "Seminar-Style Module Class",
+          "size": 20,
+          "moduleCode": "CSA6880"
+        }
+      ],
+      "availability": {
+        "1800": "occupied",
+        "1830": "occupied",
+        "1900": "occupied",
+        "1930": "occupied",
+        "2000": "occupied",
+        "2030": "occupied"
+      }
+    },
+    {
+      "day": "Wednesday",
+      "classes": [
+        {
+          "classNo": "1",
+          "startTime": "1800",
+          "endTime": "2100",
+          "weeks": [2, 3, 4, 5, 6, 7, 8],
+          "day": "Wednesday",
+          "lessonType": "Seminar-Style Module Class",
+          "size": 20,
+          "moduleCode": "CSA6880"
+        },
+        {
+          "classNo": "W2",
+          "startTime": "1600",
+          "endTime": "1800",
+          "weeks": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+          "day": "Wednesday",
+          "lessonType": "Tutorial",
+          "size": 12,
+          "moduleCode": "GET1008/​GEX1005"
+        }
+      ],
+      "availability": {
+        "1600": "occupied",
+        "1630": "occupied",
+        "1700": "occupied",
+        "1730": "occupied",
+        "1800": "occupied",
+        "1830": "occupied",
+        "1900": "occupied",
+        "1930": "occupied",
+        "2000": "occupied",
+        "2030": "occupied"
+      }
+    },
+    {
+      "day": "Thursday",
+      "classes": [
+        {
+          "classNo": "1",
+          "startTime": "1800",
+          "endTime": "2100",
+          "weeks": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+          "day": "Thursday",
+          "lessonType": "Seminar-Style Module Class",
+          "size": 15,
+          "moduleCode": "NM6103"
+        }
+      ],
+      "availability": {
+        "1800": "occupied",
+        "1830": "occupied",
+        "1900": "occupied",
+        "1930": "occupied",
+        "2000": "occupied",
+        "2030": "occupied"
+      }
+    },
+    {
+      "day": "Tuesday",
+      "classes": [
+        {
+          "classNo": "W12",
+          "startTime": "0800",
+          "endTime": "1000",
+          "weeks": [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+          "day": "Tuesday",
+          "lessonType": "Tutorial",
+          "size": 12,
+          "moduleCode": "GET1008/​GEX1005"
+        },
+        {
+          "classNo": "W4",
+          "startTime": "1000",
+          "endTime": "1200",
+          "weeks": [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+          "day": "Tuesday",
+          "lessonType": "Tutorial",
+          "size": 12,
+          "moduleCode": "GET1008/​GEX1005"
+        },
+        {
+          "classNo": "1",
+          "startTime": "1800",
+          "endTime": "2100",
+          "weeks": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+          "day": "Tuesday",
+          "lessonType": "Seminar-Style Module Class",
+          "size": 10,
+          "moduleCode": "NM6770/​CSA6770"
+        }
+      ],
+      "availability": {
+        "1000": "occupied",
+        "1030": "occupied",
+        "1100": "occupied",
+        "1130": "occupied",
+        "1800": "occupied",
+        "1830": "occupied",
+        "1900": "occupied",
+        "1930": "occupied",
+        "2000": "occupied",
+        "2030": "occupied",
+        "0800": "occupied",
+        "0830": "occupied",
+        "0900": "occupied",
+        "0930": "occupied"
+      }
+    }
   ]
 }

--- a/website/src/data/excludedFreeRooms.ts
+++ b/website/src/data/excludedFreeRooms.ts
@@ -1,0 +1,22 @@
+/**
+ * This file contains a list of rooms that should be excluded from the
+ * "Find Free Rooms" feature.
+ *
+ * These are rooms that typically are used for other purposes, but very
+ * occassionally have timetabled lessons. We do not want students to visit these
+ * rooms because of the free rooms feature and find themselves in awkward
+ * situations where they need to be chased out of the room.
+ */
+
+const excludedFromFreeRooms = new Set<string>([
+  // Dept Meeting Room (CNM) - Requested by Dept Staff to Delist from Free Rooms
+  'AS6-0333',
+  // Play Room (CNM) - Requested by Dept Staff to Delist from Free Rooms
+  'AS6-0338',
+  // Metaverse Foundry (SoC)
+  'COM3-B1-11',
+  // Makers@SoC (SoC)
+  'COM3-01-19',
+]);
+
+export default excludedFromFreeRooms;

--- a/website/src/utils/venues.test.ts
+++ b/website/src/utils/venues.test.ts
@@ -35,6 +35,7 @@ describe(sortVenues, () => {
 
   test('sort venues using natual sorting', () => {
     expect(venues.map(([venue]) => venue)).toEqual([
+      'AS6-0333',
       'CQT/SR0622',
       'LT1',
       'lt2',
@@ -61,7 +62,7 @@ describe('searchVenue()', () => {
 
     expect(searchVenue(venues, 'T1')).toEqual(getVenues('LT1', 'LT17'));
 
-    expect(searchVenue(venues, '0')).toEqual(getVenues('S11-0302', 'CQT/SR0622'));
+    expect(searchVenue(venues, '0')).toEqual(getVenues('AS6-0333', 'S11-0302', 'CQT/SR0622'));
 
     // Non-existent venue
     expect(searchVenue(venues, 'cofeve')).toEqual([]);
@@ -122,6 +123,16 @@ describe(filterAvailability, () => {
 
     expect(availableVenues).toHaveLength(1);
     expect(availableVenues[0][0]).toEqual('LT1');
+  });
+
+  test("should not return venues that are excluded from 'find free rooms' feature", () => {
+    const availableVenues = filterAvailability(venues, {
+      day: 0,
+      time: 9,
+      duration: 1,
+    });
+
+    expect(availableVenues.some((allVenues) => allVenues[0] === 'AS6-0333')).toBe(false);
   });
 });
 

--- a/website/src/utils/venues.ts
+++ b/website/src/utils/venues.ts
@@ -2,6 +2,7 @@ import { VenueInfo, VenueSearchOptions, VenueDetailList, OCCUPIED } from 'types/
 import { range, entries, padStart, clamp } from 'lodash';
 import produce from 'immer';
 
+import excludedRooms from 'data/excludedFreeRooms';
 import { tokenize } from './moduleSearch';
 import { SCHOOLDAYS } from './timify';
 
@@ -40,7 +41,13 @@ export function filterAvailability(
 ): VenueDetailList {
   const { day, time, duration } = options;
 
-  return venues.filter(([, venue]) => {
+  return venues.filter(([venueName, venue]) => {
+    if (excludedRooms.has(venueName)) {
+      // Locations with occasional timetabled lessons where their main purpose
+      // isn't for lessons, and should not be identified as a "Free Room".
+      return false;
+    }
+
     const start = time * 100;
     const dayAvailability = venue.find((availability) => availability.day === SCHOOLDAYS[day]);
     if (!dayAvailability) return true;


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context

From NUSMods Email:

Dear NUSMods team,

It has recently come to my attention that our department meeting room, AS6-0333, is listed on NUSMods as a "free room". (https://nusmods.com/venues)
This has resulted in students coming into our department premises to use the room, and even accessed the staff pantry which is connected to the meeting room.

This room is not meant to be used as a free-for-all study space; while we are happy to allow students (especially CNM students) to use the space, prior permission should be sought from the department first.

I seek your assistance to remove the listing at your earliest convenience. Thank you.

And a further email that said "I seek your assistance to remove AS6-0333 and AS6-0338 from your “find free rooms” function. They are not meant to be used this way."

## Implementation

- Add excluded rooms to `website/src/data/`
- Ensure these excluded rooms don't show up when users use the find free rooms feature
- Update tests
- Add tests