### PR TITLE
Add support for Timetable for TAs

### DIFF
--- a/website/src/actions/__snapshots__/timetables.test.ts.snap
+++ b/website/src/actions/__snapshots__/timetables.test.ts.snap
@@ -10,6 +10,7 @@ Object {
 exports[`changeLesson should return updated information to change lesson 1`] = `
 Object {
   "payload": Object {
+    "activeLesson": "1",
     "classNo": "1",
     "lessonType": "Recitation",
     "moduleCode": "CS1010S",

--- a/website/src/actions/timetables.test.ts
+++ b/website/src/actions/timetables.test.ts
@@ -36,7 +36,7 @@ test('modifyLesson should return lesson payload', () => {
 test('changeLesson should return updated information to change lesson', () => {
   const semester: Semester = 1;
   const lesson: Lesson = lessons[1];
-  expect(actions.changeLesson(semester, lesson)).toMatchSnapshot();
+  expect(actions.changeLesson(semester, lesson, lesson.classNo)).toMatchSnapshot();
 });
 
 test('cancelModifyLesson should not have payload', () => {

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -235,6 +235,10 @@ export function validateTimetable(semester: Semester) {
       const module = moduleBank.modules[moduleCode];
       if (!module) return;
 
+      // If the module is customised, we do not validate it
+      if (timetables.customisedModules[semester].includes(moduleCode)) {
+        return
+      }
       const [validatedLessonConfig, changedLessonTypes] = validateModuleLessons(
         semester,
         lessonConfig,

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -120,6 +120,28 @@ export function setLesson(
   };
 }
 
+export const ADD_CUSTOM_MODULE = 'ADD_CUSTOM_MODULE' as const;
+export function addCustomModule(semester: Semester, moduleCode: ModuleCode) {
+  return {
+    type: ADD_CUSTOM_MODULE,
+    payload: {
+      semester,
+      moduleCode,
+    },
+  };
+}
+
+export const REMOVE_CUSTOM_MODULE = 'REMOVE_CUSTOM_MODULE' as const;
+export function removeCustomModule(semester: Semester, moduleCode: ModuleCode) {
+  return {
+    type: REMOVE_CUSTOM_MODULE,
+    payload: {
+      semester,
+      moduleCode,
+    },
+  };
+}
+
 export const ADD_LESSON = 'ADD_LESSON' as const;
 export function addLesson(
   semester: Semester,

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -108,6 +108,7 @@ export function setLesson(
   moduleCode: ModuleCode,
   lessonType: LessonType,
   classNo: ClassNo,
+  activeLesson: ClassNo
 ) {
   return {
     type: CHANGE_LESSON,
@@ -116,6 +117,7 @@ export function setLesson(
       moduleCode,
       lessonType,
       classNo,
+      activeLesson
     },
   };
 }
@@ -178,8 +180,8 @@ export function removeLesson(
   };
 }
 
-export function changeLesson(semester: Semester, lesson: Lesson) {
-  return setLesson(semester, lesson.moduleCode, lesson.lessonType, lesson.classNo);
+export function changeLesson(semester: Semester, lesson: Lesson, activeLesson: ClassNo) {
+  return setLesson(semester, lesson.moduleCode, lesson.lessonType, lesson.classNo, activeLesson);
 }
 
 export const SET_LESSON_CONFIG = 'SET_LESSON_CONFIG' as const;

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -90,6 +90,18 @@ export function modifyLesson(activeLesson: Lesson) {
   };
 }
 
+
+export const CUSTOMISE_MODULE = 'CUSTOMISE_LESSON' as const;
+export function customiseLesson(semester: Semester, moduleCode: ModuleCode) {
+  return {
+    type: CUSTOMISE_MODULE,
+    payload: {
+      semester,
+      moduleCode,
+    },
+  };
+}
+
 export const CHANGE_LESSON = 'CHANGE_LESSON' as const;
 export function setLesson(
   semester: Semester,
@@ -99,6 +111,42 @@ export function setLesson(
 ) {
   return {
     type: CHANGE_LESSON,
+    payload: {
+      semester,
+      moduleCode,
+      lessonType,
+      classNo,
+    },
+  };
+}
+
+export const ADD_LESSON = 'ADD_LESSON' as const;
+export function addLesson(
+  semester: Semester,
+  moduleCode: ModuleCode,
+  lessonType: LessonType,
+  classNo: ClassNo,
+) {
+  return {
+    type: ADD_LESSON,
+    payload: {
+      semester,
+      moduleCode,
+      lessonType,
+      classNo,
+    },
+  };
+}
+
+export const REMOVE_LESSON = 'REMOVE_LESSON' as const;
+export function removeLesson(
+  semester: Semester,
+  moduleCode: ModuleCode,
+  lessonType: LessonType,
+  classNo: ClassNo,
+) {
+  return {
+    type: REMOVE_LESSON,
     payload: {
       semester,
       moduleCode,

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -90,7 +90,6 @@ export function modifyLesson(activeLesson: Lesson) {
   };
 }
 
-
 export const CUSTOMISE_MODULE = 'CUSTOMISE_LESSON' as const;
 export function customiseLesson(semester: Semester, moduleCode: ModuleCode) {
   return {
@@ -108,7 +107,7 @@ export function setLesson(
   moduleCode: ModuleCode,
   lessonType: LessonType,
   classNo: ClassNo,
-  activeLesson: ClassNo
+  activeLesson: ClassNo,
 ) {
   return {
     type: CHANGE_LESSON,
@@ -117,7 +116,7 @@ export function setLesson(
       moduleCode,
       lessonType,
       classNo,
-      activeLesson
+      activeLesson,
     },
   };
 }
@@ -238,8 +237,12 @@ export function validateTimetable(semester: Semester) {
       if (!module) return;
 
       // If the module is customised, we do not validate it
-      if (timetables.customisedModules[semester].includes(moduleCode)) {
-        return
+      if (
+        timetables.customisedModules &&
+        timetables.customisedModules[semester] &&
+        timetables.customisedModules[semester].includes(moduleCode)
+      ) {
+        return;
       }
       const [validatedLessonConfig, changedLessonTypes] = validateModuleLessons(
         semester,

--- a/website/src/reducers/app.test.ts
+++ b/website/src/reducers/app.test.ts
@@ -20,6 +20,7 @@ const appInitialState: AppState = {
   isFeedbackModalOpen: false,
   promptRefresh: false,
   notifications: [],
+  customiseModule: '',
 };
 const appHasSemesterTwoState: AppState = { ...appInitialState, activeSemester: anotherSemester };
 const appHasActiveLessonState: AppState = { ...appInitialState, activeLesson: lesson };
@@ -55,7 +56,7 @@ test('app should set active lesson', () => {
 });
 
 test('app should accept lesson change and unset active lesson', () => {
-  const action = changeLesson(semester, lesson);
+  const action = changeLesson(semester, lesson, lesson.classNo);
   const nextState: AppState = reducer(appInitialState, action);
 
   expect(nextState).toEqual(appInitialState);

--- a/website/src/reducers/app.ts
+++ b/website/src/reducers/app.ts
@@ -3,7 +3,7 @@ import { Actions } from 'types/actions';
 import config from 'config';
 
 import { forceRefreshPrompt } from 'utils/debug';
-import { MODIFY_LESSON, CHANGE_LESSON, CANCEL_MODIFY_LESSON } from 'actions/timetables';
+import { MODIFY_LESSON, CHANGE_LESSON, CANCEL_MODIFY_LESSON, CUSTOMISE_MODULE } from 'actions/timetables';
 import { SELECT_SEMESTER } from 'actions/settings';
 import {
   OPEN_NOTIFICATION,
@@ -18,6 +18,7 @@ const defaultAppState = (): AppState => ({
   activeSemester: config.semester,
   // The lesson being modified on the timetable.
   activeLesson: null,
+  customiseModule: null,
   isOnline: navigator.onLine,
   isFeedbackModalOpen: false,
   promptRefresh: forceRefreshPrompt(),
@@ -36,6 +37,11 @@ function app(state: AppState = defaultAppState(), action: Actions): AppState {
       return {
         ...state,
         activeLesson: action.payload.activeLesson,
+      };
+    case CUSTOMISE_MODULE:
+      return {
+        ...state,
+        customiseModule: action.payload.moduleCode,
       };
     case CANCEL_MODIFY_LESSON:
     case CHANGE_LESSON:

--- a/website/src/reducers/app.ts
+++ b/website/src/reducers/app.ts
@@ -18,7 +18,7 @@ const defaultAppState = (): AppState => ({
   activeSemester: config.semester,
   // The lesson being modified on the timetable.
   activeLesson: null,
-  customiseModule: null,
+  customiseModule: "",
   isOnline: navigator.onLine,
   isFeedbackModalOpen: false,
   promptRefresh: forceRefreshPrompt(),

--- a/website/src/reducers/app.ts
+++ b/website/src/reducers/app.ts
@@ -3,7 +3,12 @@ import { Actions } from 'types/actions';
 import config from 'config';
 
 import { forceRefreshPrompt } from 'utils/debug';
-import { MODIFY_LESSON, CHANGE_LESSON, CANCEL_MODIFY_LESSON, CUSTOMISE_MODULE } from 'actions/timetables';
+import {
+  MODIFY_LESSON,
+  CHANGE_LESSON,
+  CANCEL_MODIFY_LESSON,
+  CUSTOMISE_MODULE,
+} from 'actions/timetables';
 import { SELECT_SEMESTER } from 'actions/settings';
 import {
   OPEN_NOTIFICATION,
@@ -18,7 +23,7 @@ const defaultAppState = (): AppState => ({
   activeSemester: config.semester,
   // The lesson being modified on the timetable.
   activeLesson: null,
-  customiseModule: "",
+  customiseModule: '',
   isOnline: navigator.onLine,
   isFeedbackModalOpen: false,
   promptRefresh: forceRefreshPrompt(),

--- a/website/src/reducers/index.test.ts
+++ b/website/src/reducers/index.test.ts
@@ -67,6 +67,7 @@ test('reducers should set export data state', () => {
         PC1222: 2,
       },
     },
+    customisedModules: {},
     hidden: { [1]: ['PC1222'] },
     academicYear: expect.any(String),
     archive: {},

--- a/website/src/reducers/timetables.test.ts
+++ b/website/src/reducers/timetables.test.ts
@@ -207,6 +207,7 @@ describe('stateReconciler', () => {
     },
     academicYear: config.academicYear,
     archive: oldArchive,
+    customisedModules: {},
   };
 
   const { stateReconciler } = persistConfig;
@@ -259,6 +260,7 @@ describe('redux schema migration', () => {
     hidden: {},
     academicYear: '2022/2023',
     archive: {},
+    customisedModules: {},
     _persist: {
       version: 1,
       rehydrated: false,
@@ -283,6 +285,7 @@ describe('redux schema migration', () => {
     hidden: {},
     academicYear: '2022/2023',
     archive: {},
+    customisedModules: {},
     _persist: {
       version: 1, // version kept the same because the framework does not support it in unit tests
       rehydrated: false,

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -19,7 +19,6 @@ import {
   SET_LESSON_CONFIG,
   SET_TIMETABLE,
   SHOW_LESSON_IN_TIMETABLE,
-  CUSTOMISE_MODULE,
 } from 'actions/timetables';
 import { getNewColor } from 'utils/colors';
 import { SET_EXPORTED_DATA } from 'actions/constants';
@@ -131,7 +130,7 @@ function moduleLessonConfig(
       if (!(classNo && lessonType)) return state;
       return {
         ...state,
-        [lessonType]: [...state.lessonType, classNo],
+        [lessonType]: [...state[lessonType], classNo],
       };
     }
     case REMOVE_LESSON: {
@@ -139,7 +138,7 @@ function moduleLessonConfig(
       if (!(classNo && lessonType)) return state;
       return {
         ...state,
-        [lessonType]: state.lessonType.filter(lesson => lesson !== classNo),
+        [lessonType]: state[lessonType].filter(lesson => lesson !== classNo),
       };
     }
     default:
@@ -165,6 +164,8 @@ function semTimetable(
     case REMOVE_MODULE:
       return omit(state, [moduleCode]);
     case CHANGE_LESSON:
+    case ADD_LESSON:
+    case REMOVE_LESSON:
     case SET_LESSON_CONFIG:
       return {
         ...state,
@@ -251,6 +252,8 @@ function timetables(
     case REMOVE_MODULE:
     case SELECT_MODULE_COLOR:
     case CHANGE_LESSON:
+    case ADD_LESSON:
+    case REMOVE_LESSON:
     case SET_LESSON_CONFIG:
     case HIDE_LESSON_IN_TIMETABLE:
     case SHOW_LESSON_IN_TIMETABLE: {

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -122,7 +122,7 @@ function moduleLessonConfig(
       if (!(classNo && lessonType)) return state;
       return {
         ...state,
-        [lessonType]: [classNo],
+        [lessonType]: [...state[lessonType].filter(lesson => lesson !== action.payload.activeLesson), action.payload.classNo],
       };
     }
     case SET_LESSON_CONFIG:

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -19,6 +19,8 @@ import {
   SET_LESSON_CONFIG,
   SET_TIMETABLE,
   SHOW_LESSON_IN_TIMETABLE,
+  ADD_CUSTOM_MODULE,
+  REMOVE_CUSTOM_MODULE
 } from 'actions/timetables';
 import { getNewColor } from 'utils/colors';
 import { SET_EXPORTED_DATA } from 'actions/constants';
@@ -221,12 +223,31 @@ function semHiddenModules(state = defaultHiddenState, action: Actions) {
   }
 }
 
+// Map of CustomisedModules
+const defaultCustomisedModulesState: ModuleCode[] = [];
+function customisedModules(state = defaultCustomisedModulesState, action: Actions) {
+  if (!action.payload) {
+    return state;
+  }
+
+  switch (action.type) {
+    case ADD_CUSTOM_MODULE:
+      if (state.includes(action.payload.moduleCode)) return state;
+      return [...state, action.payload.moduleCode];
+    case REMOVE_CUSTOM_MODULE:
+      return state.filter((c) => c !== action.payload.moduleCode);
+    default:
+      return state;
+  }
+}
+
 export const defaultTimetableState: TimetablesState = {
   lessons: {},
   colors: {},
   hidden: {},
   academicYear: config.academicYear,
   archive: {},
+  customisedModules: {},
 };
 
 function timetables(
@@ -256,13 +277,16 @@ function timetables(
     case REMOVE_LESSON:
     case SET_LESSON_CONFIG:
     case HIDE_LESSON_IN_TIMETABLE:
-    case SHOW_LESSON_IN_TIMETABLE: {
+    case SHOW_LESSON_IN_TIMETABLE: 
+    case ADD_CUSTOM_MODULE:
+    case REMOVE_CUSTOM_MODULE:{
       const { semester } = action.payload;
 
       return produce(state, (draft) => {
         draft.lessons[semester] = semTimetable(draft.lessons[semester], action);
         draft.colors[semester] = semColors(state.colors[semester], action);
         draft.hidden[semester] = semHiddenModules(state.hidden[semester], action);
+        draft.customisedModules[semester] = customisedModules(state.customisedModules[semester], action);
       });
     }
 

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -42,7 +42,6 @@ export function migrateV1toV2(
         const lessonArray = [lessonValue];
         newSemester[moduleCode][lessonType] = lessonArray;
       });
-
       if (!newLessons[semester]) {
         newLessons[semester] = {};
       }

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -11,12 +11,15 @@ import config from 'config';
 import {
   ADD_MODULE,
   CHANGE_LESSON,
+  ADD_LESSON,
+  REMOVE_LESSON,
   HIDE_LESSON_IN_TIMETABLE,
   REMOVE_MODULE,
   SELECT_MODULE_COLOR,
   SET_LESSON_CONFIG,
   SET_TIMETABLE,
   SHOW_LESSON_IN_TIMETABLE,
+  CUSTOMISE_MODULE,
 } from 'actions/timetables';
 import { getNewColor } from 'utils/colors';
 import { SET_EXPORTED_DATA } from 'actions/constants';
@@ -123,7 +126,22 @@ function moduleLessonConfig(
     }
     case SET_LESSON_CONFIG:
       return action.payload.lessonConfig;
-
+    case ADD_LESSON: {
+      const { classNo, lessonType } = action.payload;
+      if (!(classNo && lessonType)) return state;
+      return {
+        ...state,
+        [lessonType]: [...state.lessonType, classNo],
+      };
+    }
+    case REMOVE_LESSON: {
+      const { classNo, lessonType } = action.payload;
+      if (!(classNo && lessonType)) return state;
+      return {
+        ...state,
+        [lessonType]: state.lessonType.filter(lesson => lesson !== classNo),
+      };
+    }
     default:
       return state;
   }

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -20,7 +20,7 @@ import {
   SET_TIMETABLE,
   SHOW_LESSON_IN_TIMETABLE,
   ADD_CUSTOM_MODULE,
-  REMOVE_CUSTOM_MODULE
+  REMOVE_CUSTOM_MODULE,
 } from 'actions/timetables';
 import { getNewColor } from 'utils/colors';
 import { SET_EXPORTED_DATA } from 'actions/constants';
@@ -122,7 +122,10 @@ function moduleLessonConfig(
       if (!(classNo && lessonType)) return state;
       return {
         ...state,
-        [lessonType]: [...state[lessonType].filter(lesson => lesson !== action.payload.activeLesson), action.payload.classNo],
+        [lessonType]: [
+          ...state[lessonType].filter((lesson) => lesson !== action.payload.activeLesson),
+          action.payload.classNo,
+        ],
       };
     }
     case SET_LESSON_CONFIG:
@@ -140,7 +143,7 @@ function moduleLessonConfig(
       if (!(classNo && lessonType)) return state;
       return {
         ...state,
-        [lessonType]: state[lessonType].filter(lesson => lesson !== classNo),
+        [lessonType]: state[lessonType].filter((lesson) => lesson !== classNo),
       };
     }
     default:
@@ -277,16 +280,19 @@ function timetables(
     case REMOVE_LESSON:
     case SET_LESSON_CONFIG:
     case HIDE_LESSON_IN_TIMETABLE:
-    case SHOW_LESSON_IN_TIMETABLE: 
+    case SHOW_LESSON_IN_TIMETABLE:
     case ADD_CUSTOM_MODULE:
-    case REMOVE_CUSTOM_MODULE:{
+    case REMOVE_CUSTOM_MODULE: {
       const { semester } = action.payload;
 
       return produce(state, (draft) => {
         draft.lessons[semester] = semTimetable(draft.lessons[semester], action);
         draft.colors[semester] = semColors(state.colors[semester], action);
         draft.hidden[semester] = semHiddenModules(state.hidden[semester], action);
-        draft.customisedModules[semester] = customisedModules(state.customisedModules[semester], action);
+        draft.customisedModules[semester] = customisedModules(
+          state.customisedModules[semester],
+          action,
+        );
       });
     }
 

--- a/website/src/selectors/timetables.ts
+++ b/website/src/selectors/timetables.ts
@@ -38,3 +38,8 @@ export const getSemesterTimetableColors = createSelector(
   (colors) => (semester: Semester | null) =>
     semester === null ? EMPTY_OBJECT : colors[semester] ?? EMPTY_OBJECT,
 );
+
+export const getCustomisingLesson = createSelector(
+  ({ app }: State) => app.customiseModule,
+  (customiseModule) => customiseModule ?? null,
+)

--- a/website/src/selectors/timetables.ts
+++ b/website/src/selectors/timetables.ts
@@ -42,4 +42,4 @@ export const getSemesterTimetableColors = createSelector(
 export const getCustomisingLesson = createSelector(
   ({ app }: State) => app.customiseModule,
   (customiseModule) => customiseModule ?? null,
-)
+);

--- a/website/src/types/reducers.ts
+++ b/website/src/types/reducers.ts
@@ -51,7 +51,7 @@ export type NotificationData = { readonly message: string } & NotificationOption
 export type AppState = {
   readonly activeSemester: Semester;
   readonly activeLesson: Lesson | null;
-  readonly customiseModule: ModuleCode | null;
+  readonly customiseModule: ModuleCode;
   readonly isOnline: boolean;
   readonly isFeedbackModalOpen: boolean;
   readonly notifications: NotificationData[];

--- a/website/src/types/reducers.ts
+++ b/website/src/types/reducers.ts
@@ -113,6 +113,7 @@ export type SettingsState = {
 export type ColorMapping = { [moduleCode: string]: ColorIndex };
 export type SemesterColorMap = { [semester: string]: ColorMapping };
 export type HiddenModulesMap = { [semester: string]: ModuleCode[] };
+export type CustomisedModulesMap = { [semester: string]: ModuleCode[] };
 
 export type TimetablesState = {
   readonly lessons: TimetableConfig;
@@ -121,6 +122,7 @@ export type TimetablesState = {
   readonly academicYear: string;
   // Mapping of academic year to old timetable config
   readonly archive: { [key: string]: TimetableConfig };
+  readonly customisedModules: CustomisedModulesMap;
 };
 
 /* venueBank.js */

--- a/website/src/types/reducers.ts
+++ b/website/src/types/reducers.ts
@@ -51,6 +51,7 @@ export type NotificationData = { readonly message: string } & NotificationOption
 export type AppState = {
   readonly activeSemester: Semester;
   readonly activeLesson: Lesson | null;
+  readonly customiseModule: ModuleCode | null;
   readonly isOnline: boolean;
   readonly isFeedbackModalOpen: boolean;
   readonly notifications: NotificationData[];

--- a/website/src/views/timetable/Timetable.tsx
+++ b/website/src/views/timetable/Timetable.tsx
@@ -19,6 +19,7 @@ import { TimePeriod } from 'types/venues';
 import styles from './Timetable.scss';
 import TimetableTimings from './TimetableTimings';
 import TimetableDay from './TimetableDay';
+import { ModuleCode } from 'types/modules';
 
 type Props = TimerData & {
   lessons: TimetableArrangement;
@@ -29,6 +30,7 @@ type Props = TimerData & {
   showTitle?: boolean;
   onModifyCell?: OnModifyCell;
   highlightPeriod?: TimePeriod;
+  customisedModules?: ModuleCode[];
 };
 
 type State = {
@@ -108,6 +110,7 @@ class Timetable extends React.PureComponent<Props, State> {
                 highlightPeriod={
                   highlightPeriod && index === highlightPeriod.day ? highlightPeriod : undefined
                 }
+                customisedModules={this.props.customisedModules}
               />
             ))}
           </ol>

--- a/website/src/views/timetable/Timetable.tsx
+++ b/website/src/views/timetable/Timetable.tsx
@@ -16,10 +16,10 @@ import elements from 'views/elements';
 import withTimer, { TimerData } from 'views/hocs/withTimer';
 
 import { TimePeriod } from 'types/venues';
+import { ModuleCode } from 'types/modules';
 import styles from './Timetable.scss';
 import TimetableTimings from './TimetableTimings';
 import TimetableDay from './TimetableDay';
-import { ModuleCode } from 'types/modules';
 
 type Props = TimerData & {
   lessons: TimetableArrangement;

--- a/website/src/views/timetable/TimetableCell.tsx
+++ b/website/src/views/timetable/TimetableCell.tsx
@@ -4,7 +4,7 @@ import { isEqual } from 'lodash';
 import { addWeeks, format, parseISO } from 'date-fns';
 import NUSModerator, { AcadWeekInfo } from 'nusmoderator';
 
-import { consumeWeeks, WeekRange } from 'types/modules';
+import { consumeWeeks, ModuleCode, WeekRange } from 'types/modules';
 import { HoverLesson, ModifiableLesson } from 'types/timetables';
 import { OnHoverCell } from 'types/views';
 
@@ -26,6 +26,7 @@ type Props = {
   onClick?: (position: ClientRect) => void;
   hoverLesson?: HoverLesson | null;
   transparent: boolean;
+  customisedModules?: ModuleCode[];
 };
 
 const lessonDateFormat = 'MMM dd';
@@ -131,7 +132,7 @@ const TimetableCell: React.FC<Props> = (props) => {
       {...conditionalProps}
     >
       <div className={styles.cellContainer}>
-        <div className={styles.moduleName}>{moduleName}</div>
+        <div className={styles.moduleName}>{moduleName}{props.customisedModules && props.customisedModules.includes(lesson.moduleCode)?' (TA)':null}</div>
         <div>
           {LESSON_TYPE_ABBREV[lesson.lessonType]} [{lesson.classNo}]
         </div>

--- a/website/src/views/timetable/TimetableCell.tsx
+++ b/website/src/views/timetable/TimetableCell.tsx
@@ -132,7 +132,7 @@ const TimetableCell: React.FC<Props> = (props) => {
       {...conditionalProps}
     >
       <div className={styles.cellContainer}>
-        <div className={styles.moduleName}>{moduleName}{props.customisedModules && props.customisedModules.includes(lesson.moduleCode)?' (TA)':null}</div>
+        <div className={styles.moduleName}>{moduleName}{props.customisedModules && props.customisedModules.includes(lesson.moduleCode)?'*':null}</div>
         <div>
           {LESSON_TYPE_ABBREV[lesson.lessonType]} [{lesson.classNo}]
         </div>

--- a/website/src/views/timetable/TimetableCell.tsx
+++ b/website/src/views/timetable/TimetableCell.tsx
@@ -132,7 +132,12 @@ const TimetableCell: React.FC<Props> = (props) => {
       {...conditionalProps}
     >
       <div className={styles.cellContainer}>
-        <div className={styles.moduleName}>{moduleName}{props.customisedModules && props.customisedModules.includes(lesson.moduleCode)?'*':null}</div>
+        <div className={styles.moduleName}>
+          {moduleName}
+          {props.customisedModules && props.customisedModules.includes(lesson.moduleCode)
+            ? '*'
+            : null}
+        </div>
         <div>
           {LESSON_TYPE_ABBREV[lesson.lessonType]} [{lesson.classNo}]
         </div>

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -74,7 +74,8 @@ type Props = OwnProps & {
   timetableWithLessons: SemTimetableConfigWithLessons;
   modules: ModulesMap;
   activeLesson: Lesson | null;
-  customiseModule: ModuleCode | null;
+  customiseModule: ModuleCode;
+  customisedModules: ModuleCode[];
   timetableOrientation: TimetableOrientation;
   showTitle: boolean;
   hiddenInTimetable: ModuleCode[];
@@ -427,6 +428,7 @@ class TimetableContent extends React.Component<Props, State> {
                   isScrolledHorizontally={this.state.isScrolledHorizontally}
                   showTitle={isShowingTitle}
                   onModifyCell={this.modifyCell}
+                  customisedModules={this.props.customisedModules}
                 />
               </div>
             )}
@@ -487,6 +489,7 @@ function mapStateToProps(state: StoreState, ownProps: OwnProps) {
     modules,
     activeLesson: state.app.activeLesson,
     customiseModule: state.app.customiseModule,
+    customisedModules: state.timetables.customisedModules[semester],
     timetableOrientation: state.theme.timetableOrientation,
     showTitle: state.theme.showTitle,
     hiddenInTimetable,

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -84,7 +84,7 @@ type Props = OwnProps & {
   addModule: (semester: Semester, moduleCode: ModuleCode) => void;
   removeModule: (semester: Semester, moduleCode: ModuleCode) => void;
   modifyLesson: (lesson: Lesson) => void;
-  changeLesson: (semester: Semester, lesson: Lesson) => void;
+  changeLesson: (semester: Semester, lesson: Lesson, activeLesson: ClassNo) => void;
   cancelModifyLesson: () => void;
   undo: () => void;
   addLesson: (semester: Semester, moduleCode: ModuleCode, lessonType: LessonType, classNo: ClassNo) => void;
@@ -177,7 +177,7 @@ class TimetableContent extends React.Component<Props, State> {
         this.props.removeLesson(this.props.semester, lesson.moduleCode, lesson.lessonType, lesson.classNo);
       }
     } else if (lesson.isAvailable) {
-      this.props.changeLesson(this.props.semester, lesson);
+      this.props.changeLesson(this.props.semester, lesson, this.props.activeLesson!.classNo);
 
       resetScrollPosition();
     } else if (lesson.isActive) {

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -87,8 +87,18 @@ type Props = OwnProps & {
   changeLesson: (semester: Semester, lesson: Lesson, activeLesson: ClassNo) => void;
   cancelModifyLesson: () => void;
   undo: () => void;
-  addLesson: (semester: Semester, moduleCode: ModuleCode, lessonType: LessonType, classNo: ClassNo) => void;
-  removeLesson: (semester: Semester, moduleCode: ModuleCode, lessonType: LessonType, classNo: ClassNo) => void;
+  addLesson: (
+    semester: Semester,
+    moduleCode: ModuleCode,
+    lessonType: LessonType,
+    classNo: ClassNo,
+  ) => void;
+  removeLesson: (
+    semester: Semester,
+    moduleCode: ModuleCode,
+    lessonType: LessonType,
+    classNo: ClassNo,
+  ) => void;
 };
 
 type State = {
@@ -170,14 +180,23 @@ class TimetableContent extends React.Component<Props, State> {
         position,
         className: getLessonIdentifier(lesson),
       };
-      console.log(lesson);
       if (lesson.isAvailable) {
-        this.props.addLesson(this.props.semester, lesson.moduleCode, lesson.lessonType, lesson.classNo);
+        this.props.addLesson(
+          this.props.semester,
+          lesson.moduleCode,
+          lesson.lessonType,
+          lesson.classNo,
+        );
       } else if (lesson.isActive) {
-        this.props.removeLesson(this.props.semester, lesson.moduleCode, lesson.lessonType, lesson.classNo);
+        this.props.removeLesson(
+          this.props.semester,
+          lesson.moduleCode,
+          lesson.lessonType,
+          lesson.classNo,
+        );
       }
-    } else if (lesson.isAvailable) {
-      this.props.changeLesson(this.props.semester, lesson, this.props.activeLesson!.classNo);
+    } else if (lesson.isAvailable && this.props.activeLesson) {
+      this.props.changeLesson(this.props.semester, lesson, this.props.activeLesson.classNo);
 
       resetScrollPosition();
     } else if (lesson.isActive) {
@@ -303,21 +322,26 @@ class TimetableContent extends React.Component<Props, State> {
       .filter((lesson) => !this.isHiddenInTimetable(lesson.moduleCode));
 
     if (this.props.customiseModule) {
-      const activeLessons = timetableLessons.filter((lesson) => lesson.moduleCode === this.props.customiseModule,);
+      const activeLessons = timetableLessons.filter(
+        (lesson) => lesson.moduleCode === this.props.customiseModule,
+      );
       timetableLessons = timetableLessons.filter(
         (lesson) => lesson.moduleCode !== this.props.customiseModule,
       );
 
       const module = modules[this.props.customiseModule];
-      let moduleTimetable = getModuleTimetable(module, semester);
+      const moduleTimetable = getModuleTimetable(module, semester);
       moduleTimetable.forEach((lesson) => {
-        const isActiveLesson = activeLessons.filter((timetableLesson) => 
-        timetableLesson.classNo == lesson.classNo && timetableLesson.lessonType == lesson.lessonType
-        ).length > 0
+        const isActiveLesson =
+          activeLessons.filter(
+            (timetableLesson) =>
+              timetableLesson.classNo === lesson.classNo &&
+              timetableLesson.lessonType === lesson.lessonType,
+          ).length > 0;
         const modifiableLesson: Lesson & { isActive?: boolean; isAvailable?: boolean } = {
           ...lesson,
           // Inject module code in
-          moduleCode: this.props.customiseModule!,
+          moduleCode: this.props.customiseModule,
           title: module.title,
           isAvailable: !isActiveLesson,
           isActive: isActiveLesson,
@@ -369,8 +393,7 @@ class TimetableContent extends React.Component<Props, State> {
 
             return {
               ...lesson,
-              isModifiable:
-                this.props.customiseModule
+              isModifiable: this.props.customiseModule
                 ? true
                 : !readOnly && areOtherClassesAvailable(moduleTimetable, lesson.lessonType),
             };

--- a/website/src/views/timetable/TimetableDay.tsx
+++ b/website/src/views/timetable/TimetableDay.tsx
@@ -10,6 +10,7 @@ import styles from './TimetableDay.scss';
 import TimetableRow from './TimetableRow';
 import CurrentTimeIndicator from './CurrentTimeIndicator';
 import TimetableHighlight from './TimetableHighlight';
+import { ModuleCode } from 'types/modules';
 
 type Props = {
   day: string;
@@ -25,6 +26,7 @@ type Props = {
   onCellHover: OnHoverCell;
   onModifyCell?: OnModifyCell;
   highlightPeriod?: TimePeriod;
+  customisedModules?: ModuleCode[];
 };
 
 // Height of timetable per hour in vertical mode
@@ -87,6 +89,7 @@ const TimetableDay: React.FC<Props> = (props) => {
             onModifyCell={props.onModifyCell}
             hoverLesson={props.hoverLesson}
             onCellHover={props.onCellHover}
+            customisedModules={props.customisedModules}
           />
         ))}
 

--- a/website/src/views/timetable/TimetableDay.tsx
+++ b/website/src/views/timetable/TimetableDay.tsx
@@ -6,11 +6,11 @@ import { OnHoverCell, OnModifyCell } from 'types/views';
 import { convertTimeToIndex } from 'utils/timify';
 
 import { TimePeriod } from 'types/venues';
+import { ModuleCode } from 'types/modules';
 import styles from './TimetableDay.scss';
 import TimetableRow from './TimetableRow';
 import CurrentTimeIndicator from './CurrentTimeIndicator';
 import TimetableHighlight from './TimetableHighlight';
-import { ModuleCode } from 'types/modules';
 
 type Props = {
   day: string;

--- a/website/src/views/timetable/TimetableModuleTable.test.tsx
+++ b/website/src/views/timetable/TimetableModuleTable.test.tsx
@@ -3,9 +3,9 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import { CS1010S, CS3216, CS4243 } from '__mocks__/modules';
 import { addColors } from 'test-utils/theme';
 
+import * as redux from 'react-redux';
 import { TimetableModulesTableComponent, Props } from './TimetableModulesTable';
 import styles from './TimetableModulesTable.scss';
-import * as redux from 'react-redux'
 
 function make(props: Partial<Props> = {}) {
   const selectModuleColor = jest.fn();
@@ -17,8 +17,8 @@ function make(props: Partial<Props> = {}) {
   const addCustomModule = jest.fn();
   const removeCustomModule = jest.fn();
 
-  const beta = jest.spyOn(redux, 'useSelector')
-  beta.mockReturnValue(false)
+  const beta = jest.spyOn(redux, 'useSelector');
+  beta.mockReturnValue(false);
 
   const wrapper = shallow(
     <TimetableModulesTableComponent
@@ -34,11 +34,11 @@ function make(props: Partial<Props> = {}) {
       onRemoveModule={onRemoveModule}
       resetTombstone={resetTombstone}
       customiseLesson={customiseLesson}
-      customiseModule=''
+      customiseModule=""
       addCustomModule={addCustomModule}
       removeCustomModule={removeCustomModule}
       {...props}
-    />
+    />,
   );
 
   return {

--- a/website/src/views/timetable/TimetableModuleTable.test.tsx
+++ b/website/src/views/timetable/TimetableModuleTable.test.tsx
@@ -5,6 +5,7 @@ import { addColors } from 'test-utils/theme';
 
 import { TimetableModulesTableComponent, Props } from './TimetableModulesTable';
 import styles from './TimetableModulesTable.scss';
+import * as redux from 'react-redux'
 
 function make(props: Partial<Props> = {}) {
   const selectModuleColor = jest.fn();
@@ -12,6 +13,12 @@ function make(props: Partial<Props> = {}) {
   const hideLessonInTimetable = jest.fn();
   const showLessonInTimetable = jest.fn();
   const resetTombstone = jest.fn();
+  const customiseLesson = jest.fn();
+  const addCustomModule = jest.fn();
+  const removeCustomModule = jest.fn();
+
+  const beta = jest.spyOn(redux, 'useSelector')
+  beta.mockReturnValue(false)
 
   const wrapper = shallow(
     <TimetableModulesTableComponent
@@ -26,8 +33,12 @@ function make(props: Partial<Props> = {}) {
       showLessonInTimetable={showLessonInTimetable}
       onRemoveModule={onRemoveModule}
       resetTombstone={resetTombstone}
+      customiseLesson={customiseLesson}
+      customiseModule=''
+      addCustomModule={addCustomModule}
+      removeCustomModule={removeCustomModule}
       {...props}
-    />,
+    />
   );
 
   return {

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -12,7 +12,7 @@ import { State as StoreState } from 'types/state';
 import { ModuleTableOrder } from 'types/reducers';
 import { customiseLesson } from 'actions/timetables';
 import ColorPicker from 'views/components/ColorPicker';
-import { Eye, EyeOff, Trash, Tool } from 'react-feather';
+import { Eye, EyeOff, Trash, Tool, Check } from 'react-feather';
 import {
   hideLessonInTimetable,
   selectModuleColor,
@@ -37,6 +37,7 @@ export type Props = {
   moduleTableOrder: ModuleTableOrder;
   modules: ModuleWithColor[];
   tombstone: TombstoneModule | null; // Placeholder for a deleted module
+  customiseModule: ModuleCode | null;
 
   // Actions
   selectModuleColor: (semester: Semester, moduleCode: ModuleCode, colorIndex: ColorIndex) => void;
@@ -52,11 +53,25 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
     const hideBtnLabel = `${module.hiddenInTimetable ? 'Show' : 'Hide'} ${module.moduleCode}`;
     const removeBtnLabel = `Remove ${module.moduleCode} from timetable`;
     const customBtnLabel = `Customise ${module.moduleCode} in timetable`;
+    const doneBtnLabel = `Done customising ${module.moduleCode} in timetable`;
     const { semester } = props;
 
     return (
       <div className={styles.moduleActionButtons}>
-        <div className="btn-group">
+        {props.customiseModule == module.moduleCode 
+          ? <Tooltip content={doneBtnLabel} touch="hold">
+            <button
+              type="button"
+              className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
+              aria-label={removeBtnLabel}
+              onClick={() => {
+                props.customiseLesson(semester, "");
+              }}
+            >
+              <Check className={styles.actionIcon} />
+            </button>
+          </Tooltip>
+          : <div className="btn-group">
           <Tooltip content={removeBtnLabel} touch="hold">
             <button
               type="button"
@@ -100,7 +115,7 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
               <Tool className={styles.actionIcon}/>
             </button>
           </Tooltip>
-        </div>
+        </div>}
       </div>
     );
   };
@@ -177,7 +192,9 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
 };
 
 export default connect(
-  (state: StoreState) => ({ moduleTableOrder: state.settings.moduleTableOrder }),
+  (state: StoreState) => ({
+    moduleTableOrder: state.settings.moduleTableOrder,
+    customiseModule: state.app.customiseModule}),
   {
     selectModuleColor,
     hideLessonInTimetable,

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -10,7 +10,7 @@ import { ColorIndex } from 'types/timetables';
 import { ModuleCode, Semester } from 'types/modules';
 import { State as StoreState } from 'types/state';
 import { ModuleTableOrder } from 'types/reducers';
-
+import { customiseLesson } from 'actions/timetables';
 import ColorPicker from 'views/components/ColorPicker';
 import { Eye, EyeOff, Trash, Tool } from 'react-feather';
 import {
@@ -44,6 +44,7 @@ export type Props = {
   showLessonInTimetable: (semester: Semester, moduleCode: ModuleCode) => void;
   onRemoveModule: (moduleCode: ModuleCode) => void;
   resetTombstone: () => void;
+  customiseLesson: (semester: Semester, moduleCode: ModuleCode) => void;
 };
 
 export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
@@ -92,7 +93,7 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
               className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
               aria-label={customBtnLabel}
               onClick={() => {
-                // trigger redux state to edit module
+                props.customiseLesson(semester, module.moduleCode);
               }}
             >
               <Tool className={styles.actionIcon}/>
@@ -180,5 +181,6 @@ export default connect(
     selectModuleColor,
     hideLessonInTimetable,
     showLessonInTimetable,
+    customiseLesson,
   },
 )(React.memo(TimetableModulesTableComponent));

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import classnames from 'classnames';
 import { sortBy } from 'lodash';
@@ -8,7 +8,7 @@ import produce from 'immer';
 import { ModuleWithColor, TombstoneModule } from 'types/views';
 import { ColorIndex } from 'types/timetables';
 import { ModuleCode, Semester } from 'types/modules';
-import { State as StoreState } from 'types/state';
+import { State, State as StoreState } from 'types/state';
 import { ModuleTableOrder } from 'types/reducers';
 import { customiseLesson, addCustomModule, removeCustomModule } from 'actions/timetables';
 import ColorPicker from 'views/components/ColorPicker';
@@ -51,6 +51,7 @@ export type Props = {
 };
 
 export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
+  const beta = useSelector(({ settings }: State) => settings.beta);
   const renderModuleActions = (module: ModuleWithColor) => {
     const hideBtnLabel = `${module.hiddenInTimetable ? 'Show' : 'Hide'} ${module.moduleCode}`;
     const removeBtnLabel = `Remove ${module.moduleCode} from timetable`;
@@ -107,7 +108,7 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
               )}
             </button>
           </Tooltip>
-          <Tooltip content={customBtnLabel} touch="hold">
+          {beta && <Tooltip content={customBtnLabel} touch="hold">
             <button
               type="button"
               className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
@@ -122,7 +123,7 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
             >
               <Tool className={styles.actionIcon}/>
             </button>
-          </Tooltip>
+          </Tooltip>}
         </div>}
       </div>
     );

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -12,7 +12,7 @@ import { State as StoreState } from 'types/state';
 import { ModuleTableOrder } from 'types/reducers';
 
 import ColorPicker from 'views/components/ColorPicker';
-import { Eye, EyeOff, Trash } from 'react-feather';
+import { Eye, EyeOff, Trash, Tool } from 'react-feather';
 import {
   hideLessonInTimetable,
   selectModuleColor,
@@ -50,6 +50,7 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
   const renderModuleActions = (module: ModuleWithColor) => {
     const hideBtnLabel = `${module.hiddenInTimetable ? 'Show' : 'Hide'} ${module.moduleCode}`;
     const removeBtnLabel = `Remove ${module.moduleCode} from timetable`;
+    const customBtnLabel = `Customise ${module.moduleCode} in timetable`;
     const { semester } = props;
 
     return (
@@ -83,6 +84,18 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
               ) : (
                 <EyeOff className={styles.actionIcon} />
               )}
+            </button>
+          </Tooltip>
+          <Tooltip content={customBtnLabel} touch="hold">
+            <button
+              type="button"
+              className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
+              aria-label={customBtnLabel}
+              onClick={() => {
+                // trigger redux state to edit module
+              }}
+            >
+              <Tool className={styles.actionIcon}/>
             </button>
           </Tooltip>
         </div>

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -93,6 +93,7 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
               className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
               aria-label={customBtnLabel}
               onClick={() => {
+                // TODO: add modal for warning 
                 props.customiseLesson(semester, module.moduleCode);
               }}
             >

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -37,7 +37,7 @@ export type Props = {
   moduleTableOrder: ModuleTableOrder;
   modules: ModuleWithColor[];
   tombstone: TombstoneModule | null; // Placeholder for a deleted module
-  customiseModule: ModuleCode | null;
+  customiseModule: ModuleCode;
 
   // Actions
   selectModuleColor: (semester: Semester, moduleCode: ModuleCode, colorIndex: ColorIndex) => void;
@@ -112,6 +112,8 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
               type="button"
               className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
               aria-label={customBtnLabel}
+              disabled={props.customiseModule !== "" && props.customiseModule != module.moduleCode}
+              hidden={props.customiseModule !== "" && props.customiseModule != module.moduleCode}
               onClick={() => {
                 // TODO: add modal for warning 
                 props.addCustomModule(semester, module.moduleCode);

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -10,7 +10,7 @@ import { ColorIndex } from 'types/timetables';
 import { ModuleCode, Semester } from 'types/modules';
 import { State as StoreState } from 'types/state';
 import { ModuleTableOrder } from 'types/reducers';
-import { customiseLesson } from 'actions/timetables';
+import { customiseLesson, addCustomModule, removeCustomModule } from 'actions/timetables';
 import ColorPicker from 'views/components/ColorPicker';
 import { Eye, EyeOff, Trash, Tool, Check } from 'react-feather';
 import {
@@ -44,6 +44,8 @@ export type Props = {
   hideLessonInTimetable: (semester: Semester, moduleCode: ModuleCode) => void;
   showLessonInTimetable: (semester: Semester, moduleCode: ModuleCode) => void;
   onRemoveModule: (moduleCode: ModuleCode) => void;
+  addCustomModule: (semester: Semester, moduleCode: ModuleCode) => void;
+  removeCustomModule: (semester: Semester, moduleCode: ModuleCode) => void;
   resetTombstone: () => void;
   customiseLesson: (semester: Semester, moduleCode: ModuleCode) => void;
 };
@@ -77,7 +79,10 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
               type="button"
               className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
               aria-label={removeBtnLabel}
-              onClick={() => props.onRemoveModule(module.moduleCode)}
+              onClick={() => {
+                props.onRemoveModule(module.moduleCode);
+                props.removeCustomModule(semester, module.moduleCode);
+              }}
             >
               <Trash className={styles.actionIcon} />
             </button>
@@ -109,6 +114,7 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
               aria-label={customBtnLabel}
               onClick={() => {
                 // TODO: add modal for warning 
+                props.addCustomModule(semester, module.moduleCode);
                 props.customiseLesson(semester, module.moduleCode);
               }}
             >
@@ -200,5 +206,7 @@ export default connect(
     hideLessonInTimetable,
     showLessonInTimetable,
     customiseLesson,
+    addCustomModule,
+    removeCustomModule,
   },
 )(React.memo(TimetableModulesTableComponent));

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -10,14 +10,17 @@ import { ColorIndex } from 'types/timetables';
 import { ModuleCode, Semester } from 'types/modules';
 import { State, State as StoreState } from 'types/state';
 import { ModuleTableOrder } from 'types/reducers';
-import { customiseLesson, addCustomModule, removeCustomModule } from 'actions/timetables';
-import ColorPicker from 'views/components/ColorPicker';
-import { Eye, EyeOff, Trash, Tool, Check } from 'react-feather';
 import {
+  customiseLesson,
+  addCustomModule,
+  removeCustomModule,
   hideLessonInTimetable,
   selectModuleColor,
   showLessonInTimetable,
 } from 'actions/timetables';
+import ColorPicker from 'views/components/ColorPicker';
+import { Eye, EyeOff, Trash, Tool, Check } from 'react-feather';
+
 import { getExamDate, getFormattedExamDate, renderMCs } from 'utils/modules';
 import { intersperse } from 'utils/array';
 import { BULLET_NBSP } from 'utils/react';
@@ -61,70 +64,78 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
 
     return (
       <div className={styles.moduleActionButtons}>
-        {props.customiseModule == module.moduleCode 
-          ? <Tooltip content={doneBtnLabel} touch="hold">
+        {props.customiseModule === module.moduleCode ? (
+          <Tooltip content={doneBtnLabel} touch="hold">
             <button
               type="button"
               className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
               aria-label={removeBtnLabel}
               onClick={() => {
-                props.customiseLesson(semester, "");
+                props.customiseLesson(semester, '');
               }}
             >
               <Check className={styles.actionIcon} />
             </button>
           </Tooltip>
-          : <div className="btn-group">
-          <Tooltip content={removeBtnLabel} touch="hold">
-            <button
-              type="button"
-              className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
-              aria-label={removeBtnLabel}
-              onClick={() => {
-                props.onRemoveModule(module.moduleCode);
-                props.removeCustomModule(semester, module.moduleCode);
-              }}
-            >
-              <Trash className={styles.actionIcon} />
-            </button>
-          </Tooltip>
-          <Tooltip content={hideBtnLabel} touch="hold">
-            <button
-              type="button"
-              className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
-              aria-label={hideBtnLabel}
-              onClick={() => {
-                if (module.hiddenInTimetable) {
-                  props.showLessonInTimetable(semester, module.moduleCode);
-                } else {
-                  props.hideLessonInTimetable(semester, module.moduleCode);
-                }
-              }}
-            >
-              {module.hiddenInTimetable ? (
-                <Eye className={styles.actionIcon} />
-              ) : (
-                <EyeOff className={styles.actionIcon} />
-              )}
-            </button>
-          </Tooltip>
-          {beta && <Tooltip content={customBtnLabel} touch="hold">
-            <button
-              type="button"
-              className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
-              aria-label={customBtnLabel}
-              disabled={props.customiseModule !== "" && props.customiseModule != module.moduleCode}
-              hidden={props.customiseModule !== "" && props.customiseModule != module.moduleCode}
-              onClick={() => {
-                // TODO: add modal for warning 
-                props.addCustomModule(semester, module.moduleCode);
-                props.customiseLesson(semester, module.moduleCode);
-              }}
-            >
-              <Tool className={styles.actionIcon}/>
-            </button>
-          </Tooltip>}
-        </div>}
+        ) : (
+          <div className="btn-group">
+            <Tooltip content={removeBtnLabel} touch="hold">
+              <button
+                type="button"
+                className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
+                aria-label={removeBtnLabel}
+                onClick={() => {
+                  props.onRemoveModule(module.moduleCode);
+                  props.removeCustomModule(semester, module.moduleCode);
+                }}
+              >
+                <Trash className={styles.actionIcon} />
+              </button>
+            </Tooltip>
+            <Tooltip content={hideBtnLabel} touch="hold">
+              <button
+                type="button"
+                className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
+                aria-label={hideBtnLabel}
+                onClick={() => {
+                  if (module.hiddenInTimetable) {
+                    props.showLessonInTimetable(semester, module.moduleCode);
+                  } else {
+                    props.hideLessonInTimetable(semester, module.moduleCode);
+                  }
+                }}
+              >
+                {module.hiddenInTimetable ? (
+                  <Eye className={styles.actionIcon} />
+                ) : (
+                  <EyeOff className={styles.actionIcon} />
+                )}
+              </button>
+            </Tooltip>
+            {beta && (
+              <Tooltip content={customBtnLabel} touch="hold">
+                <button
+                  type="button"
+                  className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
+                  aria-label={customBtnLabel}
+                  disabled={
+                    props.customiseModule !== '' && props.customiseModule !== module.moduleCode
+                  }
+                  hidden={
+                    props.customiseModule !== '' && props.customiseModule !== module.moduleCode
+                  }
+                  onClick={() => {
+                    // TODO: add modal for warning
+                    props.addCustomModule(semester, module.moduleCode);
+                    props.customiseLesson(semester, module.moduleCode);
+                  }}
+                >
+                  <Tool className={styles.actionIcon} />
+                </button>
+              </Tooltip>
+            )}
+          </div>
+        )}
       </div>
     );
   };
@@ -203,7 +214,8 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
 export default connect(
   (state: StoreState) => ({
     moduleTableOrder: state.settings.moduleTableOrder,
-    customiseModule: state.app.customiseModule}),
+    customiseModule: state.app.customiseModule,
+  }),
   {
     selectModuleColor,
     hideLessonInTimetable,

--- a/website/src/views/timetable/TimetableRow.tsx
+++ b/website/src/views/timetable/TimetableRow.tsx
@@ -6,6 +6,7 @@ import { OnHoverCell, OnModifyCell } from 'types/views';
 import { convertTimeToIndex } from 'utils/timify';
 import styles from './TimetableRow.scss';
 import TimetableCell from './TimetableCell';
+import { ModuleCode } from 'types/modules';
 
 type Props = {
   verticalMode: boolean;
@@ -16,6 +17,7 @@ type Props = {
   hoverLesson?: HoverLesson | null;
   onCellHover: OnHoverCell;
   onModifyCell?: OnModifyCell;
+  customisedModules?: ModuleCode[];
 };
 
 /**
@@ -70,6 +72,7 @@ const TimetableRow: React.FC<Props> = (props) => {
             hoverLesson={props.hoverLesson}
             onHover={props.onCellHover}
             transparent={lesson.startTime === lesson.endTime}
+            customisedModules={props.customisedModules}
             {...conditionalProps}
           />
         );

--- a/website/src/views/timetable/TimetableRow.tsx
+++ b/website/src/views/timetable/TimetableRow.tsx
@@ -4,9 +4,9 @@ import { HoverLesson, ModifiableLesson } from 'types/timetables';
 import { OnHoverCell, OnModifyCell } from 'types/views';
 
 import { convertTimeToIndex } from 'utils/timify';
+import { ModuleCode } from 'types/modules';
 import styles from './TimetableRow.scss';
 import TimetableCell from './TimetableCell';
-import { ModuleCode } from 'types/modules';
 
 type Props = {
   verticalMode: boolean;


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Closes #3404 
## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
UI side:
* A new button with the setting icon will be added next to the delete/hide button for each of the modules at the bottom
* Once the edit button is pressed, the timetable will enter the state where all possible slots for that module are now selectable/removable
* At this point, buttons next to the module below will turn into a **DONE** button, this will end the customisation mode
* A special symbol (*) is placed on **ALL** of the slots for modules to emphasis that the module has been customised

Code side:
* Implement the UI mentioned above
* A new redux state that stores the modules that are customised will be added.
* New redux actions needed for this state
## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
It will only available in beta 