### PR TITLE
Use new NUS course/unit terminology

### DIFF
--- a/website/src/__mocks__/modules/CS1010S.json
+++ b/website/src/__mocks__/modules/CS1010S.json
@@ -4,7 +4,7 @@
   "acadYear": "2017/2018",
   "department": "Computer Science",
   "faculty": "Computing",
-  "description": "This module introduces the fundamental concepts of problem solving by computing and programming using an imperative programming language. It is the first and foremost introductory course to computing and is equivalent to CS1010 and CS1010E Programming Methodology. Topics covered include problem solving by computing, writing pseudo-codes, basic problem formulation and problem solving, program development, coding, testing and debugging, fundamental programming constructs (variables, types, expressions, assignments, functions, control structures, etc.), fundamental data structures: arrays, strings and structures, simple file processing, and basic recursion. This module is appropriate for FoS students.",
+  "description": "This course introduces the fundamental concepts of problem solving by computing and programming using an imperative programming language. It is the first and foremost introductory course to computing and is equivalent to CS1010 and CS1010E Programming Methodology. Topics covered include problem solving by computing, writing pseudo-codes, basic problem formulation and problem solving, program development, coding, testing and debugging, fundamental programming constructs (variables, types, expressions, assignments, functions, control structures, etc.), fundamental data structures: arrays, strings and structures, simple file processing, and basic recursion. This course is appropriate for FoS students.",
   "moduleCredit": "4",
   "workload": [2, 1, 1, 3, 3],
   "preclusion": "CG1101, CS1010, CS1010E, CS1010FC, CS1101, CS1101C, CS1101S",

--- a/website/src/config/index.ts
+++ b/website/src/config/index.ts
@@ -8,10 +8,10 @@ import modRegData from 'data/modreg-schedule.json';
 import appConfig from './app-config.json';
 
 export const regPeriods = [
-  'Select Modules',
+  'Select Courses',
   'Select Tutorials / Labs',
   'Add / Swap Tutorials',
-  'Submit Module Requests',
+  'Submit Course Requests',
 ] as const;
 export type RegPeriodType = typeof regPeriods[number];
 

--- a/website/src/reducers/settings.test.ts
+++ b/website/src/reducers/settings.test.ts
@@ -28,9 +28,9 @@ const settingsWithFaculty: SettingsState = { ...initialState, faculty };
 const settingsWithDarkMode: SettingsState = { ...initialState, mode: DARK_MODE };
 const settingsWithDismissedNotifications: SettingsState = produce(initialState, (draft) => {
   draft.modRegNotification.dismissed = [
-    { type: 'Select Modules', name: '1' },
+    { type: 'Select Courses', name: '1' },
     { type: 'Add / Swap Tutorials', name: '' },
-    { type: 'Select Modules', name: '2' },
+    { type: 'Select Courses', name: '2' },
   ];
 });
 
@@ -111,7 +111,7 @@ describe('modRegNotification settings', () => {
     expect(
       reducer(
         settingsWithDismissedNotifications,
-        actions.dismissModregNotification({ type: 'Select Modules', name: '1' } as RegPeriod),
+        actions.dismissModregNotification({ type: 'Select Courses', name: '1' } as RegPeriod),
       ).modRegNotification.dismissed,
     ).toEqual(settingsWithDismissedNotifications.modRegNotification.dismissed);
 
@@ -126,13 +126,13 @@ describe('modRegNotification settings', () => {
     expect(
       reducer(
         settingsWithDismissedNotifications,
-        actions.dismissModregNotification({ type: 'Select Modules', name: '3' } as RegPeriod),
+        actions.dismissModregNotification({ type: 'Select Courses', name: '3' } as RegPeriod),
       ).modRegNotification.dismissed,
     ).toEqual([
-      { type: 'Select Modules', name: '1' },
+      { type: 'Select Courses', name: '1' },
       { type: 'Add / Swap Tutorials', name: '' },
-      { type: 'Select Modules', name: '2' },
-      { type: 'Select Modules', name: '3' },
+      { type: 'Select Courses', name: '2' },
+      { type: 'Select Courses', name: '3' },
     ]);
   });
 
@@ -141,9 +141,9 @@ describe('modRegNotification settings', () => {
       reducer(
         reducer(
           initialState,
-          actions.dismissModregNotification({ type: 'Select Modules', name: '1' } as RegPeriod),
+          actions.dismissModregNotification({ type: 'Select Courses', name: '1' } as RegPeriod),
         ),
-        actions.enableModRegNotification({ type: 'Select Modules', name: '1' } as RegPeriod),
+        actions.enableModRegNotification({ type: 'Select Courses', name: '1' } as RegPeriod),
       ).modRegNotification.dismissed,
     ).toEqual([]);
   });

--- a/website/src/selectors/modreg.test.ts
+++ b/website/src/selectors/modreg.test.ts
@@ -24,19 +24,19 @@ describe(getRounds, () => {
   const DEFAULT_SCHEDULE = {
     Undergraduate: convertModRegDates([
       {
-        type: 'Select Modules',
+        type: 'Select Courses',
         name: '1',
         start: '2019-07-25T09:00:00+08:00',
         end: '2019-07-29T12:00:00+08:00',
       },
       {
-        type: 'Select Modules',
+        type: 'Select Courses',
         name: '2',
         start: '2019-07-31T09:00:00+08:00',
         end: '2019-08-02T12:00:00+08:00',
       },
       {
-        type: 'Submit Module Requests',
+        type: 'Submit Course Requests',
         name: '1',
         start: '2019-07-31T09:00:00+08:00',
         end: '2019-08-01T12:00:00+08:00',
@@ -50,11 +50,11 @@ describe(getRounds, () => {
     mockTime('2019-07-30T09:00:00+08:00');
     expect(getRounds(settings(), DEFAULT_SCHEDULE)).toEqual([
       expect.objectContaining({
-        type: 'Select Modules',
+        type: 'Select Courses',
         name: '2',
       }),
       expect.objectContaining({
-        type: 'Submit Module Requests',
+        type: 'Submit Course Requests',
         name: '1',
       }),
     ]);
@@ -65,7 +65,7 @@ describe(getRounds, () => {
     mockTime('2019-07-25T12:00:00+08:00');
     expect(getRounds(settings(), DEFAULT_SCHEDULE)).toEqual([
       expect.objectContaining({
-        type: 'Select Modules',
+        type: 'Select Courses',
         name: '1',
       }),
     ]);
@@ -88,10 +88,10 @@ describe(getRounds, () => {
   test('should not return dismissed rounds', () => {
     mockTime('2019-07-24T09:00:00+08:00');
     expect(
-      getRounds(settings({ dismissed: [{ type: 'Select Modules', name: '1' }] }), DEFAULT_SCHEDULE),
+      getRounds(settings({ dismissed: [{ type: 'Select Courses', name: '1' }] }), DEFAULT_SCHEDULE),
     ).toEqual([
       expect.objectContaining({
-        type: 'Select Modules',
+        type: 'Select Courses',
         name: '1',
         dismissed: true,
       }),

--- a/website/src/types/modules.ts
+++ b/website/src/types/modules.ts
@@ -107,17 +107,17 @@ type AttributeMap = {
 export type NUSModuleAttributes = Partial<AttributeMap>;
 
 export const attributeDescription: { [key in keyof AttributeMap]: string } = {
-  year: 'Year long module',
+  year: 'Year long course',
   su: 'Has S/U option for Undergraduate students only',
   grsu: 'Has S/U option for relevant Graduate (Research) students only',
   ssgf: 'SkillsFuture funded',
   sfs: 'SkillsFuture series',
-  lab: 'Lab based module',
-  ism: 'Independent study module',
+  lab: 'Lab based course',
+  ism: 'Independent study course',
   urop: 'Undergraduate Research Opportunities Program',
   fyp: 'Honours / Final Year Project',
-  mpes1: "Included in Semester 1's Module Planning Exercise",
-  mpes2: "Included in Semester 2's Module Planning Exercise",
+  mpes1: "Included in Semester 1's Course Planning Exercise",
+  mpes2: "Included in Semester 2's Course Planning Exercise",
 };
 
 // RawLesson is a lesson time slot obtained from the API.

--- a/website/src/utils/modules.test.ts
+++ b/website/src/utils/modules.test.ts
@@ -157,15 +157,15 @@ describe(getFirstAvailableSemester, () => {
 describe(renderMCs, () => {
   it.each<[string | number, string]>([
     // Plural
-    [0, '0 MCs'],
-    ['0', '0 MCs'],
-    [5, '5 MCs'],
-    ['5', '5 MCs'],
-    ['0.5', '0.5 MCs'],
+    [0, '0 Units'],
+    ['0', '0 Units'],
+    [5, '5 Units'],
+    ['5', '5 Units'],
+    ['0.5', '0.5 Units'],
 
     // Singular
-    [1, '1 MC'],
-    ['1', '1 MC'],
+    [1, '1 Unit'],
+    ['1', '1 Unit'],
   ])('%s to equal %s', (mc, expected) => expect(renderMCs(mc)).toEqual(noBreak(expected)));
 });
 

--- a/website/src/utils/modules.ts
+++ b/website/src/utils/modules.ts
@@ -83,7 +83,7 @@ export function getSemestersOffered(module: Module): Semester[] {
 
 export function renderMCs(moduleCredits: number | string) {
   const credit = typeof moduleCredits === 'string' ? parseFloat(moduleCredits) : moduleCredits;
-  return `${credit}${NBSP}${credit === 1 ? 'MC' : 'MCs'}`;
+  return `${credit}${NBSP}${credit === 1 ? 'Unit' : 'Units'}`;
 }
 
 export function renderExamDuration(examDuration: number) {

--- a/website/src/views/AppShell.tsx
+++ b/website/src/views/AppShell.tsx
@@ -65,7 +65,7 @@ function useFetchModuleListAndTimetableModules(): {
         .catch((error) => {
           captureException(error);
           dispatch(
-            openNotification('Data for some modules failed to load', {
+            openNotification('Data for some courses failed to load', {
               action: {
                 text: 'Retry',
                 handler: () => fetchTimetableModulesImpl(timetable, semester),
@@ -121,7 +121,7 @@ const AppShell: FC = ({ children }) => {
   const theme = useSelector((state: State) => state.theme.id);
 
   if (!isModuleListReady && moduleListError) {
-    return <ApiError dataName="module information" retry={refetchModuleListAndTimetableModules} />;
+    return <ApiError dataName="course information" retry={refetchModuleListAndTimetableModules} />;
   }
 
   return (

--- a/website/src/views/components/KeyboardShortcuts.tsx
+++ b/website/src/views/components/KeyboardShortcuts.tsx
@@ -62,7 +62,7 @@ const KeyboardShortcuts: React.FC = () => {
     });
 
     bind('m', NAVIGATION, 'Go to course finder', () => {
-      history.push('/modules');
+      history.push('/courses');
     });
 
     bind('v', NAVIGATION, 'Go to venues page', () => {

--- a/website/src/views/components/KeyboardShortcuts.tsx
+++ b/website/src/views/components/KeyboardShortcuts.tsx
@@ -61,7 +61,7 @@ const KeyboardShortcuts: React.FC = () => {
       history.push('/timetable');
     });
 
-    bind('m', NAVIGATION, 'Go to module finder', () => {
+    bind('m', NAVIGATION, 'Go to course finder', () => {
       history.push('/modules');
     });
 

--- a/website/src/views/components/disqus/CommentCount.test.tsx
+++ b/website/src/views/components/disqus/CommentCount.test.tsx
@@ -10,7 +10,7 @@ jest.mock('utils/insertScript', () => jest.fn());
 );
 
 const disqusConfig = {
-  url: 'https://nusmods.com/modules/CS1010/reviews',
+  url: 'https://nusmods.com/courses/CS1010/reviews',
   identifier: 'CS1010',
   title: 'CS1010 Programming Methodology',
 };

--- a/website/src/views/components/module-info/ModuleExamClash.tsx
+++ b/website/src/views/components/module-info/ModuleExamClash.tsx
@@ -51,7 +51,7 @@ export const ModuleExamClashComponent: React.FC<Props> = ({
     <div className={classnames('text-danger', styles.alert)}>
       <AlertTriangle className={styles.icon} />
       <p className={styles.warning}>
-        Your {useSingular ? 'module' : 'modules'}{' '}
+        Your {useSingular ? 'course' : 'courses'}{' '}
         <LinkModuleCodes>{clashes.map((module) => module.moduleCode).join(', ')}</LinkModuleCodes>{' '}
         {useSingular ? 'has' : 'have'} exams at the same time
       </p>

--- a/website/src/views/contribute/ContributeContainer/ContributeContainer.tsx
+++ b/website/src/views/contribute/ContributeContainer/ContributeContainer.tsx
@@ -69,7 +69,7 @@ const ContributeContainer: FC<Props> = ({ modules, beta, ...props }) => {
         <section>
           <header>
             <ReviewIcon />
-            <h3>Write Module Reviews</h3>
+            <h3>Write Course Reviews</h3>
           </header>
 
           <p>

--- a/website/src/views/contribute/ContributeContainer/ContributeContainer.tsx
+++ b/website/src/views/contribute/ContributeContainer/ContributeContainer.tsx
@@ -73,9 +73,9 @@ const ContributeContainer: FC<Props> = ({ modules, beta, ...props }) => {
           </header>
 
           <p>
-            Help your fellow students make better choices when planning their module by leaving your
-            honest opinions on modules you have taken before. Here are all of the modules you have
-            taken this year:
+            Help your fellow students make better choices when planning their courses by leaving
+            your honest opinions on courses you have taken before. Here are all of the courses you
+            have taken this year:
           </p>
 
           <div className={styles.writeReviews}>

--- a/website/src/views/errors/ApiError.tsx
+++ b/website/src/views/errors/ApiError.tsx
@@ -49,7 +49,7 @@ export default class ApiError extends React.PureComponent<Props> {
 
           <p>This could be because your device is offline or NUSMods is down :(</p>
           {/* TODO: Remove hacky message after we figure out what is wrong with Elastic Search. */}
-          {dataName === 'module information' && (
+          {dataName === 'course information' && (
             <>
               <strong>Module search might be having issues at the moment. 😟</strong>
               <p>

--- a/website/src/views/errors/ApiError.tsx
+++ b/website/src/views/errors/ApiError.tsx
@@ -51,7 +51,7 @@ export default class ApiError extends React.PureComponent<Props> {
           {/* TODO: Remove hacky message after we figure out what is wrong with Elastic Search. */}
           {dataName === 'course information' && (
             <>
-              <strong>Module search might be having issues at the moment. 😟</strong>
+              <strong>Course search might be having issues at the moment. 😟</strong>
               <p>
                 If it isn't working, please try the module search{' '}
                 {window.innerWidth < breakpointUp('md').minWidth && 'on a desktop browser '}on the

--- a/website/src/views/errors/ModuleFinderApiError.tsx
+++ b/website/src/views/errors/ModuleFinderApiError.tsx
@@ -7,7 +7,7 @@ type ModuleFinderApiErrorProps = {
 };
 
 const ModuleFinderApiError: React.FC<ModuleFinderApiErrorProps> = ({ searchkit }) => (
-  <ApiError dataName="module information" retry={() => searchkit.reloadSearch()} />
+  <ApiError dataName="course information" retry={() => searchkit.reloadSearch()} />
 );
 
 export default ModuleFinderApiError;

--- a/website/src/views/errors/ModuleNotFoundPage.tsx
+++ b/website/src/views/errors/ModuleNotFoundPage.tsx
@@ -77,7 +77,7 @@ export class ModuleNotFoundPageComponent extends PureComponent<Props> {
             <p>
               Otherwise, if this is not what you are looking for,{' '}
               <Link to="/">go back to nusmods.com</Link> or{' '}
-              <Link to="/modules">try the course finder</Link>.
+              <Link to="/courses">try the course finder</Link>.
             </p>
           </>
         ) : (

--- a/website/src/views/errors/ModuleNotFoundPage.tsx
+++ b/website/src/views/errors/ModuleNotFoundPage.tsx
@@ -47,7 +47,7 @@ export class ModuleNotFoundPageComponent extends PureComponent<Props> {
 
     return (
       <div className={styles.container}>
-        <Title>Module Not Found</Title>
+        <Title>Course Not Found</Title>
 
         {this.props.availableArchive.length ? (
           <>
@@ -77,7 +77,7 @@ export class ModuleNotFoundPageComponent extends PureComponent<Props> {
             <p>
               Otherwise, if this is not what you are looking for,{' '}
               <Link to="/">go back to nusmods.com</Link> or{' '}
-              <Link to="/modules">try the module finder</Link>.
+              <Link to="/modules">try the course finder</Link>.
             </p>
           </>
         ) : (

--- a/website/src/views/errors/__snapshots__/ModuleFinderApiError.test.tsx.snap
+++ b/website/src/views/errors/__snapshots__/ModuleFinderApiError.test.tsx.snap
@@ -22,13 +22,13 @@ exports[`ModuleFinderApiError should render 1`] = `
           Oh no...
         </span>
          
-        We can't load the module information
+        We can't load the course information
       </h1>
       <p>
         This could be because your device is offline or NUSMods is down :(
       </p>
       <strong>
-        Module search might be having issues at the moment. 😟
+        Course search might be having issues at the moment. 😟
       </strong>
       <p>
         If it isn't working, please try the module search
@@ -70,13 +70,13 @@ exports[`ModuleFinderApiError should render with url 1`] = `
           Oh no...
         </span>
          
-        We can't load the module information
+        We can't load the course information
       </h1>
       <p>
         This could be because your device is offline or NUSMods is down :(
       </p>
       <strong>
-        Module search might be having issues at the moment. 😟
+        Course search might be having issues at the moment. 😟
       </strong>
       <p>
         If it isn't working, please try the module search

--- a/website/src/views/layout/GlobalSearch.tsx
+++ b/website/src/views/layout/GlobalSearch.tsx
@@ -227,7 +227,7 @@ class GlobalSearch extends Component<Props, State> {
                   <span className="btn-svg">
                     View All <ChevronRight className={styles.svg} />
                   </span>
-                  <span className={styles.headerName}>Modules</span>
+                  <span className={styles.headerName}>Courses</span>
                 </div>
 
                 {modules.map((module, index) => (

--- a/website/src/views/layout/GlobalSearchContainer.test.tsx
+++ b/website/src/views/layout/GlobalSearchContainer.test.tsx
@@ -100,7 +100,7 @@ describe('GlobalSearchContainer', () => {
     userEvent.type(getByRole('textbox'), '1 ');
     expect(getAllByRole('option').map((elem) => elem.textContent)).toMatchInlineSnapshot(`
       Array [
-        "View All Modules",
+        "View All Courses",
         "AA1010 TestSem 1",
         "AB1010 TestSem 1",
         "AC1010 TestSem 1",
@@ -161,7 +161,7 @@ describe('GlobalSearchContainer', () => {
     userEvent.type(getByRole('textbox'), '1 ');
     expect(getAllByRole('option').map((elem) => elem.textContent)).toMatchInlineSnapshot(`
       Array [
-        "View All Modules",
+        "View All Courses",
         "AA1010 TestSem 1",
         "AB1010 TestSem 1",
         "AC1010 TestSem 1",
@@ -182,7 +182,7 @@ describe('GlobalSearchContainer', () => {
     userEvent.type(getByRole('textbox'), 'AA');
     expect(getAllByRole('option').map((elem) => elem.textContent)).toMatchInlineSnapshot(`
       Array [
-        "View All Modules",
+        "View All Courses",
         "AA1010 TestSem 1",
         "View All Venues",
         "AA-1",
@@ -198,7 +198,7 @@ describe('GlobalSearchContainer', () => {
     userEvent.type(getByRole('textbox'), '1010');
     expect(getAllByRole('option').map((elem) => elem.textContent)).toMatchInlineSnapshot(`
       Array [
-        "View All Modules",
+        "View All Courses",
         "AA1010 TestSem 1",
         "AB1010 TestSem 1",
         "AC1010 TestSem 1",

--- a/website/src/views/layout/GlobalSearchContainer.tsx
+++ b/website/src/views/layout/GlobalSearchContainer.tsx
@@ -44,7 +44,7 @@ const GlobalSearchContainer: FC = () => {
   const onSearch = useCallback(
     (type: ResultType, query: string) => {
       // TODO: Move this into a proper function
-      const path = type === VENUE_RESULT ? '/venues' : '/modules';
+      const path = type === VENUE_RESULT ? '/venues' : '/courses';
       history.push(`${path}?q=${encodeURIComponent(query)}`);
     },
     [history],

--- a/website/src/views/layout/Navtabs.test.tsx
+++ b/website/src/views/layout/Navtabs.test.tsx
@@ -39,29 +39,29 @@ describe(Navtabs, () => {
     make();
     if (enableMpe) {
       expect(screen.getAllByRole('link').map((elem) => elem.textContent)).toMatchInlineSnapshot(`
-      Array [
-        "Today",
-        "Timetable",
-        "Modules",
-        "MPE",
-        "Venues",
-        "Settings",
-        "Contribute",
-        "Whispers",
-      ]
-    `);
+              Array [
+                "Today",
+                "Timetable",
+                "Modules",
+                "MPE",
+                "Venues",
+                "Settings",
+                "Contribute",
+                "Whispers",
+              ]
+          `);
     } else {
       expect(screen.getAllByRole('link').map((elem) => elem.textContent)).toMatchInlineSnapshot(`
-      Array [
-        "Today",
-        "Timetable",
-        "Modules",
-        "Venues",
-        "Settings",
-        "Contribute",
-        "Whispers",
-      ]
-    `);
+        Array [
+          "Today",
+          "Timetable",
+          "Courses",
+          "Venues",
+          "Settings",
+          "Contribute",
+          "Whispers",
+        ]
+      `);
     }
   });
 
@@ -69,31 +69,31 @@ describe(Navtabs, () => {
     make({ settings: { beta: true } });
     if (enableMpe) {
       expect(screen.getAllByRole('link').map((elem) => elem.textContent)).toMatchInlineSnapshot(`
-      Array [
-        "Today",
-        "Timetable",
-        "Modules",
-        "MPE",
-        "Venues",
-        "Planner",
-        "Settings",
-        "Contribute",
-        "Whispers",
-      ]
-    `);
+              Array [
+                "Today",
+                "Timetable",
+                "Modules",
+                "MPE",
+                "Venues",
+                "Planner",
+                "Settings",
+                "Contribute",
+                "Whispers",
+              ]
+          `);
     } else {
       expect(screen.getAllByRole('link').map((elem) => elem.textContent)).toMatchInlineSnapshot(`
-      Array [
-        "Today",
-        "Timetable",
-        "Modules",
-        "Venues",
-        "Planner",
-        "Settings",
-        "Contribute",
-        "Whispers",
-      ]
-    `);
+        Array [
+          "Today",
+          "Timetable",
+          "Courses",
+          "Venues",
+          "Planner",
+          "Settings",
+          "Contribute",
+          "Whispers",
+        ]
+      `);
     }
   });
 });

--- a/website/src/views/layout/Navtabs.tsx
+++ b/website/src/views/layout/Navtabs.tsx
@@ -47,7 +47,7 @@ const Navtabs: FC = () => {
       </NavLink>
       <NavLink
         {...tabProps}
-        to={{ pathname: '/modules', search: '?sem[0]=1&sem[1]=2&sem[2]=3&sem[3]=4' }}
+        to={{ pathname: '/courses', search: '?sem[0]=1&sem[1]=2&sem[2]=3&sem[3]=4' }}
       >
         <BookOpen />
         <span className={styles.title}>Courses</span>

--- a/website/src/views/layout/Navtabs.tsx
+++ b/website/src/views/layout/Navtabs.tsx
@@ -50,7 +50,7 @@ const Navtabs: FC = () => {
         to={{ pathname: '/modules', search: '?sem[0]=1&sem[1]=2&sem[2]=3&sem[3]=4' }}
       >
         <BookOpen />
-        <span className={styles.title}>Modules</span>
+        <span className={styles.title}>Courses</span>
       </NavLink>
       {enableMpe && (
         <NavLink {...tabProps} to="/mpe">

--- a/website/src/views/modules/ModuleArchiveContainer.test.tsx
+++ b/website/src/views/modules/ModuleArchiveContainer.test.tsx
@@ -93,7 +93,7 @@ describe(ModuleArchiveContainerComponent, () => {
     make();
     expect(screen.getByText(/Loading/i)).toBeInTheDocument();
     // Expect module information to be displayed
-    expect(await screen.findByText(/This module introduces/)).toBeInTheDocument();
+    expect(await screen.findByText(/This course introduces/)).toBeInTheDocument();
     // Expect component to fetch
     expect(mockAxiosRequest).toBeCalled();
   });
@@ -101,6 +101,6 @@ describe(ModuleArchiveContainerComponent, () => {
   test('should show error if module fetch failed', async () => {
     mockAxiosRequest.mockRejectedValue(someOtherError);
     make();
-    expect(await screen.findByText(/can't load the module information/)).toBeInTheDocument();
+    expect(await screen.findByText(/can't load the course information/)).toBeInTheDocument();
   });
 });

--- a/website/src/views/modules/ModuleArchiveContainer.tsx
+++ b/website/src/views/modules/ModuleArchiveContainer.tsx
@@ -99,7 +99,7 @@ export const ModuleArchiveContainerComponent: FC = () => {
   // If there is an error but module data can still be found, we assume module has
   // been loaded at some point, so we just show that instead
   if (error && !module) {
-    return <ApiError dataName="module information" retry={fetchModuleForDisplay} />;
+    return <ApiError dataName="course information" retry={fetchModuleForDisplay} />;
   }
 
   // Redirect to canonical URL

--- a/website/src/views/modules/ModuleFinderContainer/ModuleFinderContainer.tsx
+++ b/website/src/views/modules/ModuleFinderContainer/ModuleFinderContainer.tsx
@@ -68,7 +68,7 @@ const ModuleFinderContainer: React.FC = () => (
           <div>
             <HitsStats
               component={({ hitsCount }: HitsStatsDisplayProps) => (
-                <div className={styles.modulePageDivider}>{hitsCount} modules found</div>
+                <div className={styles.modulePageDivider}>{hitsCount} courses found</div>
               )}
             />
 

--- a/website/src/views/modules/ModuleFinderContainer/ModuleFinderContainer.tsx
+++ b/website/src/views/modules/ModuleFinderContainer/ModuleFinderContainer.tsx
@@ -36,7 +36,7 @@ const searchkit = new SearchkitManager(esHostUrl, {
   searchUrlPath: '_search?track_total_hits=true',
 });
 
-const pageHead = <Title>Modules</Title>;
+const pageHead = <Title>Courses</Title>;
 
 const ModuleInformationListComponent: React.FC<HitsListProps> = ({ hits }) => (
   <ul className={styles.modulesList}>
@@ -61,7 +61,7 @@ const ModuleFinderContainer: React.FC = () => (
     <SearchkitProvider searchkit={searchkit}>
       <div className="row">
         <div className="col">
-          <h1 className="sr-only">Module Finder</h1>
+          <h1 className="sr-only">Course Finder</h1>
 
           <ModuleSearchBox id="q" />
 

--- a/website/src/views/modules/ModuleFinderItem.tsx
+++ b/website/src/views/modules/ModuleFinderItem.tsx
@@ -45,7 +45,7 @@ const ModuleFinderItem: React.FC<Props> = ({ module, highlight = {} }) => (
             {intersperse(
               [
                 <span key="department">{module.department}</span>,
-                <span key="mc">{module.moduleCredit} MCs</span>,
+                <span key="mc">{module.moduleCredit} Units</span>,
               ],
               BULLET,
             )}

--- a/website/src/views/modules/ModuleFinderItem.tsx
+++ b/website/src/views/modules/ModuleFinderItem.tsx
@@ -94,7 +94,7 @@ const ModuleFinderItem: React.FC<Props> = ({ module, highlight = {} }) => (
         ) : (
           <div className={classnames(styles.notOffered, 'alert alert-warning')}>
             <Archive className={styles.archiveIcon} />
-            <p>This module is not offered this year</p>
+            <p>This course is not offered this year</p>
           </div>
         )}
         {module.workload && <ModuleWorkload workload={module.workload} />}

--- a/website/src/views/modules/ModuleFinderPager.tsx
+++ b/website/src/views/modules/ModuleFinderPager.tsx
@@ -66,7 +66,7 @@ const ModuleFinderPager: FC<PagerProps> = ({
   }
 
   return (
-    <nav aria-label="Module search result pagination">
+    <nav aria-label="Course search result pagination">
       <ul className={classnames('pagination justify-content-center', styles.paginationList)}>
         <ModuleFinderPagerButton
           tooltipTitle="First page"

--- a/website/src/views/modules/ModuleFinderSidebar.tsx
+++ b/website/src/views/modules/ModuleFinderSidebar.tsx
@@ -112,10 +112,10 @@ const ModuleFinderSidebar: React.FC = () => {
           field="moduleCredit"
           multiselect
           options={[
-            { title: '0-3 MC', to: 4 },
-            { title: '4 MC', from: 4, to: 5 },
-            { title: '5-8 MC', from: 5, to: 9 },
-            { title: 'More than 8 MC', from: 9 },
+            { title: '0-3 Units', to: 4 },
+            { title: '4 Units', from: 4, to: 5 },
+            { title: '5-8 Units', from: 5, to: 9 },
+            { title: 'More than 8 Units', from: 9 },
           ]}
           containerComponent={FilterContainer}
           itemComponent={CheckboxItem}

--- a/website/src/views/modules/ModuleFinderSidebar.tsx
+++ b/website/src/views/modules/ModuleFinderSidebar.tsx
@@ -108,7 +108,7 @@ const ModuleFinderSidebar: React.FC = () => {
 
         <NumericRefinementListFilter
           id="mcs"
-          title="MCs"
+          title="Units"
           field="moduleCredit"
           multiselect
           options={[

--- a/website/src/views/modules/ModulePageContainer.test.tsx
+++ b/website/src/views/modules/ModulePageContainer.test.tsx
@@ -42,7 +42,7 @@ const someOtherError: Partial<AxiosError> = {
   },
 };
 
-const CANONICAL = '/modules/CS1010S/programming-methodology';
+const CANONICAL = '/courses/CS1010S/programming-methodology';
 
 const initialState = reducers(undefined, initAction());
 
@@ -54,7 +54,7 @@ function make(location: string = CANONICAL) {
       <ModulePageContainerComponent />
     </Provider>,
     {
-      path: '/modules/:moduleCode/:slug?',
+      path: '/courses/:moduleCode/:slug?',
       location,
     },
   );
@@ -75,15 +75,15 @@ describe(ModulePageContainerComponent, () => {
 
   test('should show 404 page when the module code does not exist', async () => {
     mockAxiosRequest.mockRejectedValue(notFoundError);
-    make('/modules/CS1234');
+    make('/courses/CS1234');
     expect(await screen.findByText(/module CS1234 not found/)).toBeInTheDocument();
   });
 
   test('should redirect to canonical URL', async () => {
     mockAxiosRequest.mockResolvedValue(cs1010sResponse);
-    const { history } = make('/modules/CS1010S');
+    const { history } = make('/courses/CS1010S');
     await waitFor(() =>
-      expect(history.location.pathname).toBe('/modules/CS1010S/programming-methodology'),
+      expect(history.location.pathname).toBe('/courses/CS1010S/programming-methodology'),
     );
   });
 
@@ -93,7 +93,7 @@ describe(ModulePageContainerComponent, () => {
     make();
     expect(screen.getByText(/Loading/i)).toBeInTheDocument();
     // Expect module information to be displayed
-    expect(await screen.findByText(/This module introduces/)).toBeInTheDocument();
+    expect(await screen.findByText(/This course introduces/)).toBeInTheDocument();
     // Expect component to fetch
     expect(mockAxiosRequest).toBeCalled();
   });
@@ -101,6 +101,6 @@ describe(ModulePageContainerComponent, () => {
   test('should show error if module fetch failed', async () => {
     mockAxiosRequest.mockRejectedValue(someOtherError);
     make();
-    expect(await screen.findByText(/can't load the module information/)).toBeInTheDocument();
+    expect(await screen.findByText(/can't load the course information/)).toBeInTheDocument();
   });
 });

--- a/website/src/views/modules/ModulePageContainer.tsx
+++ b/website/src/views/modules/ModulePageContainer.tsx
@@ -98,7 +98,7 @@ export const ModulePageContainerComponent: FC = () => {
   // If there is an error but module data can still be found, we assume module has
   // been loaded at some point, so we just show that instead
   if (error && !module) {
-    return <ApiError dataName="module information" retry={fetchModuleForDisplay} />;
+    return <ApiError dataName="course information" retry={fetchModuleForDisplay} />;
   }
 
   // Redirect to canonical URL

--- a/website/src/views/modules/ModulePageContent.tsx
+++ b/website/src/views/modules/ModulePageContent.tsx
@@ -63,7 +63,7 @@ const ModulePageContent: React.FC<Props> = ({ module, archiveYear }) => {
   const offered = isOffered(module);
 
   const disqusConfig = {
-    url: `https://nusmods.com/modules/${moduleCode}/reviews`,
+    url: `https://nusmods.com/courses/${moduleCode}/reviews`,
     identifier: moduleCode,
     title: pageTitle,
   };

--- a/website/src/views/modules/ModulePageContent.tsx
+++ b/website/src/views/modules/ModulePageContent.tsx
@@ -297,21 +297,21 @@ const ModulePageContent: React.FC<Props> = ({ module, archiveYear }) => {
                         <h3>Hi There!</h3>
                         <p>
                           We would like to encourage everyone who enjoyed using NUSMods to
-                          contribute back to the community by writing reviews for modules that you
+                          contribute back to the community by writing reviews for courses that you
                           have taken before. Your efforts will go a long way in building up a
                           vibrant and rich NUS community.
                         </p>
                         <strong>Please note:</strong>
                         <ol className={styles.modReviewDescription}>
                           <li>
-                            Because the experience of each module will differ according to the
-                            professor teaching the module, at the start of your review, please state
-                            the semester taken and the name of the professor who taught the module
+                            Because the experience of each course will differ according to the
+                            professor teaching the course, at the start of your review, please state
+                            the semester taken and the name of the professor who taught the course
                             in that semester.
                           </li>
                           <li>
                             Other students will read your review to get an idea of what taking the
-                            module will be like. If you'd like to give feedback about the module to
+                            course will be like. If you'd like to give feedback about the course to
                             NUS, please use the official Student Feedback system as NUS does not
                             monitor these reviews.
                           </li>

--- a/website/src/views/modules/ModuleSearchBox.tsx
+++ b/website/src/views/modules/ModuleSearchBox.tsx
@@ -38,7 +38,7 @@ const ModuleSearchBox: React.FC<Props> = ({ id }) => (
     throttle={300}
     queryFields={['moduleCode^10', 'title^3', 'description']}
     queryBuilder={buildQuery}
-    placeholder="Module code, names and descriptions"
+    placeholder="Course code, names and descriptions"
   />
 );
 

--- a/website/src/views/modules/ReportError.tsx
+++ b/website/src/views/modules/ReportError.tsx
@@ -323,7 +323,7 @@ const FormContent: FC<FormContentProps> = ({
       </div>
 
       <div className="form-group col-sm-12">
-        <label htmlFor="report-error-message">Describe in detail the issues with the module</label>
+        <label htmlFor="report-error-message">Describe in detail the issues with the course</label>
         <textarea
           id="report-error-message"
           className="form-control"

--- a/website/src/views/mpe/MpeContainer.tsx
+++ b/website/src/views/mpe/MpeContainer.tsx
@@ -54,7 +54,7 @@ const MpeContainer: React.FC = () => {
   return (
     <div className={styles.pageContainer}>
       <header className={styles.header}>
-        <h1>Module Planning Exercise</h1>
+        <h1>Course Planning Exercise</h1>
         <h4>
           For AY{MPE_AY} - Semester {MPE_SEMESTER}
         </h4>

--- a/website/src/views/mpe/form/ModuleForm.tsx
+++ b/website/src/views/mpe/form/ModuleForm.tsx
@@ -176,7 +176,7 @@ const ModuleForm: React.FC<Props> = ({
       </label>
       <div className={styles.headerTitle}>
         <div className={styles.rank}>Rank</div>
-        <div className={styles.module}>Module</div>
+        <div className={styles.module}>Course</div>
         <div className={styles.moduleCount}>
           {preferences.length} / {MAX_MODULES} Modules Selected
         </div>

--- a/website/src/views/mpe/form/ModuleForm.tsx
+++ b/website/src/views/mpe/form/ModuleForm.tsx
@@ -155,7 +155,7 @@ const ModuleForm: React.FC<Props> = ({
     <div className={styles.formContainer}>
       <label className={classnames('row', styles.mcTextField)}>
         <div className="col-sm-8">
-          Intended number of MCs (does not affect how many modules you can select):
+          Intended number of units (does not affect how many courses you can select):
         </div>
         <div className="col-sm-4">
           <input

--- a/website/src/views/mpe/form/ModuleFormBeforeSignIn.tsx
+++ b/website/src/views/mpe/form/ModuleFormBeforeSignIn.tsx
@@ -11,8 +11,8 @@ const ModuleFormBeforeSignIn: React.FC<Props> = ({ onLogin, isLoggingIn }) => (
     <div className={styles.image}>
       <img src={mpePlaceholder} alt="" />
     </div>
-    <h4>Start Module Planning Exercise</h4>
-    <p>Select your modules and we will automatically save your changes</p>
+    <h4>Start Course Planning Exercise</h4>
+    <p>Select your courses and we will automatically save your changes</p>
     <button
       type="button"
       className="btn btn-outline-primary btn-svg"

--- a/website/src/views/mpe/form/ModulesSelect.tsx
+++ b/website/src/views/mpe/form/ModulesSelect.tsx
@@ -192,7 +192,7 @@ export class ModulesSelectComponent extends Component<Props, State> {
         )}
         {showNoResultMessage && (
           <div className={styles.tip}>
-            No modules found for{' '}
+            No courses found for{' '}
             <strong>
               &quot;
               {inputValue}

--- a/website/src/views/mpe/form/ModulesSelectContainer.tsx
+++ b/website/src/views/mpe/form/ModulesSelectContainer.tsx
@@ -38,7 +38,7 @@ function ModulesSelectContainer({ moduleList, addModule, removeModule }: Props) 
           moduleCount={moduleList.length}
           onChange={addModule}
           placeholder={
-            isOnline ? 'Add module to the preference list' : 'You need to be online to add modules'
+            isOnline ? 'Add course to the preference list' : 'You need to be online to add courses'
           }
           disabled={!isOnline}
           onRemoveModule={removeModule}

--- a/website/src/views/planner/CustomModuleForm.tsx
+++ b/website/src/views/planner/CustomModuleForm.tsx
@@ -74,7 +74,7 @@ export const CustomModuleFormComponent: React.FC<Props> = (props) => {
 
       <div className="form-row">
         <div className="col-md-3">
-          <label htmlFor="input-mc">Module Credits</label>
+          <label htmlFor="input-mc">Units</label>
           <input
             ref={inputModuleCredit}
             id="input-mc"

--- a/website/src/views/planner/ModuleMenu.tsx
+++ b/website/src/views/planner/ModuleMenu.tsx
@@ -22,7 +22,7 @@ const ModuleMenu = memo((props: Props) => {
   const myRef = useRef<HTMLDivElement>(null);
 
   const menuItems: MenuItem[] = [
-    { label: 'Edit MC and Title', action: props.editCustomData },
+    { label: 'Edit Unit and Title', action: props.editCustomData },
     { label: 'Remove', action: props.removeModule, className: 'dropdown-item-danger' },
   ];
 

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
@@ -141,7 +141,7 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
     return (
       <header className={styles.header}>
         <h1>
-          Module Planner{' '}
+          Course Planner{' '}
           <button
             className="btn btn-sm btn-outline-success"
             type="button"

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
@@ -153,7 +153,7 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
 
         <div className={styles.headerRight}>
           <p className={styles.moduleStats}>
-            {count} {count === 1 ? 'module' : 'modules'} / {renderMCs(credits)}
+            {count} {count === 1 ? 'course' : 'courses'} / {renderMCs(credits)}
           </p>
 
           <button

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
@@ -192,7 +192,7 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
 
     return (
       <div className={styles.pageContainer}>
-        <Title>Module Planner</Title>
+        <Title>Course Planner</Title>
 
         {this.renderHeader()}
 
@@ -254,7 +254,7 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
                 >
                   <div className={styles.trashMessage}>
                     <Trash />
-                    <p>Drop modules here to remove them</p>
+                    <p>Drop courses here to remove them</p>
                   </div>
                   {provided.placeholder}
                 </div>

--- a/website/src/views/planner/PlannerModule.tsx
+++ b/website/src/views/planner/PlannerModule.tsx
@@ -136,7 +136,7 @@ const PlannerModule = memo<Props>((props) => {
             })}
             onClick={() => setEditingPlaceholder(true)}
           >
-            {moduleCode || 'Select Module'} <ChevronDown />
+            {moduleCode || 'Select Course'} <ChevronDown />
           </button>{' '}
           {moduleCode && moduleTitle && (
             <Link to={modulePage(moduleCode, moduleTitle)}>{moduleTitle}</Link>

--- a/website/src/views/planner/PlannerModule.tsx
+++ b/website/src/views/planner/PlannerModule.tsx
@@ -91,7 +91,7 @@ const PlannerModule = memo<Props>((props) => {
           <>
             <div className={styles.conflictHeader}>
               <AlertTriangle className={styles.warningIcon} />
-              <p>These modules may need to be taken first</p>
+              <p>These courses may need to be taken first</p>
             </div>
 
             <ul className={styles.prereqs}>

--- a/website/src/views/planner/PlannerSemester.tsx
+++ b/website/src/views/planner/PlannerSemester.tsx
@@ -37,7 +37,7 @@ function renderSemesterMeta(plannerModules: PlannerModuleInfo[]) {
   return (
     <div className={styles.semesterMeta}>
       <p>
-        {plannerModules.length} {plannerModules.length === 1 ? 'module' : 'modules'}
+        {plannerModules.length} {plannerModules.length === 1 ? 'course' : 'courses'}
       </p>
       <p>{renderMCs(moduleCredits)}</p>
     </div>

--- a/website/src/views/planner/PlannerYear.tsx
+++ b/website/src/views/planner/PlannerYear.tsx
@@ -50,7 +50,7 @@ export default class PlannerYear extends PureComponent<Props, State> {
         </h2>
         <div className={styles.yearMeta}>
           <p>
-            {count} {count === 1 ? 'module' : 'modules'}
+            {count} {count === 1 ? 'course' : 'courses'}
           </p>
           <p>{renderMCs(credits)}</p>
         </div>

--- a/website/src/views/routes/Routes.tsx
+++ b/website/src/views/routes/Routes.tsx
@@ -25,7 +25,7 @@ const Routes: React.FC = () => (
   <Switch>
     <Redirect exact from="/" to="/timetable" />
     <Route path="/timetable/:semester?/:action?" component={TimetableContainer} />
-    <Route exact path="/modules" component={ModuleFinderContainer} />
+    <Route exact path="/courses" component={ModuleFinderContainer} />
     <Route path="/modules/:moduleCode/:slug?" component={ModulePageContainer} />
     <Route path="/archive/:moduleCode/:year/:slug?" component={ModuleArchiveContainer} />
     <Route path="/venues/:venue?" component={VenuesContainer} />

--- a/website/src/views/routes/Routes.tsx
+++ b/website/src/views/routes/Routes.tsx
@@ -26,7 +26,7 @@ const Routes: React.FC = () => (
     <Redirect exact from="/" to="/timetable" />
     <Route path="/timetable/:semester?/:action?" component={TimetableContainer} />
     <Route exact path="/courses" component={ModuleFinderContainer} />
-    <Route path="/modules/:moduleCode/:slug?" component={ModulePageContainer} />
+    <Route path="/courses/:moduleCode/:slug?" component={ModulePageContainer} />
     <Route path="/archive/:moduleCode/:year/:slug?" component={ModuleArchiveContainer} />
     <Route path="/venues/:venue?" component={VenuesContainer} />
     <Route path="/today" component={TodayContainer} />

--- a/website/src/views/routes/paths.test.ts
+++ b/website/src/views/routes/paths.test.ts
@@ -2,7 +2,7 @@ import { modulePage, timetablePage, semesterForTimetablePage, venuePage } from '
 
 test('modulePagePath should generate route correctly', () => {
   expect(modulePage('CS1010S', 'Programming Methodology')).toBe(
-    '/modules/CS1010S/programming-methodology',
+    '/courses/CS1010S/programming-methodology',
   );
 });
 

--- a/website/src/views/routes/paths.ts
+++ b/website/src/views/routes/paths.ts
@@ -34,7 +34,7 @@ export function semesterForTimetablePage(semStr: string | null | undefined): Sem
 
 // Module Code, Module Title -> Module page path
 export function modulePage(moduleCode: ModuleCode, moduleTitle?: ModuleTitle | null): string {
-  return `/modules/${moduleCode}/${kebabCase(moduleTitle || '')}`;
+  return `/courses/${moduleCode}/${kebabCase(moduleTitle || '')}`;
 }
 
 export function moduleArchive(

--- a/website/src/views/settings/BetaToggle.tsx
+++ b/website/src/views/settings/BetaToggle.tsx
@@ -4,7 +4,7 @@ import ExternalLink from 'views/components/ExternalLink';
 import config from 'config';
 import styles from './SettingsContainer.scss';
 
-export const currentTests = ['Module planner: plan modules in future semesters'];
+export const currentTests = ['Course planner: plan courses in future semesters'];
 
 type Props = {
   betaTester: boolean;

--- a/website/src/views/static/AboutContainer.tsx
+++ b/website/src/views/static/AboutContainer.tsx
@@ -22,8 +22,8 @@ const AboutContainer: React.FC<Props> = (props) => (
       <ExternalLink href="http://benghee.eu/">Beng</ExternalLink> to provide a better way for
       students to plan their school timetables. Over time, more features have been added to improve
       the lives of NUS students. Besides timetable planning, NUSMods also serves as a complete
-      knowledge bank of NUS modules by providing useful module-related information such as
-      community-driven module reviews and discussions.
+      knowledge bank of NUS courses by providing useful course-related information such as
+      community-driven course reviews and discussions.
     </p>
 
     <h3>Goals</h3>

--- a/website/src/views/static/FaqContainer.tsx
+++ b/website/src/views/static/FaqContainer.tsx
@@ -35,7 +35,7 @@ const FaqContainer: React.FC = () => (
       </li>
       <li>
         <a href="#mistakes">
-          Why can&apos;t I add this module in semester X? My faculty says that it is available in
+          Why can&apos;t I add this course in semester X? My faculty says that it is available in
           semester X.
         </a>
       </li>
@@ -67,7 +67,7 @@ const FaqContainer: React.FC = () => (
         <li>You cannot find a course.</li>
         <li>Semester X data is not available.</li>
         <li>
-          You cannot add a module in semester X but your faculty says it is available in that
+          You cannot add a course in semester X but your faculty says it is available in that
           semester.
         </li>
       </ul>
@@ -79,8 +79,8 @@ const FaqContainer: React.FC = () => (
       </ol>
       <p>
         After you have done all the above and the error persists, please use the "Report Error"
-        button on the module page to report an issue to the module's department or faculty. If the
-        department or faculty for this module cannot be found on this list, please refer to ModReg's
+        button on the course page to report an issue to the course's department or faculty. If the
+        department or faculty for this course cannot be found on this list, please refer to ModReg's
         contact list for{' '}
         <ExternalLink href="http://www.nus.edu.sg/ModReg/docs/UGFac_Contacts.pdf">
           undergraduate
@@ -144,8 +144,8 @@ const FaqContainer: React.FC = () => (
       <p>
         Starting in AY18/19 Special Term I, NUSMods will become the university&apos;s official
         timetable planner. However, apart from that, we are unaffiliated with NUS. NUSMods certainly
-        does not make decisions regarding your curriculum, module availability and module timetable.
-        If you have questions regarding your curriculum, module registration, LumiNUS, or anything
+        does not make decisions regarding your curriculum, course availability and course timetable.
+        If you have questions regarding your curriculum, course registration, Canvas, or anything
         unrelated to NUSMods, please either contact your faculty or just{' '}
         <ExternalLink href="https://www.google.com/">Google</ExternalLink> it.
       </p>

--- a/website/src/views/static/FaqContainer.tsx
+++ b/website/src/views/static/FaqContainer.tsx
@@ -28,7 +28,7 @@ const FaqContainer: React.FC = () => (
         <a href="#mistakes">Can you update the exam date?</a>
       </li>
       <li>
-        <a href="#mistakes">Can you add this module?</a>
+        <a href="#mistakes">Can you add this course?</a>
       </li>
       <li>
         <a href="#mistakes">When will semester X data be available?</a>
@@ -64,7 +64,7 @@ const FaqContainer: React.FC = () => (
       <ul>
         <li>There is a missing lecture or tutorial slot.</li>
         <li>The exam date is wrong.</li>
-        <li>You cannot find a module.</li>
+        <li>You cannot find a course.</li>
         <li>Semester X data is not available.</li>
         <li>
           You cannot add a module in semester X but your faculty says it is available in that
@@ -73,7 +73,7 @@ const FaqContainer: React.FC = () => (
       </ul>
       <p>Please ensure the following:</p>
       <ol>
-        <li>You are sure that the module should exist or that the data on NUSMods is wrong.</li>
+        <li>You are sure that the course should exist or that the data on NUSMods is wrong.</li>
         <li>You have waited one day and the error is still present.</li>
         <li>You have refreshed NUSMods after step 2.</li>
       </ol>

--- a/website/src/views/timetable/ModulesSelect.tsx
+++ b/website/src/views/timetable/ModulesSelect.tsx
@@ -179,7 +179,7 @@ const ModulesSelect: FC<Props> = ({
         )}
         {showNoResultMessage && (
           <div className={styles.tip}>
-            No modules found for{' '}
+            No courses found for{' '}
             <strong>
               &quot;
               {inputValue}

--- a/website/src/views/timetable/ModulesSelectContainer.tsx
+++ b/website/src/views/timetable/ModulesSelectContainer.tsx
@@ -52,7 +52,7 @@ class ModulesSelectContainer extends Component<Props> {
             moduleCount={this.props.moduleList.length}
             onChange={this.onChange}
             placeholder={
-              isOnline ? 'Add module to timetable' : 'You need to be online to add modules'
+              isOnline ? 'Add course to timetable' : 'You need to be online to add courses'
             }
             disabled={!isOnline}
             onRemoveModule={this.props.removeModule}

--- a/website/src/views/timetable/ModulesTableFooter.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.tsx
@@ -22,8 +22,8 @@ export const moduleOrders: { [moduleTableOrder: string]: ModuleOrder } = {
     label: 'Exam Date',
     orderBy: (module: Module, semester: Semester) => getExamDate(module, semester) || '',
   },
-  mc: { label: 'Module Credits', orderBy: (module: Module) => parseFloat(module.moduleCredit) },
-  code: { label: 'Module Code', orderBy: (module: Module) => module.moduleCode },
+  mc: { label: 'Course Credits', orderBy: (module: Module) => parseFloat(module.moduleCredit) },
+  code: { label: 'Course Code', orderBy: (module: Module) => module.moduleCode },
 };
 
 type Props = {

--- a/website/src/views/timetable/ModulesTableFooter.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.tsx
@@ -49,7 +49,7 @@ const ModulesTableFooter: React.FC<Props> = (props) => {
         <hr />
       </div>
       <div className="col">
-        Total Module Credits: <strong>{renderMCs(totalMCs)}</strong>
+        Total Units: <strong>{renderMCs(totalMCs)}</strong>
       </div>
       <div className={classnames(styles.moduleOrder, 'col no-export')}>
         <label htmlFor="moduleOrder">Order</label>

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -237,7 +237,7 @@ class TimetableContent extends React.Component<Props, State> {
       return (
         <div className="row">
           <div className="col-sm-12">
-            <p className="text-sm-center">No modules added.</p>
+            <p className="text-sm-center">No courses added.</p>
           </div>
         </div>
       );


### PR DESCRIPTION
## Context

**Received this email from NUS.**

Dear All,

NUS will be implementing a University-wide change to the following terminologies by July 2023 (i.e. before AY2023/24 Semester 1). Accordingly, all NUS IT systems that display the impacted terminologies to the users (students and staff) are required to make corresponding changes.
 
As-Is Terminology | To-Be Terminology
-- | --
Module | Course
Module Credit / MC | Unit
Cumulative Average Point (CAP) | Grade Point Average (GPA)

We would like to suggest changes be made to NUSMods as it is very much frequented by students. Changes are textual, and the scope of changes include application name, page titles, field labels, menu labels, reports, emails, errors/warnings/information, etc.

## Implementation

Write a bunch of regexes to change source code that decides what gets shown on the views.

e.g. `(['"])([A-Z\sa-z.-]*)(module)([A-Z\sa-z.-]*)(['"])` to capture `"Something module something"`, then text replacement.

And some manual search and replace.

NUSMods does not have any mention of CAP so no replacements are necessary for CAP > GPA.