### PR TITLE
New UI Feature: Show the # of active units in Timetable

### DIFF
--- a/website/src/views/timetable/ModulesTableFooter.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.tsx
@@ -54,7 +54,7 @@ const ModulesTableFooter: React.FC<Props> = (props) => {
       </div>
       <div className="col">
         <div>
-          Active Units: <strong>{renderMCs(hiddenMCs)}</strong>
+          Active Units: <strong>{renderMCs(shownMCs)}</strong>
         </div>
         <div>
           Total Units: <strong>{renderMCs(totalMCs)}</strong>

--- a/website/src/views/timetable/ModulesTableFooter.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.tsx
@@ -37,9 +37,10 @@ type Props = {
 
 const ModulesTableFooter: React.FC<Props> = (props) => {
   const totalMCs = sumBy(props.modules, (module) => parseFloat(module.moduleCredit));
-  const shownMCs = props.modules
-    .filter((module) => !props.hiddenInTimetable.includes(module.moduleCode))
-    .reduce((acc, module) => acc + parseFloat(module.moduleCredit), 0);
+  const shownMCs = sumBy(
+    props.modules.filter((module) => !props.hiddenInTimetable.includes(module.moduleCode)),
+    (module) => parseFloat(module.moduleCredit),
+  );
 
   return (
     <div className={classnames(styles.footer, 'row align-items-center')}>

--- a/website/src/views/timetable/ModulesTableFooter.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.tsx
@@ -53,9 +53,11 @@ const ModulesTableFooter: React.FC<Props> = (props) => {
         <hr />
       </div>
       <div className="col">
-        <div>
-          Active Units: <strong>{renderMCs(shownMCs)}</strong>
-        </div>
+        {shownMCs !== totalMCs && (
+          <div>
+            Active Units: <strong>{renderMCs(shownMCs)}</strong>
+          </div>
+        )}
         <div>
           Total Units: <strong>{renderMCs(totalMCs)}</strong>
         </div>

--- a/website/src/views/timetable/ModulesTableFooter.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import { filter, map, sumBy } from 'lodash';
+import { map, sumBy } from 'lodash';
 import { connect } from 'react-redux';
 
 import { ModuleTableOrder } from 'types/reducers';
@@ -37,10 +37,10 @@ type Props = {
 
 const ModulesTableFooter: React.FC<Props> = (props) => {
   const totalMCs = sumBy(props.modules, (module) => parseFloat(module.moduleCredit));
-  const hiddenMCs = sumBy(
-    filter(props.modules, (module) => !props.hiddenInTimetable.includes(module.moduleCode)),
-    (module) => parseFloat(module.moduleCredit),
-  );
+  const hiddenMCs = props.modules
+    .filter((module) => !props.hiddenInTimetable.includes(module.moduleCode))
+    .reduce((acc, module) => acc + parseFloat(module.moduleCredit), 0);
+
   return (
     <div className={classnames(styles.footer, 'row align-items-center')}>
       <div className="col-12">
@@ -60,7 +60,6 @@ const ModulesTableFooter: React.FC<Props> = (props) => {
           Total Units: <strong>{renderMCs(totalMCs)}</strong>
         </div>
       </div>
-
       <div className={classnames(styles.moduleOrder, 'col no-export')}>
         <label htmlFor="moduleOrder">Order</label>
         <select

--- a/website/src/views/timetable/ModulesTableFooter.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.tsx
@@ -37,7 +37,7 @@ type Props = {
 
 const ModulesTableFooter: React.FC<Props> = (props) => {
   const totalMCs = sumBy(props.modules, (module) => parseFloat(module.moduleCredit));
-  const hiddenMCs = props.modules
+  const shownMCs = props.modules
     .filter((module) => !props.hiddenInTimetable.includes(module.moduleCode))
     .reduce((acc, module) => acc + parseFloat(module.moduleCredit), 0);
 

--- a/website/src/views/timetable/ModulesTableFooter.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classnames from 'classnames';
-import { map, sumBy } from 'lodash';
+import { filter, map, sumBy } from 'lodash';
 import { connect } from 'react-redux';
 
 import { ModuleTableOrder } from 'types/reducers';
@@ -30,13 +30,17 @@ type Props = {
   semester: Semester;
   moduleTableOrder: ModuleTableOrder;
   modules: Module[];
+  hiddenInTimetable: string[];
 
   setModuleTableOrder: (moduleTableOrder: ModuleTableOrder) => void;
 };
 
 const ModulesTableFooter: React.FC<Props> = (props) => {
   const totalMCs = sumBy(props.modules, (module) => parseFloat(module.moduleCredit));
-
+  const hiddenMCs = sumBy(
+    filter(props.modules, (module) => !props.hiddenInTimetable.includes(module.moduleCode)),
+    (module) => parseFloat(module.moduleCredit),
+  );
   return (
     <div className={classnames(styles.footer, 'row align-items-center')}>
       <div className="col-12">
@@ -49,8 +53,14 @@ const ModulesTableFooter: React.FC<Props> = (props) => {
         <hr />
       </div>
       <div className="col">
-        Total Units: <strong>{renderMCs(totalMCs)}</strong>
+        <div>
+          Active Units: <strong>{renderMCs(hiddenMCs)}</strong>
+        </div>
+        <div>
+          Total Units: <strong>{renderMCs(totalMCs)}</strong>
+        </div>
       </div>
+
       <div className={classnames(styles.moduleOrder, 'col no-export')}>
         <label htmlFor="moduleOrder">Order</label>
         <select

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -277,6 +277,7 @@ class TimetableContent extends React.Component<Props, State> {
       timetableOrientation,
       showTitle,
       readOnly,
+      hiddenInTimetable,
     } = this.props;
 
     const { showExamCalendar } = this.state;
@@ -427,7 +428,7 @@ class TimetableContent extends React.Component<Props, State> {
                 <ModulesTableFooter
                   modules={addedModules}
                   semester={semester}
-                  hiddenInTimetable={this.props.hiddenInTimetable}
+                  hiddenInTimetable={hiddenInTimetable}
                 />
               </div>
             </div>

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -269,8 +269,15 @@ class TimetableContent extends React.Component<Props, State> {
   }
 
   render() {
-    const { semester, modules, colors, activeLesson, timetableOrientation, showTitle, readOnly } =
-      this.props;
+    const {
+      semester,
+      modules,
+      colors,
+      activeLesson,
+      timetableOrientation,
+      showTitle,
+      readOnly,
+    } = this.props;
 
     const { showExamCalendar } = this.state;
 
@@ -417,7 +424,11 @@ class TimetableContent extends React.Component<Props, State> {
                 {this.renderModuleSections(addedModules, !isVerticalOrientation)}
               </div>
               <div className="col-12">
-                <ModulesTableFooter modules={addedModules} semester={semester} />
+                <ModulesTableFooter
+                  modules={addedModules}
+                  semester={semester}
+                  hiddenInTimetable={this.props.hiddenInTimetable}
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Implements #3459 

In the recent NUSMods Ideas thread on Reddit, I saw someone suggest to implement a display for `Active Units` alongside the `Total Units` when viewing a timetable.
![image](https://github.com/nusmodifications/nusmods/assets/31369072/b9533a24-bdb0-4504-83f9-c691202fe242)


## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
1. Passed `TimetableContent.tsx`'s `hiddenInTimetable` prop (array of module codes) to `ModulesTableFooter.tsx` as a new prop
2. Calculated the active unit count by filtering the list of modules (previously passed as prop), removing hidden modules
3. Ran the existing `renderMCs()` function to get the correct text output

### Video showing changes
https://github.com/nusmodifications/nusmods/assets/31369072/a26b1132-a9dc-49f0-a87e-ea58875ba046

### Mobile view
![image](https://github.com/nusmodifications/nusmods/assets/31369072/712c2ebb-1c52-4ff0-9b60-9bd16a389555)



## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->

[Reddit thread](https://www.reddit.com/r/nus/comments/14q5o1r/comment/jqlpxpf/?utm_source=share&utm_medium=web2x&context=3)
