### PR TITLE
Display coursereg notification modal in front

### DIFF
--- a/website/src/styles/constants.scss
+++ b/website/src/styles/constants.scss
@@ -180,13 +180,13 @@ $navbar-z-index: 890;
 $module-finder-search-z-index-md: 850;
 
 // navtabs and navbar should never overlap the dropdown
+$modreg-notification-z-index: 970;
 $zindex-dropdown: 910; // Bootstrap override
 $fab-z-index: 800;
 $venue-map-z-index: 760;
 $venue-detail-z-index: 750;
 $side-menu-z-index: 700;
 $side-menu-overlay-z-index: 690;
-$modreg-notification-z-index: 970;
 $timetable-warning-z-index: 200;
 $timetable-scolled-day-z-index: 120;
 $timetable-selected-cell-z-index: 110;

--- a/website/src/styles/constants.scss
+++ b/website/src/styles/constants.scss
@@ -186,7 +186,7 @@ $venue-map-z-index: 760;
 $venue-detail-z-index: 750;
 $side-menu-z-index: 700;
 $side-menu-overlay-z-index: 690;
-$modreg-notification-z-index: 910;
+$modreg-notification-z-index: 970;
 $timetable-warning-z-index: 200;
 $timetable-scolled-day-z-index: 120;
 $timetable-selected-cell-z-index: 110;


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
Resolves #3446 
<!-- Or provide a brief explanation about the problem -->

## Implementation
<!-- Explain how your solution solves the problem -->
The z-index of the timetable module select dropdown (.module-select-z-index) is 960, I simply increased the z-index of the Coursereg notification modal from 910 to 970 in constants.scss, so it will be displayed as the frontmost element.

<!-- If it affects UI, an image or gif is greatly encouraged. -->

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
This is my first PR to NUSMods. I have yet to test out this change outside of yarn test as I couldn't get the modal to popup (it is now outside the Coursereg period). If someone knows how to test or can provide me with guidance on how to test, it would be good.