### PR TITLE
feat(timetable): restore customizable timetables

### DIFF
--- a/website/src/actions/__snapshots__/timetables.test.ts.snap
+++ b/website/src/actions/__snapshots__/timetables.test.ts.snap
@@ -10,6 +10,7 @@ exports[`cancelModifyLesson should not have payload 1`] = `
 exports[`changeLesson should return updated information to change lesson 1`] = `
 {
   "payload": {
+    "activeLesson": "1",
     "classNo": "1",
     "lessonType": "Recitation",
     "moduleCode": "CS1010S",

--- a/website/src/actions/timetables.test.ts
+++ b/website/src/actions/timetables.test.ts
@@ -60,9 +60,9 @@ describe('fillTimetableBlanks', () => {
   test('do nothing if timetable is already full', () => {
     const timetable = {
       CS1010S: {
-        Lecture: '1',
-        Tutorial: '1',
-        Recitation: '1',
+        Lecture: ['1'],
+        Tutorial: ['1'],
+        Recitation: ['1'],
       },
     };
 
@@ -76,8 +76,8 @@ describe('fillTimetableBlanks', () => {
   test('fill missing lessons with randomly generated modules', () => {
     const timetable = {
       CS1010S: {
-        Lecture: '1',
-        Tutorial: '1',
+        Lecture: ['1'],
+        Tutorial: ['1'],
       },
       CS3216: {},
     };
@@ -95,9 +95,9 @@ describe('fillTimetableBlanks', () => {
         semester,
         moduleCode: 'CS1010S',
         lessonConfig: {
-          Lecture: '1',
-          Tutorial: '1',
-          Recitation: expect.any(String),
+          Lecture: ['1'],
+          Tutorial: ['1'],
+          Recitation: expect.any(Array),
         },
       },
     });
@@ -108,7 +108,7 @@ describe('fillTimetableBlanks', () => {
         semester,
         moduleCode: 'CS3216',
         lessonConfig: {
-          Lecture: '1',
+          Lecture: ['1'],
         },
       },
     });

--- a/website/src/actions/timetables.test.ts
+++ b/website/src/actions/timetables.test.ts
@@ -53,12 +53,13 @@ describe('fillTimetableBlanks', () => {
   const moduleBank = { modules: { CS1010S, CS3216 } };
   const timetablesState = (semester: Semester, timetable: SemTimetableConfig) => ({
     lessons: { [semester]: timetable },
+    customisedModules: { [semester]: [] },
   });
   const semester = 1;
   const action = actions.validateTimetable(semester);
 
   test('do nothing if timetable is already full', () => {
-    const timetable = {
+    const timetable: SemTimetableConfig = {
       CS1010S: {
         Lecture: ['1'],
         Tutorial: ['1'],
@@ -66,6 +67,7 @@ describe('fillTimetableBlanks', () => {
       },
     };
 
+    // TODO(zwliew): Correctly type all the `state: any` declarations in this function and the rest of the codebase.
     const state: any = { timetables: timetablesState(semester, timetable), moduleBank };
     const dispatch = jest.fn();
     action(dispatch, () => state);
@@ -74,7 +76,7 @@ describe('fillTimetableBlanks', () => {
   });
 
   test('fill missing lessons with randomly generated modules', () => {
-    const timetable = {
+    const timetable: SemTimetableConfig = {
       CS1010S: {
         Lecture: ['1'],
         Tutorial: ['1'],

--- a/website/src/actions/timetables.test.ts
+++ b/website/src/actions/timetables.test.ts
@@ -36,7 +36,7 @@ test('modifyLesson should return lesson payload', () => {
 test('changeLesson should return updated information to change lesson', () => {
   const semester: Semester = 1;
   const lesson: Lesson = lessons[1];
-  expect(actions.changeLesson(semester, lesson)).toMatchSnapshot();
+  expect(actions.changeLesson(semester, lesson, lesson.classNo)).toMatchSnapshot();
 });
 
 test('cancelModifyLesson should not have payload', () => {

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -90,15 +90,68 @@ export function modifyLesson(activeLesson: Lesson) {
   };
 }
 
+export const CUSTOMISE_MODULE = 'CUSTOMISE_LESSON' as const;
+export function customiseLesson(semester: Semester, moduleCode: ModuleCode) {
+  return {
+    type: CUSTOMISE_MODULE,
+    payload: {
+      semester,
+      moduleCode,
+    },
+  };
+}
+
 export const CHANGE_LESSON = 'CHANGE_LESSON' as const;
 export function setLesson(
   semester: Semester,
   moduleCode: ModuleCode,
   lessonType: LessonType,
   classNo: ClassNo,
+  activeLesson: ClassNo,
 ) {
   return {
     type: CHANGE_LESSON,
+    payload: {
+      semester,
+      moduleCode,
+      lessonType,
+      classNo,
+      activeLesson,
+    },
+  };
+}
+
+export const ADD_CUSTOM_MODULE = 'ADD_CUSTOM_MODULE' as const;
+export function addCustomModule(semester: Semester, moduleCode: ModuleCode) {
+  return {
+    type: ADD_CUSTOM_MODULE,
+    payload: {
+      semester,
+      moduleCode,
+    },
+  };
+}
+
+export const REMOVE_CUSTOM_MODULE = 'REMOVE_CUSTOM_MODULE' as const;
+export function removeCustomModule(semester: Semester, moduleCode: ModuleCode) {
+  return {
+    type: REMOVE_CUSTOM_MODULE,
+    payload: {
+      semester,
+      moduleCode,
+    },
+  };
+}
+
+export const ADD_LESSON = 'ADD_LESSON' as const;
+export function addLesson(
+  semester: Semester,
+  moduleCode: ModuleCode,
+  lessonType: LessonType,
+  classNo: ClassNo,
+) {
+  return {
+    type: ADD_LESSON,
     payload: {
       semester,
       moduleCode,
@@ -108,8 +161,26 @@ export function setLesson(
   };
 }
 
-export function changeLesson(semester: Semester, lesson: Lesson) {
-  return setLesson(semester, lesson.moduleCode, lesson.lessonType, lesson.classNo);
+export const REMOVE_LESSON = 'REMOVE_LESSON' as const;
+export function removeLesson(
+  semester: Semester,
+  moduleCode: ModuleCode,
+  lessonType: LessonType,
+  classNo: ClassNo,
+) {
+  return {
+    type: REMOVE_LESSON,
+    payload: {
+      semester,
+      moduleCode,
+      lessonType,
+      classNo,
+    },
+  };
+}
+
+export function changeLesson(semester: Semester, lesson: Lesson, activeLesson: ClassNo) {
+  return setLesson(semester, lesson.moduleCode, lesson.lessonType, lesson.classNo, activeLesson);
 }
 
 export const SET_LESSON_CONFIG = 'SET_LESSON_CONFIG' as const;
@@ -165,6 +236,14 @@ export function validateTimetable(semester: Semester) {
       const module = moduleBank.modules[moduleCode];
       if (!module) return;
 
+      // If the module is customised, we do not validate it
+      if (
+        timetables.customisedModules &&
+        timetables.customisedModules[semester] &&
+        timetables.customisedModules[semester].includes(moduleCode)
+      ) {
+        return;
+      }
       const [validatedLessonConfig, changedLessonTypes] = validateModuleLessons(
         semester,
         lessonConfig,

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -236,14 +236,9 @@ export function validateTimetable(semester: Semester) {
       const module = moduleBank.modules[moduleCode];
       if (!module) return;
 
-      // If the module is customised, we do not validate it
-      if (
-        timetables.customisedModules &&
-        timetables.customisedModules[semester] &&
-        timetables.customisedModules[semester].includes(moduleCode)
-      ) {
-        return;
-      }
+      // Do not validate customised modules.
+      if (timetables.customisedModules[semester]?.includes(moduleCode)) return;
+
       const [validatedLessonConfig, changedLessonTypes] = validateModuleLessons(
         semester,
         lessonConfig,

--- a/website/src/reducers/app.test.ts
+++ b/website/src/reducers/app.test.ts
@@ -20,6 +20,7 @@ const appInitialState: AppState = {
   isFeedbackModalOpen: false,
   promptRefresh: false,
   notifications: [],
+  customiseModule: '',
 };
 const appHasSemesterTwoState: AppState = { ...appInitialState, activeSemester: anotherSemester };
 const appHasActiveLessonState: AppState = { ...appInitialState, activeLesson: lesson };
@@ -55,7 +56,7 @@ test('app should set active lesson', () => {
 });
 
 test('app should accept lesson change and unset active lesson', () => {
-  const action = changeLesson(semester, lesson);
+  const action = changeLesson(semester, lesson, lesson.classNo);
   const nextState: AppState = reducer(appInitialState, action);
 
   expect(nextState).toEqual(appInitialState);

--- a/website/src/reducers/app.ts
+++ b/website/src/reducers/app.ts
@@ -3,7 +3,12 @@ import { Actions } from 'types/actions';
 import config from 'config';
 
 import { forceRefreshPrompt } from 'utils/debug';
-import { MODIFY_LESSON, CHANGE_LESSON, CANCEL_MODIFY_LESSON } from 'actions/timetables';
+import {
+  MODIFY_LESSON,
+  CHANGE_LESSON,
+  CANCEL_MODIFY_LESSON,
+  CUSTOMISE_MODULE,
+} from 'actions/timetables';
 import { SELECT_SEMESTER } from 'actions/settings';
 import {
   OPEN_NOTIFICATION,
@@ -18,6 +23,7 @@ const defaultAppState = (): AppState => ({
   activeSemester: config.semester,
   // The lesson being modified on the timetable.
   activeLesson: null,
+  customiseModule: '',
   isOnline: navigator.onLine,
   isFeedbackModalOpen: false,
   promptRefresh: forceRefreshPrompt(),
@@ -36,6 +42,11 @@ function app(state: AppState = defaultAppState(), action: Actions): AppState {
       return {
         ...state,
         activeLesson: action.payload.activeLesson,
+      };
+    case CUSTOMISE_MODULE:
+      return {
+        ...state,
+        customiseModule: action.payload.moduleCode,
       };
     case CANCEL_MODIFY_LESSON:
     case CHANGE_LESSON:

--- a/website/src/reducers/index.test.ts
+++ b/website/src/reducers/index.test.ts
@@ -10,16 +10,16 @@ const exportData: ExportData = {
   semester: 1,
   timetable: {
     CS3216: {
-      Lecture: '1',
+      Lecture: ['1'],
     },
     CS1010S: {
-      Lecture: '1',
-      Tutorial: '3',
-      Recitation: '2',
+      Lecture: ['1'],
+      Tutorial: ['3'],
+      Recitation: ['2'],
     },
     PC1222: {
-      Lecture: '1',
-      Tutorial: '3',
+      Lecture: ['1'],
+      Tutorial: ['3'],
     },
   },
   colors: {
@@ -52,16 +52,16 @@ test('reducers should set export data state', () => {
     lessons: {
       [1]: {
         CS3216: {
-          Lecture: '1',
+          Lecture: ['1'],
         },
         CS1010S: {
-          Lecture: '1',
-          Tutorial: '3',
-          Recitation: '2',
+          Lecture: ['1'],
+          Tutorial: ['3'],
+          Recitation: ['2'],
         },
         PC1222: {
-          Lecture: '1',
-          Tutorial: '3',
+          Lecture: ['1'],
+          Tutorial: ['3'],
         },
       },
     },

--- a/website/src/reducers/index.test.ts
+++ b/website/src/reducers/index.test.ts
@@ -72,6 +72,7 @@ test('reducers should set export data state', () => {
         PC1222: 2,
       },
     },
+    customisedModules: {},
     hidden: { [1]: ['PC1222'] },
     academicYear: expect.any(String),
     archive: {},

--- a/website/src/reducers/timetables.test.ts
+++ b/website/src/reducers/timetables.test.ts
@@ -1,4 +1,4 @@
-import reducer, { defaultTimetableState, persistConfig } from 'reducers/timetables';
+import reducer, { defaultTimetableState, migrateV1toV2, persistConfig } from 'reducers/timetables';
 import {
   ADD_MODULE,
   hideLessonInTimetable,
@@ -125,41 +125,41 @@ describe('lesson reducer', () => {
           lessons: {
             [1]: {
               CS1010S: {
-                Lecture: '1',
-                Recitation: '2',
+                Lecture: ['1'],
+                Recitation: ['2'],
               },
               CS3216: {
-                Lecture: '1',
+                Lecture: ['1'],
               },
             },
             [2]: {
               CS3217: {
-                Lecture: '1',
+                Lecture: ['1'],
               },
             },
           },
         },
         setLessonConfig(1, 'CS1010S', {
-          Lecture: '2',
-          Recitation: '3',
-          Tutorial: '4',
+          Lecture: ['2'],
+          Recitation: ['3'],
+          Tutorial: ['4'],
         }),
       ),
     ).toMatchObject({
       lessons: {
         [1]: {
           CS1010S: {
-            Lecture: '2',
-            Recitation: '3',
-            Tutorial: '4',
+            Lecture: ['2'],
+            Recitation: ['3'],
+            Tutorial: ['4'],
           },
           CS3216: {
-            Lecture: '1',
+            Lecture: ['1'],
           },
         },
         [2]: {
           CS3217: {
-            Lecture: '1',
+            Lecture: ['1'],
           },
         },
       },
@@ -172,7 +172,7 @@ describe('stateReconciler', () => {
     '2015/2016': {
       [1]: {
         GET1006: {
-          Lecture: '1',
+          Lecture: ['1'],
         },
       },
     },
@@ -181,13 +181,13 @@ describe('stateReconciler', () => {
   const oldLessons = {
     [1]: {
       CS1010S: {
-        Lecture: '1',
-        Recitation: '2',
+        Lecture: ['1'],
+        Recitation: ['2'],
       },
     },
     [2]: {
       CS3217: {
-        Lecture: '1',
+        Lecture: ['1'],
       },
     },
   };
@@ -237,5 +237,58 @@ describe('stateReconciler', () => {
         '2016/2017': oldLessons,
       },
     });
+  });
+});
+
+describe('redux schema migration', () => {
+  const reduxDataV1 = {
+    lessons: {
+      [1]: {
+        CS1010S: {
+          Lecture: '1',
+          Recitation: '2',
+        },
+      },
+      [2]: {
+        CS3217: {
+          Lecture: '1',
+        },
+      },
+    },
+    colors: {},
+    hidden: {},
+    academicYear: '2022/2023',
+    archive: {},
+    _persist: {
+      version: 1,
+      rehydrated: false,
+    },
+  };
+
+  const reduxDataV2 = {
+    lessons: {
+      [1]: {
+        CS1010S: {
+          Lecture: ['1'],
+          Recitation: ['2'],
+        },
+      },
+      [2]: {
+        CS3217: {
+          Lecture: ['1'],
+        },
+      },
+    },
+    colors: {},
+    hidden: {},
+    academicYear: '2022/2023',
+    archive: {},
+    _persist: {
+      version: 1, // version kept the same because the framework does not support it in unit tests
+      rehydrated: false,
+    },
+  };
+  test('should migrate from V1 to V2', () => {
+    expect(migrateV1toV2(reduxDataV1)).toEqual(reduxDataV2);
   });
 });

--- a/website/src/reducers/timetables.test.ts
+++ b/website/src/reducers/timetables.test.ts
@@ -207,6 +207,7 @@ describe('stateReconciler', () => {
     },
     academicYear: config.academicYear,
     archive: oldArchive,
+    customisedModules: {},
   };
 
   const { stateReconciler } = persistConfig;
@@ -259,6 +260,7 @@ describe('redux schema migration', () => {
     hidden: {},
     academicYear: '2022/2023',
     archive: {},
+    customisedModules: {},
     _persist: {
       version: 1,
       rehydrated: false,
@@ -283,6 +285,7 @@ describe('redux schema migration', () => {
     hidden: {},
     academicYear: '2022/2023',
     archive: {},
+    customisedModules: {},
     _persist: {
       version: 1, // version kept the same because the framework does not support it in unit tests
       rehydrated: false,

--- a/website/src/reducers/timetables.test.ts
+++ b/website/src/reducers/timetables.test.ts
@@ -260,7 +260,6 @@ describe('redux schema migration', () => {
     hidden: {},
     academicYear: '2022/2023',
     archive: {},
-    customisedModules: {},
     _persist: {
       version: 1,
       rehydrated: false,
@@ -285,7 +284,10 @@ describe('redux schema migration', () => {
     hidden: {},
     academicYear: '2022/2023',
     archive: {},
-    customisedModules: {},
+    customisedModules: {
+      [1]: [],
+      [2]: [],
+    },
     _persist: {
       version: 1, // version kept the same because the framework does not support it in unit tests
       rehydrated: false,

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -5,7 +5,7 @@ import { createMigrate, PersistedState } from 'redux-persist';
 import { PersistConfig } from 'storage/persistReducer';
 import { ModuleCode } from 'types/modules';
 import { ModuleLessonConfig, SemTimetableConfig, TimetableConfig } from 'types/timetables';
-import { ColorMapping, TimetablesState } from 'types/reducers';
+import { ColorMapping, CustomisedModulesMap, TimetablesState } from 'types/reducers';
 
 import config from 'config';
 import {
@@ -27,7 +27,7 @@ import { SET_EXPORTED_DATA } from 'actions/constants';
 import { Actions } from '../types/actions';
 
 // Migration from state V1 -> V2
-type TimetableStateV1 = Omit<TimetablesState, 'lessons'> & {
+type TimetableStateV1 = Omit<TimetablesState, 'lessons' | 'customisedModules'> & {
   lessons: { [semester: string]: { [moduleCode: string]: { [lessonType: string]: string } } };
 };
 export function migrateV1toV2(
@@ -35,8 +35,11 @@ export function migrateV1toV2(
 ): TimetablesState & PersistedState {
   const newLessons: TimetableConfig = {};
   const oldLessons = oldState.lessons;
+  const newCustomisedModules: CustomisedModulesMap = {};
 
   Object.entries(oldLessons).forEach(([semester, modules]) => {
+    newCustomisedModules[semester] = [];
+
     Object.entries(modules).forEach(([moduleCode, lessons]) => {
       const newSemester: { [moduleCode: string]: { [lessonType: string]: string[] } } = {
         [moduleCode]: {},
@@ -56,6 +59,7 @@ export function migrateV1toV2(
   return {
     ...oldState,
     lessons: newLessons,
+    customisedModules: newCustomisedModules,
   };
 }
 

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -1,10 +1,10 @@
 import { get, omit, values } from 'lodash';
 import produce from 'immer';
-import { createMigrate } from 'redux-persist';
+import { createMigrate, PersistedState } from 'redux-persist';
 
 import { PersistConfig } from 'storage/persistReducer';
 import { ModuleCode } from 'types/modules';
-import { ModuleLessonConfig, SemTimetableConfig } from 'types/timetables';
+import { ModuleLessonConfig, SemTimetableConfig, TimetableConfig } from 'types/timetables';
 import { ColorMapping, TimetablesState } from 'types/reducers';
 
 import config from 'config';
@@ -22,6 +22,40 @@ import { getNewColor } from 'utils/colors';
 import { SET_EXPORTED_DATA } from 'actions/constants';
 import { Actions } from '../types/actions';
 
+// Migration from state V1 -> V2
+type TimetableStateV1 = Omit<TimetablesState, 'lessons'> & {
+  lessons: { [semester: string]: { [moduleCode: string]: { [lessonType: string]: string } } };
+};
+export function migrateV1toV2(
+  oldState: TimetableStateV1 & PersistedState,
+): TimetablesState & PersistedState {
+  const newLessons: TimetableConfig = {};
+  const oldLessons = oldState.lessons;
+
+  Object.entries(oldLessons).forEach(([semester, modules]) => {
+    Object.entries(modules).forEach(([moduleCode, lessons]) => {
+      const newSemester: { [moduleCode: string]: { [lessonType: string]: string[] } } = {
+        [moduleCode]: {},
+      };
+
+      Object.entries(lessons).forEach(([lessonType, lessonValue]) => {
+        const lessonArray = [lessonValue];
+        newSemester[moduleCode][lessonType] = lessonArray;
+      });
+
+      if (!newLessons[semester]) {
+        newLessons[semester] = {};
+      }
+      Object.assign(newLessons[semester], newSemester);
+    });
+  });
+
+  return {
+    ...oldState,
+    lessons: newLessons,
+  };
+}
+
 export const persistConfig = {
   /* eslint-disable no-useless-computed-key */
   migrate: createMigrate({
@@ -34,9 +68,12 @@ export const persistConfig = {
       // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
       _persist: state?._persist!,
     }),
+    // Same as planner.ts
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [2]: migrateV1toV2 as any,
   }),
   /* eslint-enable */
-  version: 1,
+  version: 2,
 
   // Our own state reconciler archives old timetables if the acad year is different,
   // otherwise use the persisted timetable state
@@ -82,7 +119,7 @@ function moduleLessonConfig(
       if (!(classNo && lessonType)) return state;
       return {
         ...state,
-        [lessonType]: classNo,
+        [lessonType]: [classNo],
       };
     }
     case SET_LESSON_CONFIG:

--- a/website/src/selectors/timetables.ts
+++ b/website/src/selectors/timetables.ts
@@ -38,3 +38,8 @@ export const getSemesterTimetableColors = createSelector(
   (colors) => (semester: Semester | null) =>
     semester === null ? EMPTY_OBJECT : colors[semester] ?? EMPTY_OBJECT,
 );
+
+export const getCustomisingLesson = createSelector(
+  ({ app }: State) => app.customiseModule,
+  (customiseModule) => customiseModule ?? null,
+);

--- a/website/src/types/reducers.ts
+++ b/website/src/types/reducers.ts
@@ -51,6 +51,7 @@ export type NotificationData = { readonly message: string } & NotificationOption
 export type AppState = {
   readonly activeSemester: Semester;
   readonly activeLesson: Lesson | null;
+  readonly customiseModule: ModuleCode;
   readonly isOnline: boolean;
   readonly isFeedbackModalOpen: boolean;
   readonly notifications: NotificationData[];
@@ -112,6 +113,7 @@ export type SettingsState = {
 export type ColorMapping = { [moduleCode: string]: ColorIndex };
 export type SemesterColorMap = { [semester: string]: ColorMapping };
 export type HiddenModulesMap = { [semester: string]: ModuleCode[] };
+export type CustomisedModulesMap = { [semester: string]: ModuleCode[] };
 
 export type TimetablesState = {
   readonly lessons: TimetableConfig;
@@ -120,6 +122,7 @@ export type TimetablesState = {
   readonly academicYear: string;
   // Mapping of academic year to old timetable config
   readonly archive: { [key: string]: TimetableConfig };
+  readonly customisedModules: CustomisedModulesMap;
 };
 
 /* venueBank.js */

--- a/website/src/types/reducers.ts
+++ b/website/src/types/reducers.ts
@@ -113,7 +113,7 @@ export type SettingsState = {
 export type ColorMapping = { [moduleCode: string]: ColorIndex };
 export type SemesterColorMap = { [semester: string]: ColorMapping };
 export type HiddenModulesMap = { [semester: string]: ModuleCode[] };
-export type CustomisedModulesMap = { [semester: string]: ModuleCode[] };
+export type CustomisedModulesMap = { [semester: string]: ModuleCode[] | undefined };
 
 export type TimetablesState = {
   readonly lessons: TimetableConfig;

--- a/website/src/types/timetables.ts
+++ b/website/src/types/timetables.ts
@@ -2,7 +2,7 @@ import { ClassNo, LessonType, ModuleCode, ModuleTitle, RawLesson } from './modul
 
 //  ModuleLessonConfig is a mapping of lessonType to ClassNo for a module.
 export type ModuleLessonConfig = {
-  [lessonType: string]: ClassNo;
+  [lessonType: string]: ClassNo[];
 };
 
 // SemTimetableConfig is the timetable data for each semester.

--- a/website/src/utils/timetables.test.ts
+++ b/website/src/utils/timetables.test.ts
@@ -85,9 +85,9 @@ test('hydrateSemTimetableWithLessons should replace ClassNo with lessons', () =>
   const modules: ModulesMap = { [moduleCode]: CS1010S };
   const config: SemTimetableConfig = {
     [moduleCode]: {
-      Tutorial: '8',
-      Recitation: '4',
-      Lecture: '1',
+      Tutorial: ['8'],
+      Recitation: ['4'],
+      Lecture: ['1'],
     },
   };
 
@@ -385,15 +385,15 @@ test('timetable serialization/deserialization', () => {
     {},
     { CS1010S: {} },
     {
-      GER1000: { Tutorial: 'B01' },
+      GER1000: { Tutorial: ['B01'] },
     },
     {
-      CS2104: { Lecture: '1', Tutorial: '2' },
-      CS2105: { Lecture: '1', Tutorial: '1' },
-      CS2107: { Lecture: '1', Tutorial: '8' },
-      CS4212: { Lecture: '1', Tutorial: '1' },
-      CS4243: { Laboratory: '2', Lecture: '1' },
-      GER1000: { Tutorial: 'B01' },
+      CS2104: { Lecture: ['1'], Tutorial: ['2'] },
+      CS2105: { Lecture: ['1'], Tutorial: ['1'] },
+      CS2107: { Lecture: ['1'], Tutorial: ['8'] },
+      CS4212: { Lecture: ['1'], Tutorial: ['1'] },
+      CS4243: { Laboratory: ['2'], Lecture: ['1'] },
+      GER1000: { Tutorial: ['B01'] },
     },
   ];
 
@@ -406,8 +406,8 @@ test('deserializing edge cases', () => {
   // Duplicate module code
   expect(deserializeTimetable('CS1010S=LEC:01&CS1010S=REC:11')).toEqual({
     CS1010S: {
-      Lecture: '01',
-      Recitation: '11',
+      Lecture: ['01'],
+      Recitation: ['11'],
     },
   });
 
@@ -416,7 +416,7 @@ test('deserializing edge cases', () => {
     CS1010S: {},
     CS3217: {},
     CS2105: {
-      Lecture: '1',
+      Lecture: ['1'],
     },
   });
 });
@@ -428,8 +428,8 @@ test('isSameTimetableConfig', () => {
   // Change lessonType order
   expect(
     isSameTimetableConfig(
-      { CS2104: { Tutorial: '1', Lecture: '2' } },
-      { CS2104: { Lecture: '2', Tutorial: '1' } },
+      { CS2104: { Tutorial: ['1'], Lecture: ['2'] } },
+      { CS2104: { Lecture: ['2'], Tutorial: ['1'] } },
     ),
   ).toBe(true);
 
@@ -437,12 +437,12 @@ test('isSameTimetableConfig', () => {
   expect(
     isSameTimetableConfig(
       {
-        CS2104: { Lecture: '1', Tutorial: '2' },
-        CS2105: { Lecture: '1', Tutorial: '1' },
+        CS2104: { Lecture: ['1'], Tutorial: ['2'] },
+        CS2105: { Lecture: ['1'], Tutorial: ['1'] },
       },
       {
-        CS2105: { Lecture: '1', Tutorial: '1' },
-        CS2104: { Lecture: '1', Tutorial: '2' },
+        CS2105: { Lecture: ['1'], Tutorial: ['1'] },
+        CS2104: { Lecture: ['1'], Tutorial: ['2'] },
       },
     ),
   ).toBe(true);
@@ -450,8 +450,8 @@ test('isSameTimetableConfig', () => {
   // Different values
   expect(
     isSameTimetableConfig(
-      { CS2104: { Lecture: '1', Tutorial: '2' } },
-      { CS2104: { Lecture: '2', Tutorial: '1' } },
+      { CS2104: { Lecture: ['1'], Tutorial: ['2'] } },
+      { CS2104: { Lecture: ['2'], Tutorial: ['1'] } },
     ),
   ).toBe(false);
 
@@ -459,11 +459,11 @@ test('isSameTimetableConfig', () => {
   expect(
     isSameTimetableConfig(
       {
-        CS2104: { Tutorial: '1', Lecture: '2' },
+        CS2104: { Tutorial: ['1'], Lecture: ['2'] },
       },
       {
-        CS2104: { Tutorial: '1', Lecture: '2' },
-        CS2105: { Lecture: '1', Tutorial: '1' },
+        CS2104: { Tutorial: ['1'], Lecture: ['2'] },
+        CS2105: { Lecture: ['1'], Tutorial: ['1'] },
       },
     ),
   ).toBe(false);
@@ -499,9 +499,9 @@ describe(validateTimetableModules, () => {
 describe('validateModuleLessons', () => {
   const semester: Semester = 1;
   const lessons: ModuleLessonConfig = {
-    Lecture: '1',
-    Recitation: '10',
-    Tutorial: '11',
+    Lecture: ['1'],
+    Recitation: ['10'],
+    Tutorial: ['11'],
   };
 
   test('should leave valid lessons untouched', () => {
@@ -514,7 +514,7 @@ describe('validateModuleLessons', () => {
         semester,
         {
           ...lessons,
-          Laboratory: '2', // CS1010S has no lab
+          Laboratory: ['2'], // CS1010S has no lab
         },
         CS1010S,
       ),
@@ -527,7 +527,7 @@ describe('validateModuleLessons', () => {
         semester,
         {
           ...lessons,
-          Lecture: '2', // CS1010S has no Lecture 2
+          Lecture: ['2'], // CS1010S has no Lecture 2
         },
         CS1010S,
       ),
@@ -539,15 +539,15 @@ describe('validateModuleLessons', () => {
       validateModuleLessons(
         semester,
         {
-          Tutorial: '10',
+          Tutorial: ['10'],
         },
         CS1010S,
       ),
     ).toEqual([
       {
-        Lecture: '1',
-        Recitation: '1',
-        Tutorial: '10',
+        Lecture: ['1'],
+        Recitation: ['1'],
+        Tutorial: ['10'],
       },
       ['Lecture', 'Recitation'],
     ]);

--- a/website/src/utils/timetables.ts
+++ b/website/src/utils/timetables.ts
@@ -76,6 +76,7 @@ export const LESSON_ABBREV_TYPE: { [key: string]: LessonType } = invert(LESSON_T
 // See: https://stackoverflow.com/a/31300627
 export const LESSON_TYPE_SEP = ':';
 export const LESSON_SEP = ',';
+export const SAME_LESSON_SEP = ';';
 
 const EMPTY_OBJECT = {};
 
@@ -103,8 +104,9 @@ export function randomModuleLessonConfig(lessons: readonly RawLesson[]): ModuleL
 
   return mapValues(
     lessonByGroupsByClassNo,
-    (group: { [classNo: string]: readonly RawLesson[] }) =>
+    (group: { [classNo: string]: readonly RawLesson[] }) => [
       (first(sample(group)) as RawLesson).classNo,
+    ],
   );
 }
 
@@ -121,11 +123,12 @@ export function hydrateSemTimetableWithLessons(
       if (!module) return EMPTY_OBJECT;
 
       // TODO: Split this part into a smaller function: hydrateModuleConfigWithLessons.
-      return mapValues(moduleLessonConfig, (classNo: ClassNo, lessonType: LessonType) => {
+      return mapValues(moduleLessonConfig, (classNos: ClassNo[], lessonType: LessonType) => {
         const lessons = getModuleTimetable(module, semester);
         const newLessons = lessons.filter(
           (lesson: RawLesson): boolean =>
-            lesson.lessonType === lessonType && lesson.classNo === classNo,
+            lesson.lessonType === lessonType &&
+            classNos.some((classNo) => classNo === lesson.classNo),
         );
 
         const timetableLessons: Lesson[] = newLessons.map(
@@ -337,11 +340,14 @@ export function validateModuleLessons(
     // - classNo is not valid anymore (ie. the class was removed)
     //
     // If a lesson type is removed, then it simply won't be copied over
-    if (!lessons.some((lesson) => lesson.classNo === classNo)) {
-      validatedLessonConfig[lessonType] = lessons[0].classNo;
+    const filteredClasses =
+      classNo &&
+      classNo.filter((classNum) => lessons.some((lesson) => lesson.classNo === classNum));
+    if (!classNo || filteredClasses.length === 0) {
+      validatedLessonConfig[lessonType] = [lessons[0].classNo];
       updatedLessonTypes.push(lessonType);
     } else {
-      validatedLessonConfig[lessonType] = classNo;
+      validatedLessonConfig[lessonType] = filteredClasses;
     }
   });
 
@@ -359,9 +365,11 @@ export function getSemesterModules(
 }
 
 function serializeModuleConfig(config: ModuleLessonConfig): string {
-  // eg. { Lecture: 1, Laboratory: 2 } => LEC=1,LAB=2
+  // eg. { Lecture: 1, Laboratory: 2, Laboratory: 3 } => LEC=1,LAB=2;3
   return map(config, (classNo, lessonType) =>
-    [LESSON_TYPE_ABBREV[lessonType], encodeURIComponent(classNo)].join(LESSON_TYPE_SEP),
+    [LESSON_TYPE_ABBREV[lessonType], encodeURIComponent(classNo.join(SAME_LESSON_SEP))].join(
+      LESSON_TYPE_SEP,
+    ),
   ).join(LESSON_SEP);
 }
 
@@ -375,7 +383,7 @@ function parseModuleConfig(serialized: string | string[] | null): ModuleLessonCo
       const lessonType = LESSON_ABBREV_TYPE[lessonTypeAbbr];
       // Ignore unparsable/invalid keys
       if (!lessonType) return;
-      config[lessonType] = classNo;
+      config[lessonType] = classNo.split(SAME_LESSON_SEP);
     });
   });
 

--- a/website/src/views/components/module-info/AddModuleDropdown.test.tsx
+++ b/website/src/views/components/module-info/AddModuleDropdown.test.tsx
@@ -76,7 +76,7 @@ describe(AddModuleDropdownComponent, () => {
 
   test('should show remove button when the module is in timetable', () => {
     // eslint-disable-next-line no-useless-computed-key
-    const container = make(CS3216, { [1]: { CS3216: { Lecture: '1' } } });
+    const container = make(CS3216, { [1]: { CS3216: { Lecture: ['1'] } } });
     const button = container.wrapper.find('button');
 
     expect(button.text()).toMatch('Remove');

--- a/website/src/views/components/module-info/LessonTimetable.tsx
+++ b/website/src/views/components/module-info/LessonTimetable.tsx
@@ -32,6 +32,7 @@ const SemesterLessonTimetable: FC<{ semesterData?: SemesterData }> = ({ semester
     <Timetable
       lessons={arrangedLessons}
       onModifyCell={(lesson: Lesson) => history.push(venuePage(lesson.venue))}
+      customisedModules={[]}
     />
   );
 };

--- a/website/src/views/settings/BetaToggle.tsx
+++ b/website/src/views/settings/BetaToggle.tsx
@@ -4,7 +4,10 @@ import ExternalLink from 'views/components/ExternalLink';
 import config from 'config';
 import styles from './SettingsContainer.scss';
 
-export const currentTests = ['Course planner: plan courses in future semesters'];
+export const currentTests = [
+  'Course planner: plan courses in future semesters',
+  'TA view: customise the visibility of courses in your timetable',
+];
 
 type Props = {
   betaTester: boolean;

--- a/website/src/views/settings/SettingsContainer.tsx
+++ b/website/src/views/settings/SettingsContainer.tsx
@@ -129,7 +129,7 @@ const SettingsContainer: React.FC<Props> = ({
       </p>
 
       <div className={styles.preview}>
-        <Timetable lessons={previewTimetable} />
+        <Timetable lessons={previewTimetable} customisedModules={[]} />
       </div>
 
       <div>

--- a/website/src/views/tetris/TetrisGame.tsx
+++ b/website/src/views/tetris/TetrisGame.tsx
@@ -101,6 +101,7 @@ function renderPiece(tiles: Board) {
       hoverLesson={null}
       onModifyCell={noop}
       onCellHover={noop}
+      customisedModules={[]}
     />
   );
 }
@@ -407,7 +408,7 @@ export default class TetrisGame extends PureComponent<Props, State> {
 
         <div className={styles.game}>
           {this.renderOverlay()}
-          <Timetable lessons={lessons} isVerticalOrientation />
+          <Timetable lessons={lessons} isVerticalOrientation customisedModules={[]} />
         </div>
 
         <div className={styles.sidebar}>

--- a/website/src/views/timetable/ShareTimetable.test.tsx
+++ b/website/src/views/timetable/ShareTimetable.test.tsx
@@ -29,7 +29,7 @@ describe('ShareTimetable', () => {
 
   const timetable = {
     CS1010S: {
-      Lecture: '1',
+      Lecture: ['1'],
     },
   };
 

--- a/website/src/views/timetable/Timetable.tsx
+++ b/website/src/views/timetable/Timetable.tsx
@@ -30,7 +30,7 @@ type Props = TimerData & {
   showTitle?: boolean;
   onModifyCell?: OnModifyCell;
   highlightPeriod?: TimePeriod;
-  customisedModules?: ModuleCode[];
+  customisedModules: ModuleCode[];
 };
 
 type State = {

--- a/website/src/views/timetable/Timetable.tsx
+++ b/website/src/views/timetable/Timetable.tsx
@@ -16,6 +16,7 @@ import elements from 'views/elements';
 import withTimer, { TimerData } from 'views/hocs/withTimer';
 
 import { TimePeriod } from 'types/venues';
+import { ModuleCode } from 'types/modules';
 import styles from './Timetable.scss';
 import TimetableTimings from './TimetableTimings';
 import TimetableDay from './TimetableDay';
@@ -29,6 +30,7 @@ type Props = TimerData & {
   showTitle?: boolean;
   onModifyCell?: OnModifyCell;
   highlightPeriod?: TimePeriod;
+  customisedModules?: ModuleCode[];
 };
 
 type State = {
@@ -108,6 +110,7 @@ class Timetable extends React.PureComponent<Props, State> {
                 highlightPeriod={
                   highlightPeriod && index === highlightPeriod.day ? highlightPeriod : undefined
                 }
+                customisedModules={this.props.customisedModules}
               />
             ))}
           </ol>

--- a/website/src/views/timetable/TimetableCell.test.tsx
+++ b/website/src/views/timetable/TimetableCell.test.tsx
@@ -38,7 +38,9 @@ function make(additionalProps: Partial<Props> = {}) {
   return {
     onClick,
     onHover: props.onHover,
-    wrapper: shallow(<TimetableCell onClick={onClick} lesson={DEFAULT_LESSON} {...props} />),
+    wrapper: shallow(
+      <TimetableCell onClick={onClick} lesson={DEFAULT_LESSON} {...props} customisedModules={[]} />,
+    ),
   };
 }
 

--- a/website/src/views/timetable/TimetableCell.tsx
+++ b/website/src/views/timetable/TimetableCell.tsx
@@ -26,7 +26,7 @@ type Props = {
   onClick?: (position: ClientRect) => void;
   hoverLesson?: HoverLesson | null;
   transparent: boolean;
-  customisedModules?: ModuleCode[];
+  customisedModules: ModuleCode[];
 };
 
 const lessonDateFormat = 'MMM dd';
@@ -87,7 +87,8 @@ function formatWeekRange(weekRange: WeekRange) {
  * might explore other representations e.g. grouped lessons
  */
 const TimetableCell: React.FC<Props> = (props) => {
-  const { lesson, showTitle, onClick, onHover, hoverLesson, transparent } = props;
+  const { lesson, showTitle, onClick, onHover, hoverLesson, transparent, customisedModules } =
+    props;
 
   const moduleName = showTitle ? `${lesson.moduleCode} ${lesson.title}` : lesson.moduleCode;
   const Cell = props.onClick ? 'button' : 'div';
@@ -134,9 +135,7 @@ const TimetableCell: React.FC<Props> = (props) => {
       <div className={styles.cellContainer}>
         <div className={styles.moduleName}>
           {moduleName}
-          {props.customisedModules && props.customisedModules.includes(lesson.moduleCode)
-            ? '*'
-            : null}
+          {customisedModules.includes(lesson.moduleCode) && '*'}
         </div>
         <div>
           {LESSON_TYPE_ABBREV[lesson.lessonType]} [{lesson.classNo}]

--- a/website/src/views/timetable/TimetableCell.tsx
+++ b/website/src/views/timetable/TimetableCell.tsx
@@ -4,7 +4,7 @@ import { isEqual } from 'lodash';
 import { addWeeks, format, parseISO } from 'date-fns';
 import NUSModerator, { AcadWeekInfo } from 'nusmoderator';
 
-import { consumeWeeks, WeekRange } from 'types/modules';
+import { consumeWeeks, ModuleCode, WeekRange } from 'types/modules';
 import { HoverLesson, ModifiableLesson } from 'types/timetables';
 import { OnHoverCell } from 'types/views';
 
@@ -26,6 +26,7 @@ type Props = {
   onClick?: (position: ClientRect) => void;
   hoverLesson?: HoverLesson | null;
   transparent: boolean;
+  customisedModules?: ModuleCode[];
 };
 
 const lessonDateFormat = 'MMM dd';
@@ -131,7 +132,12 @@ const TimetableCell: React.FC<Props> = (props) => {
       {...conditionalProps}
     >
       <div className={styles.cellContainer}>
-        <div className={styles.moduleName}>{moduleName}</div>
+        <div className={styles.moduleName}>
+          {moduleName}
+          {props.customisedModules && props.customisedModules.includes(lesson.moduleCode)
+            ? '*'
+            : null}
+        </div>
         <div>
           {LESSON_TYPE_ABBREV[lesson.lessonType]} [{lesson.classNo}]
         </div>

--- a/website/src/views/timetable/TimetableContainer.test.tsx
+++ b/website/src/views/timetable/TimetableContainer.test.tsx
@@ -117,7 +117,7 @@ describe(TimetableContainerComponent, () => {
 
   test('should eventually display imported timetable if there is one', async () => {
     const semester = 1;
-    const importedTimetable = { [moduleCodeThatCanBeLoaded]: { Lecture: '1' } };
+    const importedTimetable = { [moduleCodeThatCanBeLoaded]: { Lecture: ['1'] } };
     const location = timetableShare(semester, importedTimetable);
     make(location);
 
@@ -136,7 +136,7 @@ describe(TimetableContainerComponent, () => {
 
   test('should ignore invalid modules in imported timetable', () => {
     const semester = 1;
-    const importedTimetable = { TRUMP2020: { Lecture: '1' } };
+    const importedTimetable = { TRUMP2020: { Lecture: ['1'] } };
     const location = timetableShare(semester, importedTimetable);
     make(location);
 
@@ -159,7 +159,7 @@ describe(TimetableContainerComponent, () => {
     store.dispatch({ type: SUCCESS_KEY(FETCH_MODULE), payload: CS3216 });
 
     // Populate mock timetable
-    const timetable = { CS1010S: { Lecture: '1' }, CS3216: { Lecture: '1' } };
+    const timetable = { CS1010S: { Lecture: ['1'] }, CS3216: { Lecture: ['1'] } };
     (store.dispatch as Dispatch)(setTimetable(semester, timetable));
 
     // Expect nothing to be fetched as timetable exists in `moduleBank`.

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -509,6 +509,7 @@ function mapStateToProps(state: StoreState, ownProps: OwnProps) {
   const { semester, timetable } = ownProps;
   const { modules } = state.moduleBank;
   const timetableWithLessons = hydrateSemTimetableWithLessons(timetable, modules, semester);
+  // TODO(zwliew): fix the type signature of state.timetables.hidden[semester]
   const hiddenInTimetable = state.timetables.hidden[semester] || [];
 
   return {
@@ -518,7 +519,7 @@ function mapStateToProps(state: StoreState, ownProps: OwnProps) {
     modules,
     activeLesson: state.app.activeLesson,
     customiseModule: state.app.customiseModule,
-    customisedModules: state.timetables.customisedModules[semester],
+    customisedModules: state.timetables.customisedModules[semester] ?? [],
     timetableOrientation: state.theme.timetableOrientation,
     showTitle: state.theme.showTitle,
     hiddenInTimetable,

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import _ from 'lodash';
 
 import { ColorMapping, HORIZONTAL, ModulesMap, TimetableOrientation } from 'types/reducers';
-import { Module, ModuleCode, Semester } from 'types/modules';
+import { ClassNo, LessonType, Module, ModuleCode, Semester } from 'types/modules';
 import {
   ColoredLesson,
   Lesson,
@@ -20,6 +20,8 @@ import {
   changeLesson,
   modifyLesson,
   removeModule,
+  addLesson,
+  removeLesson,
 } from 'actions/timetables';
 import { undo } from 'actions/undoHistory';
 import {
@@ -72,6 +74,8 @@ type Props = OwnProps & {
   timetableWithLessons: SemTimetableConfigWithLessons;
   modules: ModulesMap;
   activeLesson: Lesson | null;
+  customiseModule: ModuleCode;
+  customisedModules: ModuleCode[];
   timetableOrientation: TimetableOrientation;
   showTitle: boolean;
   hiddenInTimetable: ModuleCode[];
@@ -80,9 +84,21 @@ type Props = OwnProps & {
   addModule: (semester: Semester, moduleCode: ModuleCode) => void;
   removeModule: (semester: Semester, moduleCode: ModuleCode) => void;
   modifyLesson: (lesson: Lesson) => void;
-  changeLesson: (semester: Semester, lesson: Lesson) => void;
+  changeLesson: (semester: Semester, lesson: Lesson, activeLesson: ClassNo) => void;
   cancelModifyLesson: () => void;
   undo: () => void;
+  addLesson: (
+    semester: Semester,
+    moduleCode: ModuleCode,
+    lessonType: LessonType,
+    classNo: ClassNo,
+  ) => void;
+  removeLesson: (
+    semester: Semester,
+    moduleCode: ModuleCode,
+    lessonType: LessonType,
+    classNo: ClassNo,
+  ) => void;
 };
 
 type State = {
@@ -159,8 +175,28 @@ class TimetableContent extends React.Component<Props, State> {
     this.props.hiddenInTimetable.includes(moduleCode);
 
   modifyCell = (lesson: ModifiableLesson, position: ClientRect) => {
-    if (lesson.isAvailable) {
-      this.props.changeLesson(this.props.semester, lesson);
+    if (this.props.customiseModule === lesson.moduleCode) {
+      this.modifiedCell = {
+        position,
+        className: getLessonIdentifier(lesson),
+      };
+      if (lesson.isAvailable) {
+        this.props.addLesson(
+          this.props.semester,
+          lesson.moduleCode,
+          lesson.lessonType,
+          lesson.classNo,
+        );
+      } else if (lesson.isActive) {
+        this.props.removeLesson(
+          this.props.semester,
+          lesson.moduleCode,
+          lesson.lessonType,
+          lesson.classNo,
+        );
+      }
+    } else if (lesson.isAvailable && this.props.activeLesson) {
+      this.props.changeLesson(this.props.semester, lesson, this.props.activeLesson.classNo);
 
       resetScrollPosition();
     } else if (lesson.isActive) {
@@ -286,7 +322,34 @@ class TimetableContent extends React.Component<Props, State> {
       // Do not process hidden modules
       .filter((lesson) => !this.isHiddenInTimetable(lesson.moduleCode));
 
-    if (activeLesson) {
+    if (this.props.customiseModule) {
+      const activeLessons = timetableLessons.filter(
+        (lesson) => lesson.moduleCode === this.props.customiseModule,
+      );
+      timetableLessons = timetableLessons.filter(
+        (lesson) => lesson.moduleCode !== this.props.customiseModule,
+      );
+
+      const module = modules[this.props.customiseModule];
+      const moduleTimetable = getModuleTimetable(module, semester);
+      moduleTimetable.forEach((lesson) => {
+        const isActiveLesson =
+          activeLessons.filter(
+            (timetableLesson) =>
+              timetableLesson.classNo === lesson.classNo &&
+              timetableLesson.lessonType === lesson.lessonType,
+          ).length > 0;
+        const modifiableLesson: Lesson & { isActive?: boolean; isAvailable?: boolean } = {
+          ...lesson,
+          // Inject module code in
+          moduleCode: this.props.customiseModule,
+          title: module.title,
+          isAvailable: !isActiveLesson,
+          isActive: isActiveLesson,
+        };
+        timetableLessons.push(modifiableLesson);
+      });
+    } else if (activeLesson) {
       const { moduleCode } = activeLesson;
       // Remove activeLesson because it will appear again
       timetableLessons = timetableLessons.filter(
@@ -331,8 +394,9 @@ class TimetableContent extends React.Component<Props, State> {
 
             return {
               ...lesson,
-              isModifiable:
-                !readOnly && areOtherClassesAvailable(moduleTimetable, lesson.lessonType),
+              isModifiable: this.props.customiseModule
+                ? true
+                : !readOnly && areOtherClassesAvailable(moduleTimetable, lesson.lessonType),
             };
           }),
         ),
@@ -388,6 +452,7 @@ class TimetableContent extends React.Component<Props, State> {
                   isScrolledHorizontally={this.state.isScrolledHorizontally}
                   showTitle={isShowingTitle}
                   onModifyCell={this.modifyCell}
+                  customisedModules={this.props.customisedModules}
                 />
               </div>
             )}
@@ -451,6 +516,8 @@ function mapStateToProps(state: StoreState, ownProps: OwnProps) {
     timetableWithLessons,
     modules,
     activeLesson: state.app.activeLesson,
+    customiseModule: state.app.customiseModule,
+    customisedModules: state.timetables.customisedModules[semester],
     timetableOrientation: state.theme.timetableOrientation,
     showTitle: state.theme.showTitle,
     hiddenInTimetable,
@@ -464,4 +531,6 @@ export default connect(mapStateToProps, {
   changeLesson,
   cancelModifyLesson,
   undo,
+  addLesson,
+  removeLesson,
 })(TimetableContent);

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -258,6 +258,7 @@ class TimetableContent extends React.Component<Props, State> {
       readOnly={this.props.readOnly}
       tombstone={tombstone}
       resetTombstone={this.resetTombstone}
+      customisedModules={this.props.customisedModules}
     />
   );
 
@@ -339,7 +340,7 @@ class TimetableContent extends React.Component<Props, State> {
               timetableLesson.classNo === lesson.classNo &&
               timetableLesson.lessonType === lesson.lessonType,
           ).length > 0;
-        const modifiableLesson: Lesson & { isActive?: boolean; isAvailable?: boolean } = {
+        const modifiableLesson: Lesson & { isActive: boolean; isAvailable: boolean } = {
           ...lesson,
           // Inject module code in
           moduleCode: this.props.customiseModule,

--- a/website/src/views/timetable/TimetableDay.tsx
+++ b/website/src/views/timetable/TimetableDay.tsx
@@ -26,7 +26,7 @@ type Props = {
   onCellHover: OnHoverCell;
   onModifyCell?: OnModifyCell;
   highlightPeriod?: TimePeriod;
-  customisedModules?: ModuleCode[];
+  customisedModules: ModuleCode[];
 };
 
 // Height of timetable per hour in vertical mode

--- a/website/src/views/timetable/TimetableDay.tsx
+++ b/website/src/views/timetable/TimetableDay.tsx
@@ -6,6 +6,7 @@ import { OnHoverCell, OnModifyCell } from 'types/views';
 import { convertTimeToIndex } from 'utils/timify';
 
 import { TimePeriod } from 'types/venues';
+import { ModuleCode } from 'types/modules';
 import styles from './TimetableDay.scss';
 import TimetableRow from './TimetableRow';
 import CurrentTimeIndicator from './CurrentTimeIndicator';
@@ -25,6 +26,7 @@ type Props = {
   onCellHover: OnHoverCell;
   onModifyCell?: OnModifyCell;
   highlightPeriod?: TimePeriod;
+  customisedModules?: ModuleCode[];
 };
 
 // Height of timetable per hour in vertical mode
@@ -87,6 +89,7 @@ const TimetableDay: React.FC<Props> = (props) => {
             onModifyCell={props.onModifyCell}
             hoverLesson={props.hoverLesson}
             onCellHover={props.onCellHover}
+            customisedModules={props.customisedModules}
           />
         ))}
 

--- a/website/src/views/timetable/TimetableModuleTable.test.tsx
+++ b/website/src/views/timetable/TimetableModuleTable.test.tsx
@@ -35,6 +35,7 @@ function make(props: Partial<Props> = {}) {
       resetTombstone={resetTombstone}
       customiseLesson={customiseLesson}
       customiseModule=""
+      customisedModules={[]}
       addCustomModule={addCustomModule}
       removeCustomModule={removeCustomModule}
       {...props}

--- a/website/src/views/timetable/TimetableModuleTable.test.tsx
+++ b/website/src/views/timetable/TimetableModuleTable.test.tsx
@@ -3,6 +3,7 @@ import { shallow, ShallowWrapper } from 'enzyme';
 import { CS1010S, CS3216, CS4243 } from '__mocks__/modules';
 import { addColors } from 'test-utils/theme';
 
+import * as redux from 'react-redux';
 import { TimetableModulesTableComponent, Props } from './TimetableModulesTable';
 import styles from './TimetableModulesTable.scss';
 
@@ -12,6 +13,12 @@ function make(props: Partial<Props> = {}) {
   const hideLessonInTimetable = jest.fn();
   const showLessonInTimetable = jest.fn();
   const resetTombstone = jest.fn();
+  const customiseLesson = jest.fn();
+  const addCustomModule = jest.fn();
+  const removeCustomModule = jest.fn();
+
+  const beta = jest.spyOn(redux, 'useSelector');
+  beta.mockReturnValue(false);
 
   const wrapper = shallow(
     <TimetableModulesTableComponent
@@ -26,6 +33,10 @@ function make(props: Partial<Props> = {}) {
       showLessonInTimetable={showLessonInTimetable}
       onRemoveModule={onRemoveModule}
       resetTombstone={resetTombstone}
+      customiseLesson={customiseLesson}
+      customiseModule=""
+      addCustomModule={addCustomModule}
+      removeCustomModule={removeCustomModule}
       {...props}
     />,
   );

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -41,6 +41,7 @@ export type Props = {
   modules: ModuleWithColor[];
   tombstone: TombstoneModule | null; // Placeholder for a deleted module
   customiseModule: ModuleCode;
+  customisedModules: ModuleCode[];
 
   // Actions
   selectModuleColor: (semester: Semester, moduleCode: ModuleCode, colorIndex: ColorIndex) => void;
@@ -135,7 +136,7 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
   };
 
   const renderModule = (module: ModuleWithColor) => {
-    const { semester, readOnly, tombstone, resetTombstone } = props;
+    const { semester, readOnly, tombstone, resetTombstone, customisedModules } = props;
 
     if (tombstone && tombstone.moduleCode === module.moduleCode) {
       return <ModuleTombstone module={module} resetTombstone={resetTombstone} />;
@@ -167,6 +168,7 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
           {!readOnly && renderModuleActions(module)}
           <Link to={modulePage(module.moduleCode, module.title)}>
             {module.moduleCode} {module.title}
+            {customisedModules.includes(module.moduleCode) && '*'}
           </Link>
           <div className={styles.moduleExam}>{intersperse(secondRowText, BULLET_NBSP)}</div>
         </div>

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import classnames from 'classnames';
 import { sortBy } from 'lodash';
@@ -8,16 +8,19 @@ import produce from 'immer';
 import { ModuleWithColor, TombstoneModule } from 'types/views';
 import { ColorIndex } from 'types/timetables';
 import { ModuleCode, Semester } from 'types/modules';
-import { State as StoreState } from 'types/state';
+import { State, State as StoreState } from 'types/state';
 import { ModuleTableOrder } from 'types/reducers';
-
-import ColorPicker from 'views/components/ColorPicker';
-import { Eye, EyeOff, Trash } from 'react-feather';
 import {
+  customiseLesson,
+  addCustomModule,
+  removeCustomModule,
   hideLessonInTimetable,
   selectModuleColor,
   showLessonInTimetable,
 } from 'actions/timetables';
+import ColorPicker from 'views/components/ColorPicker';
+import { Eye, EyeOff, Trash, Tool, Check } from 'react-feather';
+
 import { getExamDate, getFormattedExamDate, renderMCs } from 'utils/modules';
 import { intersperse } from 'utils/array';
 import { BULLET_NBSP } from 'utils/react';
@@ -37,55 +40,102 @@ export type Props = {
   moduleTableOrder: ModuleTableOrder;
   modules: ModuleWithColor[];
   tombstone: TombstoneModule | null; // Placeholder for a deleted module
+  customiseModule: ModuleCode;
 
   // Actions
   selectModuleColor: (semester: Semester, moduleCode: ModuleCode, colorIndex: ColorIndex) => void;
   hideLessonInTimetable: (semester: Semester, moduleCode: ModuleCode) => void;
   showLessonInTimetable: (semester: Semester, moduleCode: ModuleCode) => void;
   onRemoveModule: (moduleCode: ModuleCode) => void;
+  addCustomModule: (semester: Semester, moduleCode: ModuleCode) => void;
+  removeCustomModule: (semester: Semester, moduleCode: ModuleCode) => void;
   resetTombstone: () => void;
+  customiseLesson: (semester: Semester, moduleCode: ModuleCode) => void;
 };
 
 export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
+  const beta = useSelector(({ settings }: State) => settings.beta);
   const renderModuleActions = (module: ModuleWithColor) => {
     const hideBtnLabel = `${module.hiddenInTimetable ? 'Show' : 'Hide'} ${module.moduleCode}`;
     const removeBtnLabel = `Remove ${module.moduleCode} from timetable`;
+    const customBtnLabel = `Customise ${module.moduleCode} in timetable`;
+    const doneBtnLabel = `Done customising ${module.moduleCode} in timetable`;
     const { semester } = props;
 
     return (
       <div className={styles.moduleActionButtons}>
-        <div className="btn-group">
-          <Tooltip content={removeBtnLabel} touch="hold">
+        {props.customiseModule === module.moduleCode ? (
+          <Tooltip content={doneBtnLabel} touch="hold">
             <button
               type="button"
               className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
               aria-label={removeBtnLabel}
-              onClick={() => props.onRemoveModule(module.moduleCode)}
-            >
-              <Trash className={styles.actionIcon} />
-            </button>
-          </Tooltip>
-          <Tooltip content={hideBtnLabel} touch="hold">
-            <button
-              type="button"
-              className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
-              aria-label={hideBtnLabel}
               onClick={() => {
-                if (module.hiddenInTimetable) {
-                  props.showLessonInTimetable(semester, module.moduleCode);
-                } else {
-                  props.hideLessonInTimetable(semester, module.moduleCode);
-                }
+                props.customiseLesson(semester, '');
               }}
             >
-              {module.hiddenInTimetable ? (
-                <Eye className={styles.actionIcon} />
-              ) : (
-                <EyeOff className={styles.actionIcon} />
-              )}
+              <Check className={styles.actionIcon} />
             </button>
           </Tooltip>
-        </div>
+        ) : (
+          <div className="btn-group">
+            <Tooltip content={removeBtnLabel} touch="hold">
+              <button
+                type="button"
+                className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
+                aria-label={removeBtnLabel}
+                onClick={() => {
+                  props.onRemoveModule(module.moduleCode);
+                  props.removeCustomModule(semester, module.moduleCode);
+                }}
+              >
+                <Trash className={styles.actionIcon} />
+              </button>
+            </Tooltip>
+            <Tooltip content={hideBtnLabel} touch="hold">
+              <button
+                type="button"
+                className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
+                aria-label={hideBtnLabel}
+                onClick={() => {
+                  if (module.hiddenInTimetable) {
+                    props.showLessonInTimetable(semester, module.moduleCode);
+                  } else {
+                    props.hideLessonInTimetable(semester, module.moduleCode);
+                  }
+                }}
+              >
+                {module.hiddenInTimetable ? (
+                  <Eye className={styles.actionIcon} />
+                ) : (
+                  <EyeOff className={styles.actionIcon} />
+                )}
+              </button>
+            </Tooltip>
+            {beta && (
+              <Tooltip content={customBtnLabel} touch="hold">
+                <button
+                  type="button"
+                  className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
+                  aria-label={customBtnLabel}
+                  disabled={
+                    props.customiseModule !== '' && props.customiseModule !== module.moduleCode
+                  }
+                  hidden={
+                    props.customiseModule !== '' && props.customiseModule !== module.moduleCode
+                  }
+                  onClick={() => {
+                    // TODO: add modal for warning
+                    props.addCustomModule(semester, module.moduleCode);
+                    props.customiseLesson(semester, module.moduleCode);
+                  }}
+                >
+                  <Tool className={styles.actionIcon} />
+                </button>
+              </Tooltip>
+            )}
+          </div>
+        )}
       </div>
     );
   };
@@ -162,10 +212,16 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
 };
 
 export default connect(
-  (state: StoreState) => ({ moduleTableOrder: state.settings.moduleTableOrder }),
+  (state: StoreState) => ({
+    moduleTableOrder: state.settings.moduleTableOrder,
+    customiseModule: state.app.customiseModule,
+  }),
   {
     selectModuleColor,
     hideLessonInTimetable,
     showLessonInTimetable,
+    customiseLesson,
+    addCustomModule,
+    removeCustomModule,
   },
 )(React.memo(TimetableModulesTableComponent));

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -70,9 +70,7 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
               type="button"
               className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
               aria-label={removeBtnLabel}
-              onClick={() => {
-                props.customiseLesson(semester, '');
-              }}
+              onClick={() => props.customiseLesson(semester, '')}
             >
               <Check className={styles.actionIcon} />
             </button>
@@ -118,12 +116,8 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
                   type="button"
                   className={classnames('btn btn-outline-secondary btn-svg', styles.moduleAction)}
                   aria-label={customBtnLabel}
-                  disabled={
-                    props.customiseModule !== '' && props.customiseModule !== module.moduleCode
-                  }
-                  hidden={
-                    props.customiseModule !== '' && props.customiseModule !== module.moduleCode
-                  }
+                  disabled={!!props.customiseModule && props.customiseModule !== module.moduleCode}
+                  hidden={!!props.customiseModule && props.customiseModule !== module.moduleCode}
                   onClick={() => {
                     // TODO: add modal for warning
                     props.addCustomModule(semester, module.moduleCode);

--- a/website/src/views/timetable/TimetableRow.tsx
+++ b/website/src/views/timetable/TimetableRow.tsx
@@ -17,7 +17,7 @@ type Props = {
   hoverLesson?: HoverLesson | null;
   onCellHover: OnHoverCell;
   onModifyCell?: OnModifyCell;
-  customisedModules?: ModuleCode[];
+  customisedModules: ModuleCode[];
 };
 
 /**

--- a/website/src/views/timetable/TimetableRow.tsx
+++ b/website/src/views/timetable/TimetableRow.tsx
@@ -4,6 +4,7 @@ import { HoverLesson, ModifiableLesson } from 'types/timetables';
 import { OnHoverCell, OnModifyCell } from 'types/views';
 
 import { convertTimeToIndex } from 'utils/timify';
+import { ModuleCode } from 'types/modules';
 import styles from './TimetableRow.scss';
 import TimetableCell from './TimetableCell';
 
@@ -16,6 +17,7 @@ type Props = {
   hoverLesson?: HoverLesson | null;
   onCellHover: OnHoverCell;
   onModifyCell?: OnModifyCell;
+  customisedModules?: ModuleCode[];
 };
 
 /**
@@ -70,6 +72,7 @@ const TimetableRow: React.FC<Props> = (props) => {
             hoverLesson={props.hoverLesson}
             onHover={props.onCellHover}
             transparent={lesson.startTime === lesson.endTime}
+            customisedModules={props.customisedModules}
             {...conditionalProps}
           />
         );

--- a/website/src/views/venues/VenueDetails.tsx
+++ b/website/src/views/venues/VenueDetails.tsx
@@ -92,6 +92,7 @@ const VenueDetailsComponent: FC<Props> = ({
           highlightPeriod={highlightPeriod}
           isVerticalOrientation={narrowViewport}
           onModifyCell={navigateToLesson}
+          customisedModules={[]}
         />
       </div>
     </>


### PR DESCRIPTION
## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

This brings back PRs #3420 and #3434, which were reverted as part of PR #3435.

This re-resolves issue #3404.

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

The original schema migration is faulty, so I added a minor fix for that.

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->

TODOs:
1. Some tests would be good.
2. Hide in exam schedule.
3. Add a tally for how many course units are customized.
4. Deconflict `activeLessons` and `customiseModule` in the app state.
