### PR TITLE
Update module terminology to course

### DIFF
--- a/website/src/views/components/Title.tsx
+++ b/website/src/views/components/Title.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 const Title: React.FC<Props> = ({
   children,
-  description = 'NUSMods is a timetable builder and knowledge platform, providing students with a better way to plan their school timetable and useful module-related information that are community-driven.',
+  description = 'NUSMods is a timetable builder and knowledge platform, providing students with a better way to plan their school timetable and useful course-related information that are community-driven.',
 }) => (
   // We use defer=false to allow Google Analytics autotrack to send the correct
   // page title. See bootstrapping/google-analytics.js

--- a/website/src/views/components/module-info/AddModuleDropdown.tsx
+++ b/website/src/views/components/module-info/AddModuleDropdown.tsx
@@ -101,7 +101,7 @@ export class AddModuleDropdownComponent extends PureComponent<Props, State> {
         {({ getLabelProps, getItemProps, isOpen, toggleMenu, highlightedIndex, getMenuProps }) => (
           <div>
             <label {...getLabelProps({ htmlFor: id })} className="sr-only">
-              Add module to timetable
+              Add course to timetable
             </label>
 
             <div

--- a/website/src/views/components/module-info/SemesterPicker.tsx
+++ b/website/src/views/components/module-info/SemesterPicker.tsx
@@ -59,7 +59,7 @@ const SemesterPicker: FC<Props> = ({
       if (!semesterMapObtained[name]) {
         attrs[name] = {
           disabled: true,
-          title: `This module is not available in ${name}`,
+          title: `This course is not available in ${name}`,
         };
       }
     });

--- a/website/src/views/errors/ModuleNotFoundPage.tsx
+++ b/website/src/views/errors/ModuleNotFoundPage.tsx
@@ -29,7 +29,7 @@ type Props = OwnProps & {
 export class ModuleNotFoundPageComponent extends PureComponent<Props> {
   override componentDidMount() {
     Sentry.withScope(() => {
-      Sentry.captureMessage('404 - Course Not Found');
+      Sentry.captureMessage('404 - Module Not Found');
     });
 
     // If we think this is a module, try checking for archived modules

--- a/website/src/views/errors/ModuleNotFoundPage.tsx
+++ b/website/src/views/errors/ModuleNotFoundPage.tsx
@@ -29,7 +29,7 @@ type Props = OwnProps & {
 export class ModuleNotFoundPageComponent extends PureComponent<Props> {
   override componentDidMount() {
     Sentry.withScope(() => {
-      Sentry.captureMessage('404 - Module Not Found');
+      Sentry.captureMessage('404 - Course Not Found');
     });
 
     // If we think this is a module, try checking for archived modules
@@ -88,10 +88,10 @@ export class ModuleNotFoundPageComponent extends PureComponent<Props> {
               <span className={styles.bigCharacter}>4</span>
             </h1>
 
-            <h2>Oops, module {moduleCode} not found.</h2>
+            <h2>Oops, course {moduleCode} not found.</h2>
 
             <p>
-              This usually means you have a typo in the module code, or the module is not offered
+              This usually means you have a typo in the course code, or the course is not offered
               this year.
             </p>
 

--- a/website/src/views/layout/GlobalSearch.tsx
+++ b/website/src/views/layout/GlobalSearch.tsx
@@ -179,7 +179,7 @@ class GlobalSearch extends Component<Props, State> {
                     })}
                     type="button"
                   >
-                    modules
+                    courses
                   </button>{' '}
                   or{' '}
                   <button

--- a/website/src/views/modules/ModuleArchiveContainer.test.tsx
+++ b/website/src/views/modules/ModuleArchiveContainer.test.tsx
@@ -79,10 +79,10 @@ describe(ModuleArchiveContainerComponent, () => {
     mockDomReset();
   });
 
-  test('should show 404 page when the module code does not exist', async () => {
+  test('should show 404 page when the course code does not exist', async () => {
     mockAxiosRequest.mockRejectedValue(notFoundError);
     make('/archive/CS1234/2017-2018');
-    expect(await screen.findByText(/module CS1234 not found/)).toBeInTheDocument();
+    expect(await screen.findByText(/course CS1234 not found/)).toBeInTheDocument();
   });
 
   test('should redirect to canonical URL', async () => {

--- a/website/src/views/modules/ModulePageContainer.test.tsx
+++ b/website/src/views/modules/ModulePageContainer.test.tsx
@@ -82,7 +82,7 @@ describe(ModulePageContainerComponent, () => {
   test('should show 404 page when the module code does not exist', async () => {
     mockAxiosRequest.mockRejectedValue(notFoundError);
     make('/courses/CS1234');
-    expect(await screen.findByText(/module CS1234 not found/)).toBeInTheDocument();
+    expect(await screen.findByText(/course CS1234 not found/)).toBeInTheDocument();
   });
 
   test('should redirect to canonical URL', async () => {

--- a/website/src/views/modules/ModulePageContent.tsx
+++ b/website/src/views/modules/ModulePageContent.tsx
@@ -83,7 +83,7 @@ const ModulePageContent: React.FC<Props> = ({ module, archiveYear }) => {
         <div className={classnames(styles.archiveWarning, 'alert alert-warning')}>
           <Archive className={styles.archiveIcon} />
           <p>
-            You are looking at archived information of this module from academic year{' '}
+            You are looking at archived information of this course from academic year{' '}
             <strong>{archiveYear}</strong>. Information on this page may be out of date.
           </p>
         </div>
@@ -93,8 +93,8 @@ const ModulePageContent: React.FC<Props> = ({ module, archiveYear }) => {
         <div className={classnames(styles.archiveWarning, 'alert alert-warning')}>
           <Archive className={styles.archiveIcon} />
           <p>
-            This module is not offered in this academic year. You may use this information to map
-            exchange modules or to see modules that were previously or may be offered in the future.
+            This course is not offered in this academic year. You may use this information to map
+            exchange courses or to see courses that were previously or may be offered in the future.
           </p>
         </div>
       )}

--- a/website/src/views/modules/ReportError.tsx
+++ b/website/src/views/modules/ReportError.tsx
@@ -185,7 +185,7 @@ const ReportError = memo<Props>(({ module }) => {
           up to 24 hours for information to be updated before reporting any issues.
         </p>
         <p>
-          This form will send an email about this module to the faculty. If you think the issue is a
+          This form will send an email about this course to the faculty. If you think the issue is a
           bug in NUSMods, please email <a href="mailto:bugs@nusmods.com">bugs@nusmods.com</a>{' '}
           instead.
         </p>
@@ -273,7 +273,7 @@ const FormContent: FC<FormContentProps> = ({
       </div>
 
       <div className="form-group col-sm-12">
-        <label htmlFor="report-error-faculty">Department/faculty offering the module</label>
+        <label htmlFor="report-error-faculty">Department/faculty offering the course</label>
         <select
           className="form-control"
           id="report-error-faculty"
@@ -296,7 +296,7 @@ const FormContent: FC<FormContentProps> = ({
         )}
 
         <p className="form-text text-muted">
-          If the department or faculty for this module cannot be found on this list, please refer to
+          If the department or faculty for this course cannot be found on this list, please refer to
           CourseReg's contact list for{' '}
           <ExternalLink href="https://www.nus.edu.sg/coursereg/docs/UGFac_Contacts.pdf">
             undergraduate

--- a/website/src/views/planner/AddModule.tsx
+++ b/website/src/views/planner/AddModule.tsx
@@ -82,7 +82,7 @@ export default class AddModule extends React.PureComponent<Props, State> {
             onClick={() => this.setState({ isOpen: true })}
           >
             <Plus />
-            Add Modules
+            Add Courses
           </button>
         </div>
       );
@@ -96,7 +96,7 @@ export default class AddModule extends React.PureComponent<Props, State> {
       <>
         <form onSubmit={this.onSubmit} className={classnames(this.props.className, styles.form)}>
           <label htmlFor={inputId} className="sr-only">
-            Module Code
+            Course Code
           </label>
           <div className="input-group">
             <PlannerModuleSelect
@@ -119,7 +119,7 @@ export default class AddModule extends React.PureComponent<Props, State> {
 
           <div className={styles.actions}>
             <button className={classnames('btn btn-primary')} type="submit">
-              Add module
+              Add course
             </button>
             <button
               className={classnames(styles.cancel, 'btn btn-svg')}
@@ -130,7 +130,7 @@ export default class AddModule extends React.PureComponent<Props, State> {
               <span className="sr-only">Cancel</span>
             </button>
             <p className={styles.tip}>
-              Tip: You can add multiple module at once, eg. copy from your transcript
+              Tip: You can add multiple courses at once, eg. copy from your transcript
             </p>
           </div>
         </form>

--- a/website/src/views/planner/PlannerModule.tsx
+++ b/website/src/views/planner/PlannerModule.tsx
@@ -57,7 +57,7 @@ const PlannerModule = memo<Props>((props) => {
           <div className={styles.conflictHeader}>
             <AlertTriangle className={styles.warningIcon} />
             <p>
-              No data on this module.{' '}
+              No data on this course.{' '}
               <button type="button" className="btn btn-link btn-inline" onClick={editCustomData}>
                 Add data
               </button>

--- a/website/src/views/planner/PlannerSemester.tsx
+++ b/website/src/views/planner/PlannerSemester.tsx
@@ -101,7 +101,7 @@ const PlannerSemester: React.FC<Props> = ({
 
           {modules.length === 0 && (
             <p className={styles.emptyListMessage}>
-              Drop module here to add to {getSemesterName(semester)}
+              Drop course here to add to {getSemesterName(semester)}
             </p>
           )}
 

--- a/website/src/views/timetable/ModulesTableFooter.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.tsx
@@ -47,7 +47,7 @@ const ModulesTableFooter: React.FC<Props> = (props) => {
       <div className="col-12">
         {!config.examAvailabilitySet.has(props.semester) && (
           <div className="alert alert-warning">
-            Exam dates are not available for this semester yet. Module combinations may not be
+            Exam dates are not available for this semester yet. Course combinations may not be
             available due to conflicting exams.
           </div>
         )}


### PR DESCRIPTION
## Context
As per #3522, there are areas on the website which label courses as modules and this does not follow the new conventions.

## Other Information
Linked issue only specifies one page but upon searching, there are a number of files that also contain this inconsistency in naming and have updated this. Did not touch the MPE related files despite numerous mentions of "modules".