### PR TITLE
Autoscroll Course Planner to current year card

### DIFF
--- a/website/src/views/planner/PlannerYear.tsx
+++ b/website/src/views/planner/PlannerYear.tsx
@@ -1,4 +1,4 @@
-import { PureComponent } from 'react';
+import { PureComponent, Ref, createRef } from 'react';
 import classnames from 'classnames';
 import { flatMap, size, sortBy, toPairs, values } from 'lodash';
 
@@ -24,12 +24,14 @@ type Props = Readonly<{
 
 type State = {
   readonly showSpecialSem: boolean;
+  readonly currentYearCardRef: Ref<HTMLDivElement>;
 };
 
 export default class PlannerYear extends PureComponent<Props, State> {
   override state = {
     // Always display Special Terms I and II if either one has modules
     showSpecialSem: this.hasSpecialTermModules(),
+    currentYearCardRef: createRef<HTMLDivElement>(),
   };
 
   hasSpecialTermModules() {
@@ -58,6 +60,21 @@ export default class PlannerYear extends PureComponent<Props, State> {
     );
   }
 
+  override componentDidMount() {
+    if (this.props.year !== config.academicYear) {
+      return;
+    }
+    const currentYearCard = this.state.currentYearCardRef.current;
+    const parentContainer = currentYearCard?.parentElement;
+    if (!currentYearCard || !parentContainer) {
+      return;
+    }
+    parentContainer.scrollTo({
+      left: currentYearCard.offsetLeft - parentContainer.offsetLeft,
+      behavior: 'smooth',
+    });
+  }
+
   override render() {
     const { year, semesters } = this.props;
     const { showSpecialSem } = this.state;
@@ -72,6 +89,7 @@ export default class PlannerYear extends PureComponent<Props, State> {
 
     return (
       <section
+        ref={year === config.academicYear ? this.state.currentYearCardRef : undefined}
         key={year}
         className={classnames(styles.year, {
           [styles.currentYear]: year === config.academicYear,


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
#3639: Autoscroll Course Planner to current year on first render
<!-- Or provide a brief explanation about the problem -->

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
1. Add `currentYearCardRef` state variable 
2. Only pass ref to the current PlannerYear card
3. Define `componentDidMount` method in `PlannerYear`
    - Uses `currentYearCardRef` to get parent container and calculate offsets for child and parent
    - scrolls the desired amount (with `smooth` effect)

## Before
https://github.com/nusmodifications/nusmods/assets/77665182/73a54f87-4da6-43ed-9bac-267ef656a392

## After
https://github.com/nusmodifications/nusmods/assets/77665182/2fa24e4a-0337-4eea-8d34-39bcde10d12f



## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
