### PR TITLE
Add Timetable Reset Button

### DIFF
--- a/website/src/views/timetable/ResetTimetable.scss
+++ b/website/src/views/timetable/ResetTimetable.scss
@@ -1,0 +1,60 @@
+@import '~styles/utils/modules-entry';
+
+.exportMenu {
+  position: relative;
+
+  .toggle {
+    width: 100%;
+  }
+
+  .chevron {
+    margin: 0 -0.6rem 0 0.2rem;
+  }
+
+  .dropdownMenu {
+    width: 16rem;
+
+    svg {
+      margin-right: 0.2rem;
+      vertical-align: middle;
+    }
+
+    @include media-breakpoint-down(xs) {
+      width: auto;
+    }
+
+    @include media-breakpoint-up(md) {
+      font-size: $font-size-sm;
+    }
+
+    @include media-breakpoint-only(md) {
+      @include vertical-mode {
+        right: 0;
+        left: auto;
+      }
+    }
+  }
+}
+
+.modalContent {
+  display: flex;
+  font-size: 1.4rem;
+  line-height: 1.3;
+
+  svg {
+    $size: 3.8rem;
+
+    width: $size;
+    height: $size;
+    margin-right: 1.2rem;
+    color: theme-color(warning);
+  }
+}
+
+.modalButtons {
+  text-align: right;
+
+  :global(.btn) {
+    margin-right: 0.5rem;
+  }
+}

--- a/website/src/views/timetable/ResetTimetable.tsx
+++ b/website/src/views/timetable/ResetTimetable.tsx
@@ -48,9 +48,7 @@ export default class ResetTimetable extends React.PureComponent<Props, State> {
         this.props.removeModule(moduleCodes[key]);
       }
         this.props.resetTombstone();
-        console.log(this.state);
         this.closeModal();
-        console.log(this.state);
     }
 
     return (
@@ -58,7 +56,7 @@ export default class ResetTimetable extends React.PureComponent<Props, State> {
             <a
               className="btn btn-outline-primary btn-block btn-svg" onClick={() => removeAllModules(this.props.timetable)}
             >
-              <X className="svg"/> Yes, Reset My Timetable 
+              Yes, Reset My Timetable 
             </a>
       </div>
     );

--- a/website/src/views/timetable/ResetTimetable.tsx
+++ b/website/src/views/timetable/ResetTimetable.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import axios from 'axios';
+import classnames from 'classnames';
+import qs from 'query-string';
+import { Mail, XSquare } from 'react-feather';
+import type { QRCodeProps } from 'react-qr-svg';
+
+import type { SemTimetableConfig } from 'types/timetables';
+import type { Semester } from 'types/modules';
+
+import config from 'config';
+import Modal from 'views/components/Modal';
+import CloseButton from 'views/components/CloseButton';
+
+import styles from './ShareTimetable.scss';
+
+
+type Props = {
+  semester: Semester;
+  timetable: SemTimetableConfig;
+};
+
+type State = {
+  isOpen: boolean;
+};
+
+
+
+// So that I don't keep typing 'shortUrl' instead
+export const SHORT_URL_KEY = 'shorturl';
+
+export default class ResetTimetable extends React.PureComponent<Props, State> {
+
+
+  override state: State = {
+    isOpen: false
+  };
+
+
+
+
+  openModal = () => {
+    this.setState({ isOpen: true });
+  };
+
+  closeModal = () =>
+    this.setState({
+      isOpen: false
+    });
+
+
+  renderSharing() {
+    const { semester } = this.props;
+
+    return (
+      <div>
+            <a
+              className="btn btn-outline-primary btn-block btn-svg"
+            >
+              <Mail className="svg" /> Yes, Reset My Timetable 
+            </a>
+      </div>
+    );
+  }
+
+  override render() {
+    const { isOpen } = this.state;
+
+    return (
+      <>
+        <button
+          type="button"
+          className="btn btn-outline-primary btn-svg"
+          onClick={this.openModal}
+        >
+          <XSquare className="svg svg-small" />
+          Reset
+        </button>
+
+        <Modal isOpen={isOpen} onRequestClose={this.closeModal} animate>
+          <CloseButton absolutePositioned onClick={this.closeModal} />
+          <div className={styles.header}>
+            <XSquare />
+
+            <h3>Reset Timetable?</h3>
+            <p>
+              This will remove all added modules for the current semester's timetable. <br />
+              This action cannot be undone.
+            </p>
+          </div>
+
+          {this.renderSharing()}
+        </Modal>
+      </>
+    );
+  }
+}

--- a/website/src/views/timetable/ResetTimetable.tsx
+++ b/website/src/views/timetable/ResetTimetable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import axios from 'axios';
 import classnames from 'classnames';
 import qs from 'query-string';
-import { Mail, XSquare } from 'react-feather';
+import { X, XSquare } from 'react-feather';
 import type { QRCodeProps } from 'react-qr-svg';
 
 import type { SemTimetableConfig } from 'types/timetables';
@@ -55,9 +55,9 @@ export default class ResetTimetable extends React.PureComponent<Props, State> {
     return (
       <div>
             <a
-              className="btn btn-outline-primary btn-block btn-svg"
+              className="btn btn-outline-primary btn-block btn-svg" onClick={this.closeModal}
             >
-              <Mail className="svg" /> Yes, Reset My Timetable 
+              <X className="svg"/> Yes, Reset My Timetable 
             </a>
       </div>
     );

--- a/website/src/views/timetable/ResetTimetable.tsx
+++ b/website/src/views/timetable/ResetTimetable.tsx
@@ -15,6 +15,7 @@ type Props = {
   timetable: SemTimetableConfig;
 
   removeModule: (moduleCode: ModuleCode) => void;
+  resetTombstone: () => void;
 };
 
 type State = {
@@ -38,16 +39,16 @@ export default class ResetTimetable extends React.PureComponent<Props, State> {
     isOpen: false
   });
 
-  renderSharing() {
-    const { timetable, removeModule } = this.props;
+  renderReset() {
+    const { timetable, removeModule, resetTombstone } = this.props;
 
     const removeAllModules = (timetable: SemTimetableConfig) => {
       const moduleCodes = Object.keys(timetable);
     
       for (const key in moduleCodes) {
-        console.log(moduleCodes[key]);
         this.props.removeModule(moduleCodes[key]);
       }
+        this.props.resetTombstone();
         this.closeModal;
     }
 
@@ -88,7 +89,7 @@ export default class ResetTimetable extends React.PureComponent<Props, State> {
             </p>
           </div>
 
-          {this.renderSharing()}
+          {this.renderReset()}
         </Modal>
       </>
     );

--- a/website/src/views/timetable/ResetTimetable.tsx
+++ b/website/src/views/timetable/ResetTimetable.tsx
@@ -40,7 +40,6 @@ export default class ResetTimetable extends React.PureComponent<Props, State> {
   });
 
   renderReset() {
-    const { timetable, removeModule, resetTombstone } = this.props;
 
     const removeAllModules = (timetable: SemTimetableConfig) => {
       const moduleCodes = Object.keys(timetable);
@@ -49,7 +48,9 @@ export default class ResetTimetable extends React.PureComponent<Props, State> {
         this.props.removeModule(moduleCodes[key]);
       }
         this.props.resetTombstone();
-        this.closeModal;
+        console.log(this.state);
+        this.closeModal();
+        console.log(this.state);
     }
 
     return (

--- a/website/src/views/timetable/ResetTimetable.tsx
+++ b/website/src/views/timetable/ResetTimetable.tsx
@@ -1,14 +1,9 @@
 import * as React from 'react';
-import axios from 'axios';
-import classnames from 'classnames';
-import qs from 'query-string';
 import { X, XSquare } from 'react-feather';
-import type { QRCodeProps } from 'react-qr-svg';
 
 import type { SemTimetableConfig } from 'types/timetables';
-import type { Semester } from 'types/modules';
+import type { Semester, ModuleCode} from 'types/modules';
 
-import config from 'config';
 import Modal from 'views/components/Modal';
 import CloseButton from 'views/components/CloseButton';
 
@@ -18,6 +13,8 @@ import styles from './ShareTimetable.scss';
 type Props = {
   semester: Semester;
   timetable: SemTimetableConfig;
+
+  removeModule: (moduleCode: ModuleCode) => void;
 };
 
 type State = {
@@ -25,37 +22,39 @@ type State = {
 };
 
 
-
-// So that I don't keep typing 'shortUrl' instead
-export const SHORT_URL_KEY = 'shorturl';
-
 export default class ResetTimetable extends React.PureComponent<Props, State> {
-
 
   override state: State = {
     isOpen: false
   };
 
 
-
-
   openModal = () => {
     this.setState({ isOpen: true });
   };
 
-  closeModal = () =>
-    this.setState({
-      isOpen: false
-    });
-
+  closeModal = () =>   
+  this.setState({
+    isOpen: false
+  });
 
   renderSharing() {
-    const { semester } = this.props;
+    const { timetable, removeModule } = this.props;
+
+    const removeAllModules = (timetable: SemTimetableConfig) => {
+      const moduleCodes = Object.keys(timetable);
+    
+      for (const key in moduleCodes) {
+        console.log(moduleCodes[key]);
+        this.props.removeModule(moduleCodes[key]);
+      }
+        this.closeModal;
+    }
 
     return (
       <div>
             <a
-              className="btn btn-outline-primary btn-block btn-svg" onClick={this.closeModal}
+              className="btn btn-outline-primary btn-block btn-svg" onClick={() => removeAllModules(this.props.timetable)}
             >
               <X className="svg"/> Yes, Reset My Timetable 
             </a>

--- a/website/src/views/timetable/ResetTimetable.tsx
+++ b/website/src/views/timetable/ResetTimetable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { X, XSquare } from 'react-feather';
+import { XSquare } from 'react-feather';
 
 import type { SemTimetableConfig } from 'types/timetables';
 import type { Semester, ModuleCode} from 'types/modules';

--- a/website/src/views/timetable/TimetableActions.tsx
+++ b/website/src/views/timetable/TimetableActions.tsx
@@ -9,6 +9,7 @@ import { SemTimetableConfig } from 'types/timetables';
 
 import elements from 'views/elements';
 import config from 'config';
+import ResetTimetable from './ResetTimetable';
 import ShareTimetable from './ShareTimetable';
 import ExportMenu from './ExportMenu';
 
@@ -81,8 +82,8 @@ const TimetableActions: React.FC<Props> = (props) => (
     </div>
 
     <div className={styles.buttonGroup} role="group" aria-label="Timetable exporting">
+      <ResetTimetable semester={props.semester} timetable={props.timetable} />
       <ExportMenu semester={props.semester} timetable={props.timetable} />
-
       <ShareTimetable semester={props.semester} timetable={props.timetable} />
     </div>
   </div>

--- a/website/src/views/timetable/TimetableActions.tsx
+++ b/website/src/views/timetable/TimetableActions.tsx
@@ -6,6 +6,7 @@ import { Calendar, Grid, Sidebar, Type } from 'react-feather';
 import { toggleTimetableOrientation, toggleTitleDisplay } from 'actions/theme';
 import { Semester } from 'types/modules';
 import { SemTimetableConfig } from 'types/timetables';
+import { ModuleCode } from 'types/modules';
 
 import elements from 'views/elements';
 import config from 'config';
@@ -27,6 +28,8 @@ type Props = {
 
   showExamCalendar: boolean;
   toggleExamCalendar: () => void;
+
+  removeModule: (moduleCode: ModuleCode) => void;
 };
 
 const TimetableActions: React.FC<Props> = (props) => (
@@ -82,7 +85,7 @@ const TimetableActions: React.FC<Props> = (props) => (
     </div>
 
     <div className={styles.buttonGroup} role="group" aria-label="Timetable exporting">
-      <ResetTimetable semester={props.semester} timetable={props.timetable} />
+      <ResetTimetable semester={props.semester} timetable={props.timetable} removeModule={props.removeModule}/>
       <ExportMenu semester={props.semester} timetable={props.timetable} />
       <ShareTimetable semester={props.semester} timetable={props.timetable} />
     </div>

--- a/website/src/views/timetable/TimetableActions.tsx
+++ b/website/src/views/timetable/TimetableActions.tsx
@@ -30,7 +30,10 @@ type Props = {
   toggleExamCalendar: () => void;
 
   removeModule: (moduleCode: ModuleCode) => void;
+  resetTombstone: () => void;
 };
+
+
 
 const TimetableActions: React.FC<Props> = (props) => (
   <div
@@ -85,7 +88,7 @@ const TimetableActions: React.FC<Props> = (props) => (
     </div>
 
     <div className={styles.buttonGroup} role="group" aria-label="Timetable exporting">
-      <ResetTimetable semester={props.semester} timetable={props.timetable} removeModule={props.removeModule}/>
+      <ResetTimetable semester={props.semester} timetable={props.timetable} removeModule={props.removeModule} resetTombstone={props.resetTombstone}/>
       <ExportMenu semester={props.semester} timetable={props.timetable} />
       <ShareTimetable semester={props.semester} timetable={props.timetable} />
     </div>

--- a/website/src/views/timetable/TimetableActions.tsx
+++ b/website/src/views/timetable/TimetableActions.tsx
@@ -88,9 +88,9 @@ const TimetableActions: React.FC<Props> = (props) => (
     </div>
 
     <div className={styles.buttonGroup} role="group" aria-label="Timetable exporting">
-      <ResetTimetable semester={props.semester} timetable={props.timetable} removeModule={props.removeModule} resetTombstone={props.resetTombstone}/>
       <ExportMenu semester={props.semester} timetable={props.timetable} />
       <ShareTimetable semester={props.semester} timetable={props.timetable} />
+      <ResetTimetable semester={props.semester} timetable={props.timetable} removeModule={props.removeModule} resetTombstone={props.resetTombstone}/>
     </div>
   </div>
 );

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -404,6 +404,7 @@ class TimetableContent extends React.Component<Props, State> {
                   semester={semester}
                   timetable={this.props.timetable}
                   showExamCalendar={showExamCalendar}
+                  removeModule={this.removeModule}
                   toggleExamCalendar={() => this.setState({ showExamCalendar: !showExamCalendar })}
                 />
               </div>

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -278,7 +278,8 @@ class TimetableContent extends React.Component<Props, State> {
       hiddenInTimetable,
     } = this.props;
 
-    const { showExamCalendar } = this.state;
+    const { showExamCalendar, tombstone } = this.state;
+    const resetTombstone = () => this.setState({ tombstone: null });
 
     let timetableLessons: Lesson[] = timetableLessonsArray(this.props.timetableWithLessons)
       // Do not process hidden modules
@@ -405,6 +406,7 @@ class TimetableContent extends React.Component<Props, State> {
                   timetable={this.props.timetable}
                   showExamCalendar={showExamCalendar}
                   removeModule={this.removeModule}
+                  resetTombstone={resetTombstone}
                   toggleExamCalendar={() => this.setState({ showExamCalendar: !showExamCalendar })}
                 />
               </div>

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -278,7 +278,7 @@ class TimetableContent extends React.Component<Props, State> {
       hiddenInTimetable,
     } = this.props;
 
-    const { showExamCalendar, tombstone } = this.state;
+    const { showExamCalendar } = this.state;
     const resetTombstone = () => this.setState({ tombstone: null });
 
     let timetableLessons: Lesson[] = timetableLessonsArray(this.props.timetableWithLessons)


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Implements #3471 

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

Added a Reset Button to the timetable actions toolbar.
This button will prompt a popup modal asking if the user wishes to reset the timetable to an empty state.

Clicking said button will call removeModule() across all modules in the given timetable prop for the current semester, thereby removing all modules and restting the timetable. resetTombstone() is also called once to remove the last module tombstone.

Video of UI and functionality:

https://github.com/nusmodifications/nusmods/assets/39799639/37cb1b9c-3da1-4fdf-87f9-b98bdac12915


## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
