### PR TITLE
Pin binary version in PM2 config file

### DIFF
--- a/scrapers/nus-v2/ecosystem.config.js
+++ b/scrapers/nus-v2/ecosystem.config.js
@@ -16,6 +16,7 @@ module.exports = {
 
       env: {
         NODE_ENV: 'production',
+        _: '/home/ubuntu/.nvm/versions/node/v18.14.2/bin/pm2',
       },
     },
   ],

--- a/scrapers/nus-v2/scripts/run.sh
+++ b/scrapers/nus-v2/scripts/run.sh
@@ -8,6 +8,9 @@ date
 cd "$(dirname "$0")"
 cd ..
 
+# Print to Node version for logs
+echo "Running on Node version: $(node --version)"
+
 # Build the scraper
 rm -rf build
 yarn build


### PR DESCRIPTION
## Context

We've had a few scraper outages caused by the scraper being restarted and PM2 using old versions of node incompatible with some of our code.

This pins the PM2 binary to an updated version, which ensures a sufficiently-updated node version is used, which ensures that the scraper can run correctly independent of other env and path changes we might make in our production environment.

## Implementation

We previously used a larger set of env flags to deal with outages, but I've tested that specifying the PM2 binary as I've done so here is sufficient. Let's also print out the node version when starting up our scraper 
