### PR TITLE
website: Temporarily directly use GitHub API for contributor list

### DIFF
--- a/website/src/apis/github.ts
+++ b/website/src/apis/github.ts
@@ -7,6 +7,9 @@ import { VenueLocationMap } from 'types/venues';
 // We proxy https://api.github.com/repos/nusmodifications/nusmods -> https://github.nusmods.com/repo
 // This allows us to cache the response to stop 403 rate limit error caused by the
 // school sharing a single IP address
+
+// As of https://github.com/nusmodifications/nusmods/pull/3655, we will directly use https://api.github.com
+// until https://github.nusmods.com behaviour is separately restored
 const baseUrl = 'https://api.github.com/repos/nusmodifications/nusmods';
 
 const ignoredContributors = new Set([
@@ -45,6 +48,8 @@ export function getVenueLocations(): Promise<VenueLocationMap> {
     );
   }
 
+  // As of https://github.com/nusmodifications/nusmods/pull/3655, this will always fallback to
+  // use bundled venues until https://github.nusmods.com behaviour is separately restored
   if (memoizedVenuePromise) return memoizedVenuePromise;
   const url = `${baseUrl}/venues`;
   const promise = axios

--- a/website/src/apis/github.ts
+++ b/website/src/apis/github.ts
@@ -7,7 +7,7 @@ import { VenueLocationMap } from 'types/venues';
 // We proxy https://api.github.com/repos/nusmodifications/nusmods -> https://github.nusmods.com/repo
 // This allows us to cache the response to stop 403 rate limit error caused by the
 // school sharing a single IP address
-const baseUrl = 'https://github.nusmods.com';
+const baseUrl = 'https://api.github.com/repos/nusmodifications/nusmods';
 
 const ignoredContributors = new Set([
   // Renovate used to report outdated dependencies as a user via the GitHub API,
@@ -23,7 +23,7 @@ export function getContributors(): Promise<Contributor[]> {
     per_page: 100,
   });
 
-  const url = `${baseUrl}/repo/contributors?${query}`;
+  const url = `${baseUrl}/contributors?${query}`;
   return axios
     .get<Contributor[]>(url)
     .then((response) =>


### PR DESCRIPTION
## Context
The github.nusmods.com/repo and github.nusmods.com/venue API proxies are down. This means the contributor list is down and the venue list uses the bundled venue list.

## Implementation
- For contributor list, use GitHub's API directly. This could result in exceeding rate limits (and the contributor list going back down) if the /contributors page is suddenly very popular, but it's better than being down 100% of the time
- For venues, just make a note that the bundled list is always used. Venues themselves won't actually be impacted
