### PR TITLE
chore(cpex): enable

### DIFF
--- a/scrapers/cpex-scraper/src/index.ts
+++ b/scrapers/cpex-scraper/src/index.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 import env from '../env.json';
 
-const TERM = '2320';
+const TERM = '2410';
 
 // Sanity check to see if there are at least this many modules before overwriting cpexModules.json
 // The last time I ran this fully there were 3418 modules

--- a/website/src/featureFlags.ts
+++ b/website/src/featureFlags.ts
@@ -8,4 +8,4 @@
 export const enableShortUrl = false;
 
 /** Enable Course Planning Exercise */
-export const enableCPEx = false;
+export const enableCPEx = true;

--- a/website/src/views/mpe/MpeContainer.tsx
+++ b/website/src/views/mpe/MpeContainer.tsx
@@ -80,7 +80,7 @@ const MpeContainer: React.FC = () => {
             <strong>solely for planning purposes </strong> and there is no guarantee that you will
             be allocated the selected courses during the CourseReg Exercise.
           </p>
-          <p>The CPEx for this round will be from 16 Oct to 20 Oct 2023.</p>
+          <p>The CPEx for this round will be from 11 Mar to 15 Mar 2024.</p>
           <p>
             Participation in the CPEx will be used as <strong>one of the tie-breakers</strong>{' '}
             during the CourseReg Exercise, in cases where the demand exceeds the available quota and

--- a/website/src/views/mpe/constants.ts
+++ b/website/src/views/mpe/constants.ts
@@ -1,3 +1,3 @@
 export const MAX_MODULES = 7;
-export const MPE_SEMESTER: 1 | 2 = 2;
-export const MPE_AY = '2023/2024';
+export const MPE_SEMESTER: 1 | 2 = 1;
+export const MPE_AY = '2024/2025';


### PR DESCRIPTION
This PR enables CPEx for AY2024/2025 Sem 1 on both the frontend and the backend. Let's merge this on 11 Mar 2024 when the CPEx is supposed to start.

In the meantime, a preview can be accessed at https://cpex-staging.nusmods.com/cpex.