### PR TITLE
Fix cell size for e learning by setting minimum size

### DIFF
--- a/website/src/views/timetable/TimetableRow.tsx
+++ b/website/src/views/timetable/TimetableRow.tsx
@@ -40,7 +40,7 @@ const TimetableRow: React.FC<Props> = (props) => {
         const startIndex = convertTimeToIndex(lesson.startTime);
         const endIndex = convertTimeToIndex(lesson.endTime);
 
-        const size = endIndex - startIndex;
+        const size = Math.max(endIndex - startIndex, 2);
 
         const dirStyle = verticalMode ? 'top' : 'marginLeft';
         const sizeStyle = verticalMode ? 'height' : 'width';

--- a/website/src/views/timetable/TimetableRow.tsx
+++ b/website/src/views/timetable/TimetableRow.tsx
@@ -40,7 +40,7 @@ const TimetableRow: React.FC<Props> = (props) => {
         const startIndex = convertTimeToIndex(lesson.startTime);
         const endIndex = convertTimeToIndex(lesson.endTime);
 
-        const size = Math.max(endIndex - startIndex, 2);
+        const size = Math.max(endIndex - startIndex, 1);
 
         const dirStyle = verticalMode ? 'top' : 'marginLeft';
         const sizeStyle = verticalMode ? 'height' : 'width';


### PR DESCRIPTION
## Context
#3658 

This is a very short PR.


## Implementation
Currently, E-learning module information often use placeholder time since they do not have a fixed time (eg. 0900 - 0901). Since the size of the cell is calculated based on the lesson time, the placeholder time causes the UI to be a bit weird as the calculated background width is short, and the module information is hindered by the UI.
<img width="296" alt="image" src="https://github.com/nusmodifications/nusmods/assets/111076731/5cc89dee-dbb2-4530-8f4e-8e59fe9c9dd1">  


This implementation ensures that the size of the background is at least half the cell:
<img width="514" alt="image" src="https://github.com/nusmodifications/nusmods/assets/111076731/412e8a24-d996-4a87-893d-beb49a5c15f7">


My initial implementation was to make the cell occupy at least the whole cell but I thought maybe there could be lessons that are just 30 minutes, which is why I changed to such that the minimum is half a cell. 
