### PR TITLE
feat(search): add grading basis filter to module list

### DIFF
--- a/scrapers/nus-v2/src/tasks/CollateModules.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.ts
@@ -153,6 +153,7 @@ const getModuleInfo = ({
   corequisite,
   semesterData,
   attributes,
+  gradingBasisDescription,
 }: ModuleWithoutTree): ModuleInformation => ({
   moduleCode,
   title,
@@ -165,6 +166,7 @@ const getModuleInfo = ({
   preclusion,
   corequisite,
   attributes,
+  gradingBasisDescription,
   semesterData: semesterData.map(({ semester, examDate, examDuration, covidZones }) => ({
     semester,
     examDate,

--- a/scrapers/nus-v2/src/types/modules.ts
+++ b/scrapers/nus-v2/src/types/modules.ts
@@ -166,6 +166,7 @@ export type ModuleInformation = Readonly<{
   faculty: Faculty;
   workload?: Workload;
   attributes?: NUSModuleAttributes;
+  gradingBasisDescription?: string;
 
   // Requsites
   prerequisite?: string;

--- a/website/src/types/modules.ts
+++ b/website/src/types/modules.ts
@@ -170,6 +170,7 @@ export type ModuleInformation = Readonly<{
   workload?: Workload;
   aliases?: ModuleCode[];
   attributes?: NUSModuleAttributes;
+  gradingBasisDescription?: string;
 
   // Requsites
   prerequisite?: string;

--- a/website/src/views/modules/ModuleFinderSidebar.tsx
+++ b/website/src/views/modules/ModuleFinderSidebar.tsx
@@ -142,17 +142,6 @@ const ModuleFinderSidebar: React.FC = () => {
         <ChecklistFilter title="Exams" items={examFilters} />
 
         <RefinementListFilter
-          id="grading"
-          title="Grading Basis"
-          field="gradingBasisDescription.keyword"
-          operator="OR"
-          orderKey="_term"
-          orderDirection="asc"
-          containerComponent={FilterContainer}
-          itemComponent={CheckboxItem}
-        />
-
-        <RefinementListFilter
           id="level"
           title="Level"
           field="moduleCode.level"
@@ -200,6 +189,17 @@ const ModuleFinderSidebar: React.FC = () => {
           itemComponent={CheckboxItem}
           listComponent={DropdownListFilters}
           translations={{ placeholder: 'Add departments filter...' }}
+        />
+
+        <RefinementListFilter
+          id="grading"
+          title="Grading Basis"
+          field="gradingBasisDescription.keyword"
+          operator="OR"
+          orderKey="_term"
+          orderDirection="asc"
+          containerComponent={FilterContainer}
+          itemComponent={CheckboxItem}
         />
 
         <RefinementListFilter

--- a/website/src/views/modules/ModuleFinderSidebar.tsx
+++ b/website/src/views/modules/ModuleFinderSidebar.tsx
@@ -142,6 +142,17 @@ const ModuleFinderSidebar: React.FC = () => {
         <ChecklistFilter title="Exams" items={examFilters} />
 
         <RefinementListFilter
+          id="grading"
+          title="Grading Basis"
+          field="gradingBasisDescription.keyword"
+          operator="OR"
+          orderKey="_term"
+          orderDirection="asc"
+          containerComponent={FilterContainer}
+          itemComponent={CheckboxItem}
+        />
+
+        <RefinementListFilter
           id="level"
           title="Level"
           field="moduleCode.level"


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
#3664 
<!-- Or provide a brief explanation about the problem -->

## Implementation
<!-- Explain how your solution solves the problem -->
Add gradingBasisDescription to ModuleInformation type in scraper (and frontend for consistency)
Information is expected to be sent to Elastic client for indexing.
Updated view to reflect changes.
<!-- If it affects UI, an image or gif is greatly encouraged. -->

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
I'm not familiar with Elastic API and certainly unable to see the endpoint format available so will need core team to review.
Let me know if adding field ModuleInformation is insufficient and explicit indexing is required. Thanks 🙌 
