### PR TITLE
Update exam clash detection in the Module search page

### DIFF
--- a/website/src/views/modules/ModuleFinderSidebar.tsx
+++ b/website/src/views/modules/ModuleFinderSidebar.tsx
@@ -73,23 +73,27 @@ function getExamClashFilter(semester: Semester, examTimings: ExamTiming[]): Filt
   // with exam1 iff (exam2.start < exam1.end) && (exam2.end > exam1.start)
   const clashRanges = examTimings.map((exam1) => ({
     bool: {
-      must: {
-        range: {
-          'semesterData.examDate': {
-            lt: getEndTime(exam1.start, exam1.duration),
-          },
-        },
-        script: {
-          script: {
-            source: `doc.containsKey['semesterData.examDate'] && 
-              doc.containsKey['semesterData.examDuration'] && 
-              ZonedDateTime.parse(doc['semesterData.examDate'].value).plusMinutes(doc['semesterData.examDuration].value).isAfter(ZonedDateTime.parse(params.exam1start))`,
-            params: {
-              exam1start: exam1.start,
+      must: [
+        {
+          range: {
+            'semesterData.examDate': {
+              lt: getEndTime(exam1.start, exam1.duration),
             },
           },
         },
-      },
+        {
+          script: {
+            script: {
+              source: `doc.containsKey('semesterData.examDate') && 
+              doc.containsKey('semesterData.examDuration') && 
+              doc['semesterData.examDate'].value.plusMinutes(doc['semesterData.examDuration'].value).isAfter(ZonedDateTime.parse(params.exam1start))`,
+              params: {
+                exam1start: exam1.start,
+              },
+            },
+          },
+        },
+      ],
     },
   }));
 

--- a/website/src/views/modules/ModuleFinderSidebar.tsx
+++ b/website/src/views/modules/ModuleFinderSidebar.tsx
@@ -125,14 +125,14 @@ const ModuleFinderSidebar: React.FC = () => {
     const examClashFilters = Semesters.map((semester): FilterItem | null => {
       const timetable = getSemesterTimetable(semester);
       const modules = getSemesterModules(timetable, allModules);
-      // Filter for modules with non-empty exam timings, and map them to new ExamTiming objects 
+      // Filter for modules with non-empty exam timings, and map them to new ExamTiming objects
       const examTimings = modules.reduce<ExamTiming[]>((result: ExamTiming[], mod: Module) => {
         const data = getModuleSemesterData(mod, semester);
         if (data?.examDate && data?.examDuration) {
           result.push({
             start: data.examDate,
             duration: data.examDuration,
-          })
+          });
         }
         return result;
       }, []);

--- a/website/src/views/modules/ModuleFinderSidebar.tsx
+++ b/website/src/views/modules/ModuleFinderSidebar.tsx
@@ -84,8 +84,8 @@ function getExamClashFilter(semester: Semester, examTimings: ExamTiming[]): Filt
         {
           script: {
             script: {
-              source: `doc.containsKey('semesterData.examDate') && 
-              doc.containsKey('semesterData.examDuration') && 
+              source: `doc.containsKey('semesterData.examDate') &&
+              doc.containsKey('semesterData.examDuration') &&
               doc['semesterData.examDate'].value.plusMinutes(doc['semesterData.examDuration'].value).isAfter(ZonedDateTime.parse(params.exam1start))`,
               params: {
                 exam1start: exam1.start,
@@ -129,17 +129,19 @@ const ModuleFinderSidebar: React.FC = () => {
     const examClashFilters = Semesters.map((semester): FilterItem | null => {
       const timetable = getSemesterTimetable(semester);
       const modules = getSemesterModules(timetable, allModules);
-      // Filter for modules with non-empty exam timings, and map them to new ExamTiming objects
-      const examTimings = modules.reduce<ExamTiming[]>((result: ExamTiming[], mod: Module) => {
-        const data = getModuleSemesterData(mod, semester);
-        if (data?.examDate && data?.examDuration) {
-          result.push({
-            start: data.examDate,
-            duration: data.examDuration,
-          });
-        }
-        return result;
-      }, []);
+      const examTimings: ExamTiming[] = modules
+        .map((mod) => {
+          // Filter for modules with non-empty exam timings, and map them to new ExamTiming objects
+          const data = getModuleSemesterData(mod, semester);
+          if (data?.examDate && data?.examDuration) {
+            return {
+              start: data.examDate,
+              duration: data.examDuration,
+            };
+          }
+          return null;
+        })
+        .filter(notNull);
       return examTimings.length ? getExamClashFilter(semester, examTimings) : null;
     }).filter(notNull);
     return [...STATIC_EXAM_FILTER_ITEMS, ...examClashFilters];


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) --> Fix #3663
<!-- Or provide a brief explanation about the problem -->

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

Given `timetable = [m1, m2, m3]` which is the list of modules currently added in the timetable. 
To detect whether a module `X` clashes with `timetable`:
* current behaviour is to compare `X.start == m.start` (exact match) for each m in timetable
* updated behaviour:
  * assert that `(X.start < m.end) && (X.end > m.start)` for each m in timetable. This is the condition for 2 intervals to overlap, see https://stackoverflow.com/questions/325933/determine-whether-two-date-ranges-overlap

❗ However, the module struct only stores examStartTime (ISO timestamp, **assuming UTC(?)**) and examDuration (in minutes). Thus to get the endTime:
* `m.end` can be easily obtained since `m` is a known value from the timetable.
* `X.end` is more difficult since we need to compute it on-the-fly inside the Elasticsearch query.

The new Elasticsearch query I have looks like
```javascript
query: {
  bool: { must_not: [  // this document must not match *any* condition in the list, i.e. not overlap any exam
    
    bool: { must: {               // condition 1: true if this exam overlaps m1
      range: { document.start < m1.start + m1.duration },
      script: { document.start + document.duration > m1.start }   // <-- can't use 'range' b/c ES doesn't allow accessing 2 fields at the same time
    }},

    bool: { must: { ... } },     // condition 2: true if this exam overlaps m2
    bool: { must: { ... } },     // condition 3: true if this exam overlaps m3
  ]},
},
```

## TBD
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
- **Is `examStartTime` really stored in Elasticsearch in UTC or UTC+08?**
- (Unit?) Testing and how to verify correctness
