### PR TITLE
Set autoFocus for activeLesson

### DIFF
--- a/website/src/views/timetable/TimetableCell.tsx
+++ b/website/src/views/timetable/TimetableCell.tsx
@@ -128,6 +128,7 @@ const TimetableCell: React.FC<Props> = (props) => {
       onTouchStart={() => onHover(getHoverLesson(lesson))}
       onMouseLeave={() => onHover(null)}
       onTouchEnd={() => onHover(null)}
+      autoFocus={lesson.isActive}
       {...conditionalProps}
     >
       <div className={styles.cellContainer}>

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -356,7 +356,7 @@ class TimetableContent extends React.Component<Props, State> {
           verticalMode: isVerticalOrientation,
         })}
         onClick={this.cancelModifyLesson}
-        onKeyUp={(e) => e.keyCode === 27 && this.cancelModifyLesson()} // Quit modifying when Esc is pressed
+        onKeyUp={(e) => e.key === 'Escape' && this.cancelModifyLesson()} // Quit modifying when Esc is pressed
       >
         <Title>Timetable</Title>
 


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
Fix #3484 

## Implementation
Set `autoFocus` on `activeLesson`. Although this leads to multiple elements with `autoFocus`, the first one in the DOM will be chosen which would still be an `activeLesson` button. This allows the `onKeyUp` event to fire in `TimetableContent.tsx`

