### PR TITLE
Exclude Hidden Modules from being exported into iCal

### DIFF
--- a/website/src/actions/export.ts
+++ b/website/src/actions/export.ts
@@ -31,11 +31,12 @@ export function downloadAsIcal(semester: Semester) {
       .then(([ical, icalUtils]) => {
         const state = getState();
         const { modules } = state.moduleBank;
+        const hiddenModules: string[] = state.timetables.hidden[semester] || [];
 
         const timetable = getSemesterTimetableLessons(state)(semester);
         const timetableWithLessons = hydrateSemTimetableWithLessons(timetable, modules, semester);
 
-        const events = icalUtils.default(semester, timetableWithLessons, modules);
+        const events = icalUtils.default(semester, timetableWithLessons, modules, hiddenModules);
         const cal = ical.default({
           domain: 'nusmods.com',
           prodId: '//NUSMods//NUSMods//EN',

--- a/website/src/actions/export.ts
+++ b/website/src/actions/export.ts
@@ -1,4 +1,4 @@
-import type { Module, Semester } from 'types/modules';
+import type { Module, ModuleCode, Semester } from 'types/modules';
 import type { ExportData } from 'types/export';
 import type { Dispatch, GetState } from 'types/redux';
 import { hydrateSemTimetableWithLessons } from 'utils/timetables';
@@ -31,7 +31,7 @@ export function downloadAsIcal(semester: Semester) {
       .then(([ical, icalUtils]) => {
         const state = getState();
         const { modules } = state.moduleBank;
-        const hiddenModules: string[] = state.timetables.hidden[semester] || [];
+        const hiddenModules: ModuleCode[] = state.timetables.hidden[semester] || [];
 
         const timetable = getSemesterTimetableLessons(state)(semester);
         const timetableWithLessons = hydrateSemTimetableWithLessons(timetable, modules, semester);

--- a/website/src/utils/ical.test.ts
+++ b/website/src/utils/ical.test.ts
@@ -307,8 +307,18 @@ describe(iCalForTimetable, () => {
       CS1010S,
       CS3216,
     };
-    const actual = iCalForTimetable(1, mockTimetable, moduleData);
+    const actual = iCalForTimetable(1, mockTimetable, moduleData, []);
     // 5 lesson types for cs1010s, 1 for cs3216, 1 exam for cs1010s
     expect(actual).toHaveLength(7);
+  });
+
+  test('should produce the correct number of lesson after excluding hidden mod', () => {
+    const moduleData = {
+      CS1010S,
+      CS3216,
+    };
+    const actual = iCalForTimetable(1, mockTimetable, moduleData, ['CS3216']);
+    // 5 lesson types for cs1010s, 1 exam for cs1010s, ( 1 lesson for cs3216 will be exluded)
+    expect(actual).toHaveLength(6);
   });
 });

--- a/website/src/utils/ical.ts
+++ b/website/src/utils/ical.ts
@@ -174,7 +174,7 @@ export default function iCalForTimetable(
   semester: Semester,
   timetable: SemTimetableConfigWithLessons,
   moduleData: { [moduleCode: string]: Module },
-  hiddenModule: string[],
+  hiddenModules: string[],
   academicYear: string = config.academicYear,
 ): EventOption[] {
   const [year, month, day] = academicCalendar[academicYear][semester].start;
@@ -183,7 +183,7 @@ export default function iCalForTimetable(
   const events: EventOption[] = [];
 
   _.each(timetable, (lessonConfig, moduleCode) => {
-    if (hiddenModule.includes(moduleCode)) return;
+    if (hiddenModules.includes(moduleCode)) return;
 
     _.each(lessonConfig, (lessons) => {
       lessons.forEach((lesson) => {

--- a/website/src/utils/ical.ts
+++ b/website/src/utils/ical.ts
@@ -174,6 +174,7 @@ export default function iCalForTimetable(
   semester: Semester,
   timetable: SemTimetableConfigWithLessons,
   moduleData: { [moduleCode: string]: Module },
+  hiddenModule: string[],
   academicYear: string = config.academicYear,
 ): EventOption[] {
   const [year, month, day] = academicCalendar[academicYear][semester].start;
@@ -182,6 +183,8 @@ export default function iCalForTimetable(
   const events: EventOption[] = [];
 
   _.each(timetable, (lessonConfig, moduleCode) => {
+    if (hiddenModule.includes(moduleCode)) return;
+
     _.each(lessonConfig, (lessons) => {
       lessons.forEach((lesson) => {
         events.push(iCalEventForLesson(lesson, moduleData[moduleCode], semester, firstDayOfSchool));


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
#3681 

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
Added an extra parameter `hiddenModules: string[]` to `iCalForTimetable` function in ical.ts to pass in hidden modules and filter accordingly.

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
