### PR TITLE
Fix Course Selection in Planner (Exemptions & Plan to Take)

### DIFF
--- a/website/src/views/planner/AddModule.tsx
+++ b/website/src/views/planner/AddModule.tsx
@@ -119,7 +119,7 @@ export default class AddModule extends React.PureComponent<Props, State> {
 
           <div className={styles.actions}>
             <button className={classnames('btn btn-primary')} type="submit">
-              Add course
+              Add Category
             </button>
             <button
               className={classnames(styles.cancel, 'btn btn-svg')}

--- a/website/src/views/planner/PlannerModuleSelect.tsx
+++ b/website/src/views/planner/PlannerModuleSelect.tsx
@@ -8,6 +8,7 @@ import { State } from 'types/state';
 import { ModuleCode, ModuleCondensed, Semester } from 'types/modules';
 import { createSearchPredicate } from 'utils/moduleSearch';
 import { takeUntil } from 'utils/array';
+import { EXEMPTION_SEMESTER, PLAN_TO_TAKE_SEMESTER } from 'utils/planner';
 
 import styles from './PlannerModuleSelect.scss';
 
@@ -76,7 +77,7 @@ export function PlannerModuleSelectComponent({
       selectedModules = selectedModules.filter(filter);
     }
 
-    if (semester != null) {
+    if (semester != null && semester !== PLAN_TO_TAKE_SEMESTER && semester !== EXEMPTION_SEMESTER) {
       selectedModules = selectedModules.filter((module) => module.semesters.includes(semester));
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Fixes #3650 where users cannot select modules in the "Exemptions" and "Plan to Take" sections of the planner page. 
Also renamed "Add course" button to "Add Category" to be clearer.

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
Previously `AllModules` which displays all the modules in `AddModule` mistakenly filters out all the modules as `EXEMPTION_SEMESTER` and `PLAN_TO_TAKE_SEMESTER` had values of -1 and -2 respectively. The proposed change is to prevent filtering by semester in the `AddModule` for "Exemptions" and "Plan to Take".

| Before | After |
|--------|--------|
| <img width="458" alt="image" src="https://github.com/nusmodifications/nusmods/assets/56021409/c1409b1e-ec4e-446c-bc8d-afd876368c86">|<img width="452" alt="image" src="https://github.com/nusmodifications/nusmods/assets/56021409/2083a7ec-d63b-49c8-a756-27cfb71185b0">|
| |<img width="230" alt="image" src="https://github.com/nusmodifications/nusmods/assets/56021409/c9b3a135-2506-45ee-877e-178a2363d233"> |


## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
Hi I am Wei Rong and I am looking forward to contribute more to nusmods!  
