### PR TITLE
perf: MPE mod lookup with map instead of linear search

### DIFF
--- a/website/src/views/mpe/form/MpeFormContainer.tsx
+++ b/website/src/views/mpe/form/MpeFormContainer.tsx
@@ -25,19 +25,18 @@ const MpeFormContainer: React.FC<Props> = ({ getSubmission, updateSubmission }) 
     Promise.all([fetchMpeModuleList(), getSubmission()])
       .then(([fetchedMpeModuleList, fetchedSubmission]) => {
         setMpeModuleList(fetchedMpeModuleList);
+        const moduleLookup = new Map(
+          fetchedMpeModuleList.map((module) => [module.moduleCode, module]),
+        );
         setSubmission({
           ...fetchedSubmission,
           // Replace data fetched from MPE server with latest data from MPE module list
-          // TODO: Optimize. This does an linear time lookup for each preference
           preferences: fetchedSubmission.preferences.map((preference) => {
-            const mpeModule = fetchedMpeModuleList.find(
-              (m) => m.moduleCode === preference.moduleCode,
-            );
+            const mpeModule = moduleLookup.get(preference.moduleCode);
             if (!mpeModule) return preference;
             return {
               ...preference,
               moduleTitle: mpeModule.title,
-              moduleCode: mpeModule.moduleCode,
               moduleCredits: parseInt(mpeModule.moduleCredit, 10),
             };
           }),


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

closes #3674 

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

- create a lookup map to access from when comparing module codes, reducing access time to constant instead of linear
- removed `moduleCode` overwriting as they are already the same

## Profiling

tl;dr - using `Map` to lookup modulecodes is about `50x` faster at `n=1000` than `.find(...)`

step 1: generate a large array of random moduleCodes and create a mock `fetchedSubmission` object and `fetchedMpeModuleList` object

```js
const n = 10000;

const moduleCodes = Array.from({ length: n }, () =>
  (Math.random() + 1).toString(36).substring(2)
);

const fetchedMpeModuleList = moduleCodes.map((code) => ({ moduleCode: code }));
const fetchedSubmission = {
  preferences: fetchedMpeModuleList.slice(Math.floor(n / 2)),  // half of fetchedMpeModuleList
};
```

step 2: profile original implementation

```js
console.time("original");
const out1 = fetchedSubmission.preferences.map((preference) => {
  const mpeModule = fetchedMpeModuleList.find(
    (m) => m.moduleCode === preference.moduleCode
  );
  if (!mpeModule) return preference;
  return {
    ...preference,
    test: true,
  };
});
console.timeEnd("original");  // original: 557.182ms
console.log(out1.length);  // 5000
```

step 3a: profile `Map` implementation

```js
console.time("map");
const modMap = new Map(
  fetchedMpeModuleList.map((module) => [module.moduleCode, module])
);
const out2 = fetchedSubmission.preferences.map((preference) => {
  if (!modMap.get(preference.moduleCode)) return preference;
  return {
    ...preference,
    test: true,
  };
});
console.timeEnd("map");  // map: 8.299ms
console.log(out2.length);  // 5000
```

step 3b: profile `object` implementation

```js
console.time("obj");
const modObj = fetchedMpeModuleList.reduce((lookup, module) => {
  lookup[module.moduleCode] = module;
  return lookup;
}, {});
const out3 = fetchedSubmission.preferences.map((preference) => {
  if (!modObj[preference.moduleCode]) return preference;
  return {
    ...preference,
    test: true,
  };
});
console.timeEnd("obj");  // obj: 8.366ms
console.log(out3.length);  // 5000
```

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
