### PR TITLE
Fix overflow in planner module list

### DIFF
--- a/website/src/views/planner/PlannerButton.tsx
+++ b/website/src/views/planner/PlannerButton.tsx
@@ -1,0 +1,18 @@
+import { Settings } from 'react-feather';
+import { breakpointDown } from 'utils/css';
+import useMediaQuery from 'views/hooks/useMediaQuery';
+
+export type Props = Readonly<{
+  onClick: () => void;
+}>;
+
+export default function PlannerButton(props: Props) {
+  const narrowViewport = useMediaQuery(breakpointDown('sm'));
+
+  return (
+    <button className="btn btn-svg btn-outline-primary" type="button" onClick={props.onClick}>
+      <Settings className="svg" />
+      {narrowViewport ? '' : 'Settings'}
+    </button>
+  );
+}

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.scss
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.scss
@@ -1,5 +1,5 @@
-@import '~styles/utils/modules-entry';
-@import '../variables';
+@import "~styles/utils/modules-entry";
+@import "../variables";
 
 .pageContainer {
   composes: page-container from global;
@@ -60,6 +60,8 @@
 
 .moduleLists {
   display: flex;
+  width: 100%;
+  overflow-x: auto;
 }
 
 .modListHeaders {
@@ -70,12 +72,13 @@
 
 .trash {
   opacity: 0.6;
+  min-width: $semester-width;
   width: $semester-width;
   border: 1px dashed;
   border-radius: 0.4rem;
   text-align: center;
-  color: theme-color('danger');
-  background: rgba(theme-color('danger'), 0.1);
+  color: theme-color("danger");
+  background: rgba(theme-color("danger"), 0.1);
 
   &.isDraggingOver {
     opacity: 1;
@@ -83,8 +86,8 @@
 
   @include night-mode {
     opacity: 0.75;
-    color: lighten(theme-color('danger'), 20);
-    background: rgba(lighten(theme-color('danger'), 20), 0.2);
+    color: lighten(theme-color("danger"), 20);
+    background: rgba(lighten(theme-color("danger"), 20), 0.2);
   }
 }
 

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.scss
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.scss
@@ -14,12 +14,19 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 1rem;
+  width: 100%;
 
-  h1 {
+  @include scrollable;
+
+  .headerLeft {
     display: flex;
     align-items: center;
     margin: 0;
-    font-size: $font-size-xlg;
+
+    h1 {
+      font-size: $font-size-xlg;
+    }
 
     button {
       margin-left: 1rem;
@@ -33,10 +40,18 @@
   .headerRight {
     display: flex;
     align-items: center;
+    width: 100%;
   }
 
   .moduleStats {
     margin-right: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+
+    p {
+      white-space: nowrap;
+    }
   }
 }
 
@@ -61,7 +76,8 @@
 .moduleLists {
   display: flex;
   width: 100%;
-  overflow-x: auto;
+
+  @include scrollable;
 }
 
 .modListHeaders {

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.scss
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.scss
@@ -1,5 +1,5 @@
-@import "~styles/utils/modules-entry";
-@import "../variables";
+@import '~styles/utils/modules-entry';
+@import '../variables';
 
 .pageContainer {
   composes: page-container from global;
@@ -93,8 +93,8 @@
   border: 1px dashed;
   border-radius: 0.4rem;
   text-align: center;
-  color: theme-color("danger");
-  background: rgba(theme-color("danger"), 0.1);
+  color: theme-color('danger');
+  background: rgba(theme-color('danger'), 0.1);
 
   &.isDraggingOver {
     opacity: 1;
@@ -102,8 +102,8 @@
 
   @include night-mode {
     opacity: 0.75;
-    color: lighten(theme-color("danger"), 20);
-    background: rgba(lighten(theme-color("danger"), 20), 0.2);
+    color: lighten(theme-color('danger'), 20);
+    background: rgba(lighten(theme-color('danger'), 20), 0.2);
   }
 }
 

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.scss
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.scss
@@ -14,10 +14,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
   width: 100%;
-
-  @include scrollable;
+  gap: 1rem;
 
   .headerLeft {
     display: flex;
@@ -44,15 +42,17 @@
   }
 
   .moduleStats {
-    margin-right: 1rem;
     display: flex;
-    flex-wrap: wrap;
     flex-direction: row;
+    flex-wrap: wrap;
+    margin-right: 1rem;
 
     p {
       white-space: nowrap;
     }
   }
+
+  @include scrollable;
 }
 
 .addYearButton {
@@ -88,8 +88,8 @@
 
 .trash {
   opacity: 0.6;
-  min-width: $semester-width;
   width: $semester-width;
+  min-width: $semester-width;
   border: 1px dashed;
   border-radius: 0.4rem;
   text-align: center;

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
@@ -30,7 +30,7 @@ import Title from 'views/components/Title';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import Modal from 'views/components/Modal';
 import { State as StoreState } from 'types/state';
-import PlannerButton from '../PlannerButton';
+import PlannerSettingsButton from '../PlannerSettingsButton';
 import PlannerSemester from '../PlannerSemester';
 import PlannerYear from '../PlannerYear';
 import PlannerSettings from '../PlannerSettings';
@@ -160,7 +160,7 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
             <p>{renderMCs(credits)}</p>
           </div>
 
-          <PlannerButton onClick={() => this.setState({ showSettings: true })} />
+          <PlannerSettingsButton onClick={() => this.setState({ showSettings: true })} />
         </div>
       </header>
     );

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
@@ -30,6 +30,7 @@ import Title from 'views/components/Title';
 import LoadingSpinner from 'views/components/LoadingSpinner';
 import Modal from 'views/components/Modal';
 import { State as StoreState } from 'types/state';
+import PlannerButton from '../PlannerButton';
 import PlannerSemester from '../PlannerSemester';
 import PlannerYear from '../PlannerYear';
 import PlannerSettings from '../PlannerSettings';
@@ -140,8 +141,8 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
 
     return (
       <header className={styles.header}>
-        <h1>
-          Course Planner{' '}
+        <div className={styles.headerLeft}>
+          <h1>Course Planner </h1>
           <button
             className="btn btn-sm btn-outline-success"
             type="button"
@@ -149,20 +150,17 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
           >
             Beta - Send Feedback
           </button>
-        </h1>
+        </div>
 
         <div className={styles.headerRight}>
-          <p className={styles.moduleStats}>
-            {count} {count === 1 ? 'course' : 'courses'} / {renderMCs(credits)}
-          </p>
+          <div className={styles.moduleStats}>
+            <p>
+              {count} {count === 1 ? 'Course' : 'Courses'}&nbsp;/&nbsp;
+            </p>
+            <p>{renderMCs(credits)}</p>
+          </div>
 
-          <button
-            className="btn btn-svg btn-outline-primary"
-            type="button"
-            onClick={() => this.setState({ showSettings: true })}
-          >
-            <Settings className="svg" /> Settings
-          </button>
+          <PlannerButton onClick={() => this.setState({ showSettings: true })} />
         </div>
       </header>
     );

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
@@ -4,7 +4,7 @@ import { flatMap, flatten, sortBy, toPairs, values } from 'lodash';
 import { DragDropContext, Droppable, OnDragEndResponder } from 'react-beautiful-dnd';
 import classnames from 'classnames';
 
-import { Settings, Trash } from 'react-feather';
+import { Trash } from 'react-feather';
 import { Module, ModuleCode, Semester } from 'types/modules';
 import { PlannerModulesWithInfo, PlannerModuleInfo, AddModuleData } from 'types/planner';
 import { MODULE_CODE_REGEX, renderMCs, subtractAcadYear } from 'utils/modules';

--- a/website/src/views/planner/PlannerSemester.tsx
+++ b/website/src/views/planner/PlannerSemester.tsx
@@ -37,7 +37,7 @@ function renderSemesterMeta(plannerModules: PlannerModuleInfo[]) {
   return (
     <div className={styles.semesterMeta}>
       <p>
-        {plannerModules.length} {plannerModules.length === 1 ? 'course' : 'courses'}
+        {plannerModules.length} {plannerModules.length === 1 ? 'Course' : 'Courses'}
       </p>
       <p>{renderMCs(moduleCredits)}</p>
     </div>

--- a/website/src/views/planner/PlannerSettingsButton.tsx
+++ b/website/src/views/planner/PlannerSettingsButton.tsx
@@ -1,18 +1,21 @@
+import React from 'react';
 import { Settings } from 'react-feather';
 import { breakpointDown } from 'utils/css';
 import useMediaQuery from 'views/hooks/useMediaQuery';
 
-export type Props = Readonly<{
+type Props = Readonly<{
   onClick: () => void;
 }>;
 
-export default function PlannerButton(props: Props) {
+const PlannerSettingsButton: React.FC<Props> = ({ onClick }) => {
   const narrowViewport = useMediaQuery(breakpointDown('sm'));
 
   return (
-    <button className="btn btn-svg btn-outline-primary" type="button" onClick={props.onClick}>
+    <button className="btn btn-svg btn-outline-primary" type="button" onClick={onClick}>
       <Settings className="svg" />
       {narrowViewport ? '' : 'Settings'}
     </button>
   );
-}
+};
+
+export default PlannerSettingsButton;

--- a/website/src/views/planner/PlannerYear.tsx
+++ b/website/src/views/planner/PlannerYear.tsx
@@ -50,7 +50,7 @@ export default class PlannerYear extends PureComponent<Props, State> {
         </h2>
         <div className={styles.yearMeta}>
           <p>
-            {count} {count === 1 ? 'course' : 'courses'}
+            {count} {count === 1 ? 'Course' : 'Courses'}
           </p>
           <p>{renderMCs(credits)}</p>
         </div>


### PR DESCRIPTION
## Context
Fix #3698 with additional fixes to ensure header remains in size

## Implementation
- CSS fixes for overflows including scrollable and `no-wrap`
- Set minimum width for trash button
- `useMediaQuery` to allow settings button to reduce to an icon button
- Minor fix to capitalize the word "Course"/"Courses" to match the capitalization of "Unit"
