### PR TITLE
Add close button in planner settings modal

### DIFF
--- a/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
@@ -134,6 +134,8 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
 
   closeAddCustomData = () => this.setState({ showCustomModule: null });
 
+  closeSettingsModal = () => this.setState({ showSettings: false });
+
   renderHeader() {
     const modules = [...this.props.iblocsModules, ...flatten(flatMap(this.props.modules, values))];
     const credits = getTotalMC(modules);
@@ -261,12 +263,8 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
           </div>
         </DragDropContext>
 
-        <Modal
-          isOpen={this.state.showSettings}
-          onRequestClose={() => this.setState({ showSettings: false })}
-          animate
-        >
-          <PlannerSettings />
+        <Modal isOpen={this.state.showSettings} onRequestClose={this.closeSettingsModal} animate>
+          <PlannerSettings onCloseButtonClicked={this.closeSettingsModal} />
         </Modal>
 
         <Modal

--- a/website/src/views/planner/PlannerSettings.scss
+++ b/website/src/views/planner/PlannerSettings.scss
@@ -8,10 +8,6 @@
   section {
     margin-bottom: 1rem;
 
-    &:first-child {
-      margin-bottom: 0;
-    }
-
     &:last-child {
       margin-bottom: 0;
     }

--- a/website/src/views/planner/PlannerSettings.scss
+++ b/website/src/views/planner/PlannerSettings.scss
@@ -2,8 +2,15 @@
 @import 'variables';
 
 .settings {
+  display: flex;
+  flex-direction: column;
+
   section {
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
+
+    &:first-child {
+      margin-bottom: 0;
+    }
 
     &:last-child {
       margin-bottom: 0;

--- a/website/src/views/planner/PlannerSettings.tsx
+++ b/website/src/views/planner/PlannerSettings.tsx
@@ -13,6 +13,7 @@ import {
 } from 'actions/planner';
 import ExternalLink from 'views/components/ExternalLink';
 import Toggle from 'views/components/Toggle';
+import CloseButton from 'views/components/CloseButton';
 import { State } from 'types/state';
 import styles from './PlannerSettings.scss';
 
@@ -23,6 +24,7 @@ type Props = {
   readonly ignorePrereqCheck?: boolean;
 
   // Actions
+  readonly onCloseButtonClicked: () => void;
   readonly setMinYear: (str: string) => void;
   readonly setMaxYear: (str: string) => void;
   readonly setIBLOCs: (boolean: boolean) => void;
@@ -66,6 +68,9 @@ export const PlannerSettingsComponent: React.FC<Props> = (props) => {
 
   return (
     <div className={styles.settings}>
+      <div className={styles.closeButton}>
+        <CloseButton onClick={props.onCloseButtonClicked} />
+      </div>
       <section>
         <h2 className={styles.label}>Matriculated in</h2>
         <ul className={styles.years}>


### PR DESCRIPTION
## Context
Fix #3699 

## Implementation
- Use existing `CloseButton` component
- Changes the container to flexbox so that 0 height item still maintains the `margin-bottom`