### PR TITLE
Fix planner header wrap and center planner settings button cogwheel

### DIFF
--- a/website/src/views/planner/PlannerContainer/PlannerContainer.scss
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.scss
@@ -17,8 +17,8 @@
 
   .headerLeft {
     display: flex;
+    flex: 1;
     align-items: center;
-    flex: 3;
     margin: 0;
 
     h1 {
@@ -37,14 +37,12 @@
 
   .headerRight {
     display: flex;
+    justify-content: flex-end;
     align-items: center;
-    justify-content: right;
-    flex: 2;
   }
 
   .moduleStats {
     display: flex;
-    flex-direction: row;
     flex-wrap: wrap;
     margin-right: 1rem;
 

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.scss
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.scss
@@ -12,17 +12,17 @@
 
 .header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   width: 100%;
-  gap: 1rem;
 
   .headerLeft {
     display: flex;
     align-items: center;
+    flex: 3;
     margin: 0;
 
     h1 {
+      margin: 1rem;
       font-size: $font-size-xlg;
     }
 
@@ -38,7 +38,8 @@
   .headerRight {
     display: flex;
     align-items: center;
-    width: 100%;
+    justify-content: right;
+    flex: 2;
   }
 
   .moduleStats {

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.scss
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.scss
@@ -14,6 +14,7 @@
   display: flex;
   align-items: center;
   width: 100%;
+  gap: 1rem;
 
   .headerLeft {
     display: flex;

--- a/website/src/views/planner/PlannerSettingsButton.tsx
+++ b/website/src/views/planner/PlannerSettingsButton.tsx
@@ -12,7 +12,7 @@ const PlannerSettingsButton: React.FC<Props> = ({ onClick }) => {
 
   return (
     <button className="btn btn-svg btn-outline-primary" type="button" onClick={onClick}>
-      <Settings className="svg" />
+      <Settings className={narrowViewport ? '' : 'svg'} />
       {narrowViewport ? '' : 'Settings'}
     </button>
   );


### PR DESCRIPTION
## Context
Fix #3703 

## Implementation
Just CSS changes and removal of margin when "Settings" word removed

## Possible Improvements
There's a few UI minor details which I felt could've been done better but considering that we can release the planner then fix these minor things I'm going to leave these points here

- When the beta button is removed, the header text are not **visually** centered
- The module statistics portion ("0 Courses / 0 Units") should be right aligned especially at the smaller screen levels when the text is wrapped

## Screenshots
370px width with beta button:
![image](https://github.com/nusmodifications/nusmods/assets/36648707/26553fba-7543-4a8f-b675-53b6abbbe086)

500px width with beta button:
![image](https://github.com/nusmodifications/nusmods/assets/36648707/195eef4d-679a-4137-86f9-627bf4833545)

900px width with beta button:
![image](https://github.com/nusmodifications/nusmods/assets/36648707/f51b2f54-f219-4ed7-8a80-88094b18c8c3)

1600px width with beta button:
![image](https://github.com/nusmodifications/nusmods/assets/36648707/e425ce65-e583-4816-aeaa-d82d8ddd9545)

370px width without beta button:
![image](https://github.com/nusmodifications/nusmods/assets/36648707/d76ca594-cb10-4df2-9076-09fa2eaf91be)

500px width without beta button:
![image](https://github.com/nusmodifications/nusmods/assets/36648707/5b6f66e6-9cb0-4f74-a602-e2e560ec0cd1)

900px width without beta button:
![image](https://github.com/nusmodifications/nusmods/assets/36648707/64afbe05-c09d-4349-9603-73760c5a6b89)

1600px width without beta button:
![image](https://github.com/nusmodifications/nusmods/assets/36648707/2ea05a52-8b0e-4cd4-b932-20f1649cac70)
