### PR TITLE
chore: fix typo in settings container

### DIFF
--- a/website/src/views/settings/SettingsContainer.tsx
+++ b/website/src/views/settings/SettingsContainer.tsx
@@ -238,9 +238,9 @@ const SettingsContainer: React.FC<Props> = ({
         <div className="col-md-8">
           <p>
             We collect anonymous, aggregated usage information on NUSMods - think of it as a survey
-            that tells us which browsers to support and what features are popular. If you opt out, we
-            could end up removing features that you use since we won&apos;t know if anyone is using
-            them.
+            that tells us which browsers to support and what features are popular. If you opt out,
+            we could end up removing features that you use since we won&apos;t know if anyone is
+            using them.
           </p>
           <p>
             We do not use this information for advertising, or share this information with anybody.

--- a/website/src/views/settings/SettingsContainer.tsx
+++ b/website/src/views/settings/SettingsContainer.tsx
@@ -238,7 +238,7 @@ const SettingsContainer: React.FC<Props> = ({
         <div className="col-md-8">
           <p>
             We collect anonymous, aggregated usage information on NUSMods - think of it as a survey
-            to tells us which browsers to support and what features are popular. If you opt out, we
+            to tell us which browsers to support and what features are popular. If you opt out, we
             could end up removing features that you use since we won&apos;t know if anyone is using
             them.
           </p>

--- a/website/src/views/settings/SettingsContainer.tsx
+++ b/website/src/views/settings/SettingsContainer.tsx
@@ -238,7 +238,7 @@ const SettingsContainer: React.FC<Props> = ({
         <div className="col-md-8">
           <p>
             We collect anonymous, aggregated usage information on NUSMods - think of it as a survey
-            to tell us which browsers to support and what features are popular. If you opt out, we
+            that tells us which browsers to support and what features are popular. If you opt out, we
             could end up removing features that you use since we won&apos;t know if anyone is using
             them.
           </p>


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Changes `survey to tells us` to `survey to tell us` in the settings container.

Alternatively, could consider changing it to `survey that tells us`. Thoughts?

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
N/A

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
N/A
