### PR TITLE
fix(venues): VenueList subtitle color in dark mode

### DIFF
--- a/website/src/views/venues/VenueList.scss
+++ b/website/src/views/venues/VenueList.scss
@@ -59,7 +59,7 @@ $padding-v: 0.5rem;
 
 .subtitle {
   font-size: $font-size-xs;
-  color: $body-color;
+  color: var(--gray);
 }
 
 :global(.btn:hover) .subtitle {


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
Resolves #3718 
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
Before:
<img width="348" alt="Screenshot 2024-04-17 at 6 34 05 PM" src="https://github.com/nusmodifications/nusmods/assets/87565927/9c1fc881-3b07-40b4-bcf8-a8d4a3532a01">

After:
<img width="348" alt="after" src="https://github.com/nusmodifications/nusmods/assets/87565927/ddcee8e5-9796-4bf8-b90e-60f82f690955">

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
