### PR TITLE
Update checkPrerequisite to match wildcard prerequisites

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -96,7 +96,7 @@
     "icalendar": "0.7.1",
     "identity-obj-proxy": "3.0.0",
     "jest": "29.6.2",
-    "jest-environment-jsdom": "^29.5.0",
+    "jest-environment-jsdom": "^29.7.0",
     "jest-junit": "16.0.0",
     "mini-css-extract-plugin": "1.6.2",
     "nightwatch": "0.9.21",

--- a/website/src/utils/planner.test.ts
+++ b/website/src/utils/planner.test.ts
@@ -11,7 +11,11 @@ import {
 } from 'utils/planner';
 
 describe(checkPrerequisite, () => {
-  const moduleSet = new Set(['CS1010S', 'CS2107', 'CS2105', 'MA1101R', 'MA1521', 'MA2104']);
+  const moduleSet = new Set([
+    'CS1010S', 'CS2107', 'CS2105',
+    'MA1101R', 'MA1521', 'MA2104',
+    'NTW2006', 'UTC1402', 'UTC1702E'
+  ]);
 
   test('should return null if single prerequisite is met', () => {
     expect(checkPrerequisite(moduleSet, 'CS1010S')).toBeNull();
@@ -33,8 +37,30 @@ describe(checkPrerequisite, () => {
     ).toBeNull();
   });
 
+  test('should return null if single wildcard prerequisites is met', () => {
+    expect(checkPrerequisite(moduleSet, 'NTW%')).toBeNull();
+    expect(checkPrerequisite(moduleSet, 'UTC14%')).toBeNull();
+  });
+
+  test('should return null if all wildcard prerequisites are met', () => {
+    // Or operator
+    expect(
+      checkPrerequisite(moduleSet, {
+        or: ['UTC11%', 'UTC14%'],
+      }),
+    ).toBeNull();
+
+    // And operator
+    expect(
+      checkPrerequisite(moduleSet, {
+        and: ['UTC14%', 'UTC1702%'],
+      }),
+    ).toBeNull();
+  });
+
   test('should return module that are not fulfilled', () => {
     expect(checkPrerequisite(moduleSet, 'CS2030')).toEqual(['CS2030']);
+    expect(checkPrerequisite(moduleSet, 'NTW1%')).toEqual(['NTW1%']);
   });
 
   test('should return all modules that are not fulfilled', () => {
@@ -45,6 +71,16 @@ describe(checkPrerequisite, () => {
     ).toEqual([
       {
         or: ['CS2030', 'CS1020'],
+      },
+    ]);
+
+    expect(
+      checkPrerequisite(moduleSet, {
+        or: ['CS20%', 'UTC1700%'],
+      }),
+    ).toEqual([
+      {
+        or: ['CS20%', 'UTC1700%'],
       },
     ]);
   });

--- a/website/src/utils/planner.test.ts
+++ b/website/src/utils/planner.test.ts
@@ -12,9 +12,15 @@ import {
 
 describe(checkPrerequisite, () => {
   const moduleSet = new Set([
-    'CS1010S', 'CS2107', 'CS2105',
-    'MA1101R', 'MA1521', 'MA2104',
-    'NTW2006', 'UTC1402', 'UTC1702E'
+    'CS1010S',
+    'CS2107',
+    'CS2105',
+    'MA1101R',
+    'MA1521',
+    'MA2104',
+    'NTW2006',
+    'UTC1402',
+    'UTC1702E',
   ]);
 
   test('should return null if single prerequisite is met', () => {

--- a/website/src/utils/planner.ts
+++ b/website/src/utils/planner.ts
@@ -15,6 +15,7 @@ export const PLAN_TO_TAKE_YEAR = '3000';
 export const PLAN_TO_TAKE_SEMESTER = -2;
 
 const GRADE_REQUIREMENT_SEPARATOR = ':';
+const MODULE_WILD_CARD = "%";
 
 // We assume iBLOCs takes place in special term 1
 export const IBLOCS_SEMESTER = 3;
@@ -38,11 +39,20 @@ export function getSemesterName(semester: Semester) {
 export function checkPrerequisite(moduleSet: Set<ModuleCode>, tree: PrereqTree) {
   function walkTree(fragment: PrereqTree): PrereqTree[] | null {
     if (typeof fragment === 'string') {
-      if (fragment.includes(GRADE_REQUIREMENT_SEPARATOR)) {
-        const [module] = fragment.split(GRADE_REQUIREMENT_SEPARATOR);
-        return moduleSet.has(module) ? null : [module];
+      const module = fragment.includes(GRADE_REQUIREMENT_SEPARATOR)
+        ? fragment.split(GRADE_REQUIREMENT_SEPARATOR)[0]
+        : fragment;
+      
+      if (module.includes(MODULE_WILD_CARD)) {
+        const [prefix] = module.split(MODULE_WILD_CARD);
+        for (const moduleCode of moduleSet) {
+          if (moduleCode.startsWith(prefix)) {
+            return null;
+          }
+        }
       }
-      return moduleSet.has(fragment) ? null : [fragment];
+      
+      return moduleSet.has(module) ? null : [module];
     }
 
     if ('or' in fragment) {

--- a/website/src/utils/planner.ts
+++ b/website/src/utils/planner.ts
@@ -15,7 +15,7 @@ export const PLAN_TO_TAKE_YEAR = '3000';
 export const PLAN_TO_TAKE_SEMESTER = -2;
 
 const GRADE_REQUIREMENT_SEPARATOR = ':';
-const MODULE_WILD_CARD = "%";
+const MODULE_WILD_CARD = '%';
 
 // We assume iBLOCs takes place in special term 1
 export const IBLOCS_SEMESTER = 3;
@@ -42,16 +42,19 @@ export function checkPrerequisite(moduleSet: Set<ModuleCode>, tree: PrereqTree) 
       const module = fragment.includes(GRADE_REQUIREMENT_SEPARATOR)
         ? fragment.split(GRADE_REQUIREMENT_SEPARATOR)[0]
         : fragment;
-      
+
       if (module.includes(MODULE_WILD_CARD)) {
         const [prefix] = module.split(MODULE_WILD_CARD);
-        for (const moduleCode of moduleSet) {
-          if (moduleCode.startsWith(prefix)) {
-            return null;
-          }
+        let hasModule = false;
+        moduleSet.forEach((moduleCode) => {
+          hasModule = hasModule || moduleCode.startsWith(prefix);
+        });
+
+        if (hasModule) {
+          return null;
         }
       }
-      
+
       return moduleSet.has(module) ? null : [module];
     }
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1930,6 +1930,16 @@
     "@types/node" "*"
     jest-mock "^29.6.2"
 
+"@jest/environment@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.7.0.tgz#24d61f54ff1f786f3cd4073b4b94416383baf2a7"
+  integrity sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==
+  dependencies:
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    jest-mock "^29.7.0"
+
 "@jest/expect-utils@^29.5.0":
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.5.0.tgz#f74fad6b6e20f924582dc8ecbf2cb800fe43a036"
@@ -1963,6 +1973,18 @@
     jest-message-util "^29.6.2"
     jest-mock "^29.6.2"
     jest-util "^29.6.2"
+
+"@jest/fake-timers@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.7.0.tgz#fd91bf1fffb16d7d0d24a426ab1a47a49881a565"
+  integrity sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@sinonjs/fake-timers" "^10.0.2"
+    "@types/node" "*"
+    jest-message-util "^29.7.0"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
 
 "@jest/globals@^29.6.2":
   version "29.6.2"
@@ -2015,6 +2037,13 @@
   version "29.6.0"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.0.tgz#0f4cb2c8e3dca80c135507ba5635a4fd755b0040"
   integrity sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
   dependencies:
     "@sinclair/typebox" "^0.27.8"
 
@@ -2097,6 +2126,18 @@
   integrity sha512-tPKQNMPuXgvdOn2/Lg9HNfUvjYVGolt04Hp03f5hAk878uwOLikN+JzeLY0HcVgKgFl9Hs3EIqpu3WX27XNhnw==
   dependencies:
     "@jest/schemas" "^29.6.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
+"@jest/types@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
+  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
@@ -8324,18 +8365,18 @@ jest-each@^29.6.2:
     jest-util "^29.6.2"
     pretty-format "^29.6.2"
 
-jest-environment-jsdom@^29.5.0:
-  version "29.6.2"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.6.2.tgz#4fc68836a7774a771819a2f980cb47af3b1629da"
-  integrity sha512-7oa/+266AAEgkzae8i1awNEfTfjwawWKLpiw2XesZmaoVVj9u9t8JOYx18cG29rbPNtkUlZ8V4b5Jb36y/VxoQ==
+jest-environment-jsdom@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz#d206fa3551933c3fd519e5dfdb58a0f5139a837f"
+  integrity sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==
   dependencies:
-    "@jest/environment" "^29.6.2"
-    "@jest/fake-timers" "^29.6.2"
-    "@jest/types" "^29.6.1"
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/jsdom" "^20.0.0"
     "@types/node" "*"
-    jest-mock "^29.6.2"
-    jest-util "^29.6.2"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
     jsdom "^20.0.0"
 
 jest-environment-node@^29.6.2:
@@ -8447,6 +8488,21 @@ jest-message-util@^29.6.2:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-message-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
+  integrity sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.6.3"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@^29.6.2:
   version "29.6.2"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.6.2.tgz#ef9c9b4d38c34a2ad61010a021866dad41ce5e00"
@@ -8455,6 +8511,15 @@ jest-mock@^29.6.2:
     "@jest/types" "^29.6.1"
     "@types/node" "*"
     jest-util "^29.6.2"
+
+jest-mock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
+  integrity sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    jest-util "^29.7.0"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
@@ -8588,6 +8653,18 @@ jest-util@^29.6.2:
   integrity sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==
   dependencies:
     "@jest/types" "^29.6.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
+jest-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
+  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
+  dependencies:
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
     ci-info "^3.2.0"
@@ -10884,6 +10961,15 @@ pretty-format@^29.6.2:
   integrity sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==
   dependencies:
     "@jest/schemas" "^29.6.0"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 


### PR DESCRIPTION
Change checking to parse for wildcards and check for matching prefixes instead of exact string matches.

<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Proposal to fix #3733 where prerequisite wildcards returns zero matches.

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
Changed the `checkPrerequisite` function in `planner.ts` to check if any module in the set has a prefix that matches the string before the wildcard symbol (i.e. UTC  in UTC%). 

The implementation is still the same as before for non-wildcard modules.

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
- `package.json` was updated as the previous version raised an error regarding outdated jest environ version when running `yarn test`.
- Updated `planner.test.ts` file to handle tests for wildcard modules.
- This is my first time committing to nusmods :)

