### PR TITLE
Add new Packaged Laboratory lesson type

### DIFF
--- a/scrapers/nus-v2/src/utils/data.ts
+++ b/scrapers/nus-v2/src/utils/data.ts
@@ -196,6 +196,7 @@ export const activityLessonType: Record<string, LessonType> = {
   E: 'Seminar-Style Module Class',
   S: 'Sectional Teaching',
   T: 'Tutorial',
+  Y: 'Packaged Laboratory',
   '2': 'Tutorial Type 2',
   '3': 'Tutorial Type 3',
 

--- a/website/src/utils/timetables.ts
+++ b/website/src/utils/timetables.ts
@@ -56,6 +56,7 @@ export const LESSON_TYPE_ABBREV: lessonTypeAbbrev = {
   'Design Lecture': 'DLEC',
   Laboratory: 'LAB',
   Lecture: 'LEC',
+  'Packaged Laboratory': 'PLAB',
   'Packaged Lecture': 'PLEC',
   'Packaged Tutorial': 'PTUT',
   Recitation: 'REC',


### PR DESCRIPTION
## Context

There is a new lesson type called Packaged Laboratory, with code Y. 

For now it looks like the only course with it is https://nusmods.com/courses/PHS2191/laboratory-techniques-in-pharmaceutical-science-i

It used to show:
<img width="713" alt="image" src="https://github.com/nusmodifications/nusmods/assets/29654756/63a3191c-75d4-49a3-8a47-01fc7a441b5d">

Now it shows:
<img width="420" alt="image" src="https://github.com/nusmodifications/nusmods/assets/29654756/dce8f30a-ef28-415e-b269-215283193078">

## Other Information

I've updated the prod scraper 