### PR TITLE
Add other OSS projects to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,21 @@ Before submitting a pull request, please make sure the following is done:
 1. Run `yarn run ci` which runs the linting, testing and building steps. This is the command that is run on our CI system. There should not be errors shown. Alternatively, you can run the linting, testing and building step separately via `yarn run lint`, `yarn test` and `yarn run build` respectively.
 1. There might be project-specific contribution details. Please read the README of the respective projects.
 
+## Other Open Source Projects
+
+Contributing to open source projects you enjoy using and want to make better is an amazing way to give back to the community and improve your skills as a developer! Here's a non-exhaustive list of other NUS-related open source projects you might want to get your hands dirty with:
+
+1. [**CourseRekt**](https://github.com/lunaflight/courserekt/) - A tool for visualising past vacancy reports to help you strategise for course registration.
+2. [**NUS Timetable Optimizer**](https://github.com/frizensami/nus-timetable-optimizer) - An application that helps students optimize their timetables for the best possible schedule.
+3. [**LoMiNUS**](https://github.com/Beebeeoii/lominus) - An app which helps Canvas and the now-defunct LumiNUS download their files and keep them in sync.
+4. [**CATcher**](https://github.com/CATcher-org/CATcher/) - An issue management tool for software engineering project teams.
+5. [**MarkBind**](https://github.com/markbind/markbind) - A tool for generating static websites from Markdown documents.
+6. [**PowerPointLabs**](https://github.com/powerpointlabs/powerpointlabs) - A PowerPoint add-in that provides advanced features for creating presentations.
+7. [**RepoSense**](https://github.com/reposense/reposense) - A tool that generates contribution summaries for Git repositories.
+8. [**TEAMMATES**](https://github.com/teammates/teammates) - A feedback management tool for education.
+
+Good luck, and happy hacking!
+
 ### Code of Conduct
 
 We have adopted Facebook's Code of Conduct that we expect project participants to adhere to. Kindly read [the full text](https://code.facebook.com/codeofconduct) to understand what actions will and will not be tolerated.

--- a/website/package.json
+++ b/website/package.json
@@ -116,7 +116,7 @@
     "stylelint-config-standard": "20.0.0",
     "stylelint-order": "4.1.0",
     "terser-webpack-plugin": "5.3.9",
-    "typescript": "5.1.6",
+    "typescript": "5.1",
     "url-loader": "4.1.1",
     "webpack": "5.88.2",
     "webpack-cli": "4.10.0",

--- a/website/src/views/contribute/ContributeContainer/ContributeContainer.tsx
+++ b/website/src/views/contribute/ContributeContainer/ContributeContainer.tsx
@@ -289,6 +289,13 @@ const ContributeContainer: FC<Props> = ({ modules, beta, ...props }) => {
             <h4>Mailing List</h4>
             <p>Subscribe to news and updates</p>
           </ExternalLink>
+          <ExternalLink
+            className="btn btn-outline-primary"
+            href="https://github.com/nusmodifications/nusmods/blob/master/CONTRIBUTING.md#other-open-source-projects"
+          >
+            <h4>Other Open Source Projects</h4>
+            <p>Contribute to other open source projects</p>
+          </ExternalLink>
         </div>
 
         <p>

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -13351,7 +13351,7 @@ typescript@4.3.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
-typescript@5.1.6:
+typescript@5.1:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==


### PR DESCRIPTION

## Context
Fixes #3753

## Implementation
Added a button on https://nusmods.com/contribute to link to a newly added portion of open source projects added to `CONTRIBUTING.md`.
![image](https://github.com/user-attachments/assets/73273e38-4703-4589-8d72-6631889a1f21)