### PR TITLE
Add spacing between text in workload visualisation component

### DIFF
--- a/website/src/views/components/module-info/ModuleWorkload.tsx
+++ b/website/src/views/components/module-info/ModuleWorkload.tsx
@@ -99,7 +99,12 @@ const ModuleWorkload = React.memo<Props>(({ workload }) => {
                 className={styles.moduleWorkloadComponent}
                 style={{ width: `${(100 / ROW_MAX) * Math.min(ROW_MAX, Math.ceil(hours))}%` }}
               >
-                <h5 className={textClass(component)}>{workloadLabel(component, hours)}</h5>
+                <h5
+                  className={textClass(component)}
+                  style={{ marginRight: hours % 1 ? '5%' : '0.5rem' }}
+                >
+                  {workloadLabel(component, hours)}
+                </h5>
 
                 <div
                   className={classnames(styles.moduleWorkloadBlocks, {


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Closes #3775 

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
- Adjust the right margin of the workload label dynamically based on the value of 'hours'.
- If 'hours' is not a whole number, set a larger margin ('5%') for better spacing. Otherwise, use a smaller margin ('0.5rem').
![image](https://github.com/user-attachments/assets/cdcabad1-f8f2-4d81-8e83-e8d3e4a62770)