### PR TITLE
fix : Remove the unused link from the footer

### DIFF
--- a/website/src/views/layout/Footer.tsx
+++ b/website/src/views/layout/Footer.tsx
@@ -45,18 +45,6 @@ export const FooterComponent: React.FC<Props> = (props) => {
             <ExternalLink href={config.contact.githubRepo}>GitHub</ExternalLink>
           </li>
           <li>
-            <ExternalLink href={config.contact.facebook}>Facebook</ExternalLink>
-          </li>
-          <li>
-            <ExternalLink href={config.contact.messenger}>Messenger</ExternalLink>
-          </li>
-          <li>
-            <ExternalLink href={config.contact.twitter}>Twitter</ExternalLink>
-          </li>
-          <li>
-            <ExternalLink href={config.contact.blog}>Blog</ExternalLink>
-          </li>
-          <li>
             <ExternalLink href="https://api.nusmods.com/v2">API</ExternalLink>
           </li>
           <li>


### PR DESCRIPTION
This PR Removes the unused links from the footer.

Fixes #3786 


![Screenshot 2024-08-21 005550](https://github.com/user-attachments/assets/6c521048-e7f3-4314-b347-dc7794e23f79)


## How should this be tested?
- [ ] Go to Homepage 
- [ ] Check the footer section