### PR TITLE
Replaced google groups email

### DIFF
--- a/website/src/views/static/FaqContainer.tsx
+++ b/website/src/views/static/FaqContainer.tsx
@@ -178,7 +178,7 @@ const FaqContainer: React.FC = () => (
       <hr />
       <p>
         Congratulations on making it to the end! If you still want to contact us, you may reach us
-        via email at nusmods&#123;at&#125;googlegroups[dot]com or via{' '}
+        via email at mods&#123;at&#125;nusmods[dot]com or via{' '}
         <ExternalLink href={config.contact.messenger}>Messenger</ExternalLink>. Please allow up to
         90 working days for a reply. We are busy <Link to="/team">students</Link> as well!
       </p>

--- a/website/static/base/opensearch.xml
+++ b/website/static/base/opensearch.xml
@@ -7,6 +7,6 @@
   <Query role="example" searchTerms="Programming Methodology" />
   <Image height="16" width="16" type="image/png">https://nusmods.com/favicon-16x16.png</Image>
   <InputEncoding>UTF-8</InputEncoding>
-  <Contact>nusmods@googlegroups.com</Contact>
+  <Contact>mods@nusmods.com</Contact>
   <moz:SearchForm>https://nusmods.com/modules/</moz:SearchForm>
 </OpenSearchDescription>


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
Closes #3777 
Replacing all occurrences of the old email with the new email on the website. 

## Implementation
Under the opensearch.xml file, I replaced the old email with the new email according to the pull request. 
Under the FAQ tab, there is also an occurrence of the email and I replaced it. 
<img width="524" alt="Screenshot 2024-08-21 at 3 07 28 PM" src="https://github.com/user-attachments/assets/ee90334b-02ec-4b0b-bbff-473a0f97dc57">
