### PR TITLE
Replace messenger with telegram

### DIFF
--- a/website/src/config/app-config.json
+++ b/website/src/config/app-config.json
@@ -45,7 +45,6 @@
     "facebook": "https://facebook.com/nusmods",
     "githubOrg": "https://github.com/nusmodifications",
     "githubRepo": "https://github.com/nusmodifications/nusmods",
-    "messenger": "https://m.me/nusmods",
     "twitter": "https://twitter.com/nusmods",
     "telegram": "https://t.me/NUSMods"
   }

--- a/website/src/config/index.ts
+++ b/website/src/config/index.ts
@@ -63,7 +63,6 @@ export type Config = {
     facebook: string;
     githubOrg: string;
     githubRepo: string;
-    messenger: string;
     twitter: string;
     telegram: string;
   };

--- a/website/src/views/components/FeedbackModal.scss
+++ b/website/src/views/components/FeedbackModal.scss
@@ -42,7 +42,7 @@
     }
 
     &.messenger {
-      $button-bg: #0084ff;
+      $button-bg: #3aa8db;
 
       background: $button-bg;
 

--- a/website/src/views/components/FeedbackModal.scss
+++ b/website/src/views/components/FeedbackModal.scss
@@ -1,4 +1,4 @@
-@import "~styles/utils/modules-entry";
+@import '~styles/utils/modules-entry';
 
 .content {
   text-align: center;
@@ -41,7 +41,7 @@
       color: #fff;
     }
 
-    &.messenger {
+    &.telegram {
       $button-bg: #3aa8db;
 
       background: $button-bg;

--- a/website/src/views/components/FeedbackModal.tsx
+++ b/website/src/views/components/FeedbackModal.tsx
@@ -18,7 +18,7 @@ type Props = {
 export const FeedbackButtons: React.FC = () => (
   <div>
     <div className={styles.links}>
-      <ExternalLink className={styles.messenger} href={config.contact.messenger}>
+      <ExternalLink className={styles.telegram} href={config.contact.telegram}>
         <Send />
         Telegram
       </ExternalLink>
@@ -52,8 +52,8 @@ export const FeedbackModalComponent: React.FC<Props> = (props) => (
       <Heart className={styles.topIcon} />
       <h1>Let us know what you think!</h1>
       <p>
-        Thank you for your time! You can talk to us on Messenger, file an issue on GitHub, or send
-        us an email.
+        Thank you for your time! You can talk to us on Telegram, file an issue on GitHub, or send us
+        an email.
       </p>
       <FeedbackButtons />
     </div>

--- a/website/src/views/components/FeedbackModal.tsx
+++ b/website/src/views/components/FeedbackModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Heart, GitHub, Mail } from 'react-feather';
+import { Heart, GitHub, Mail, Send } from 'react-feather';
 
 import config from 'config';
 import { toggleFeedback } from 'actions/app';
@@ -18,6 +18,10 @@ type Props = {
 export const FeedbackButtons: React.FC = () => (
   <div>
     <div className={styles.links}>
+      <ExternalLink className={styles.messenger} href={config.contact.messenger}>
+        <Send />
+        Telegram
+      </ExternalLink>
       <ExternalLink className={styles.github} href={config.contact.githubRepo}>
         <GitHub />
         GitHub

--- a/website/src/views/settings/BetaToggle.tsx
+++ b/website/src/views/settings/BetaToggle.tsx
@@ -47,7 +47,7 @@ const BetaToggle = memo<Props>((props) => {
         <div className={styles.toggle}>
           <Toggle className={styles.betaToggle} isOn={betaTester} onChange={toggleStates} />
           {betaTester && hasTests && (
-            <ExternalLink className="btn btn-success" href={config.contact.messenger}>
+            <ExternalLink className="btn btn-success" href={config.contact.telegram}>
               Leave Feedback
             </ExternalLink>
           )}

--- a/website/src/views/static/AboutContainer.tsx
+++ b/website/src/views/static/AboutContainer.tsx
@@ -57,7 +57,7 @@ const AboutContainer: React.FC<Props> = (props) => (
         </button>
       </div>
       <div className={classnames('col-lg', styles.btnContainer)}>
-        <ExternalLink href={config.contact.messenger} className="btn btn-primary btn-svg btn-block">
+        <ExternalLink href={config.contact.telegram} className="btn btn-primary btn-svg btn-block">
           <Layers className="svg" />
           We need designers!
         </ExternalLink>

--- a/website/src/views/static/FaqContainer.tsx
+++ b/website/src/views/static/FaqContainer.tsx
@@ -179,9 +179,8 @@ const FaqContainer: React.FC = () => (
       <p>
         Congratulations on making it to the end! If you still want to contact us, you may reach us
         via email at mods&#123;at&#125;nusmods[dot]com or via{' '}
-        <ExternalLink href={config.contact.telegram}>Telegram</ExternalLink> or via{' '}
-        <ExternalLink href={config.contact.messenger}>Messenger</ExternalLink>. Please allow up to
-        90 working days for a reply. We are busy <Link to="/team">students</Link> as well!
+        <ExternalLink href={config.contact.telegram}>Telegram</ExternalLink>. Please allow up to 90
+        working days for a reply. We are busy <Link to="/team">students</Link> as well!
       </p>
     </div>
   </StaticPage>


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Messenger group is no longer used, adds a telegram button to the contribute page and replaces all other mentions of messenger with telegram.
Issue: https://github.com/nusmodifications/nusmods/issues/3794

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
Replace the messenger button with a telegram button. The background color uses the telegram background color and the icon uses the Send icon from react-feather

![image](https://github.com/user-attachments/assets/3be94599-0e3c-40ef-b6af-e23c6437a360)


## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
