### PR TITLE
add dark mode support for ColorPicker

### DIFF
--- a/website/src/views/components/ColorPicker.scss
+++ b/website/src/views/components/ColorPicker.scss
@@ -1,6 +1,6 @@
 @import '~styles/utils/modules-entry';
 
-$background-color: #e9e9e9;
+$background-color: var(--gray-lighter);
 $size: 1.5rem;
 $padding: 0.3rem;
 $margin-bottom: 0.15rem;


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
Issue #3815 (Title: Dark theme for color picker)
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
The problem was that the `$background-color` variable was hardcoded to a hex value in `website/src/views/components/ColorPicker.scss`

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
`$background-color` in `website/src/views/components/ColorPicker.scss` was changed to the global css variable `--gray-lighter`. 

The different shades of gray provided in `website/src/styles/utils/css-variables.scss` was tested and `--gray-lighter` seemed like the most balanced choice and looked good on both light and dark theme (see screen shots).

![Screenshot 2024-08-30 at 11 32 45](https://github.com/user-attachments/assets/f5f9e9d2-96b1-404b-8f80-0283df51b27e)

![Screenshot 2024-08-30 at 11 32 50](https://github.com/user-attachments/assets/332ff0b5-56b2-4c70-b2f2-ddfa71c7270e)


## Other Information

This is my first PR in an open source project 🙂 

<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
