### PR TITLE
fix(venues): resolve mismatched selected time period

### DIFF
--- a/website/src/views/venues/VenuesContainer.tsx
+++ b/website/src/views/venues/VenuesContainer.tsx
@@ -36,7 +36,7 @@ import HistoryDebouncer from 'utils/HistoryDebouncer';
 import { clampClassDuration, filterAvailability, searchVenue, sortVenues } from 'utils/venues';
 import { breakpointDown } from 'utils/css';
 import { defer } from 'utils/react';
-import { convertIndexToTime } from 'utils/timify';
+import { convertIndexToTime, NUM_INTERVALS_PER_HOUR } from 'utils/timify';
 
 import withVenueLocations from 'views/components/map/withVenueLocations';
 import AvailabilitySearch, { defaultSearchOptions } from './AvailabilitySearch';
@@ -182,8 +182,10 @@ export class VenuesContainerComponent extends Component<Props, State> {
 
     return {
       day: searchOptions.day,
-      startTime: convertIndexToTime(searchOptions.time * 2),
-      endTime: convertIndexToTime(2 * (searchOptions.time + searchOptions.duration)),
+      startTime: convertIndexToTime(searchOptions.time * NUM_INTERVALS_PER_HOUR),
+      endTime: convertIndexToTime(
+        NUM_INTERVALS_PER_HOUR * (searchOptions.time + searchOptions.duration),
+      ),
     };
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

This PR closes https://github.com/nusmodifications/nusmods/issues/3821.

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

For context, this was probably broken because of the added support for 15-min intervals (https://github.com/nusmodifications/nusmods/pull/3771) which caused there to be 4 periods in a single hour. This PR resolves the issue by replacing the hard-coded number of periods in an hour.