### PR TITLE
Fix Add Course button in timetable misalignment

### DIFF
--- a/website/src/views/components/Modal.scss
+++ b/website/src/views/components/Modal.scss
@@ -62,7 +62,8 @@
       max-width: 100%;
       max-height: 100%;
       padding: 0;
-    }  }
+    }
+  }
 
 
   @include media-breakpoint-up(md) {

--- a/website/src/views/components/Modal.scss
+++ b/website/src/views/components/Modal.scss
@@ -53,6 +53,18 @@
     }
   }
 
+  @include media-breakpoint-up(sm) {
+    &.fullscreen {
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      max-width: 100%;
+      max-height: 100%;
+      padding: 0;
+    }  }
+
+
   @include media-breakpoint-up(md) {
     top: 5%;
     max-height: 90%;

--- a/website/src/views/timetable/ModulesSelect.scss
+++ b/website/src/views/timetable/ModulesSelect.scss
@@ -68,7 +68,7 @@ $item-padding-vertical: 0.6rem;
   background: var(--body-bg);
 }
 
-@include media-breakpoint-up(sm) {
+@include media-breakpoint-up(xs) {
   .tip {
     position: absolute;
     top: $input-height;

--- a/website/src/views/timetable/ModulesSelect.scss
+++ b/website/src/views/timetable/ModulesSelect.scss
@@ -68,6 +68,15 @@ $item-padding-vertical: 0.6rem;
   background: var(--body-bg);
 }
 
+@include media-breakpoint-up(sm) {
+  .tip {
+    position: absolute;
+    top: $input-height;
+    right: 0;
+    left: 0;
+  }
+}
+
 @include media-breakpoint-up(md) {
   .selectList,
   .tip {


### PR DESCRIPTION
## Context
Fix for Issue #3827 

## Implementation
Added additional css styling for small and medium media breakpoint in `Modals.scss` and `ModulesSelect.scss`

## Other Information
<ins>Before: Modules select tip not visible in Small breakpoint </ins>

![Before Small Breakpoint](https://github.com/user-attachments/assets/91c5bac5-123b-4df4-afaf-950e9133fb7c)

<ins>Before: Modules select downshift component not properly aligned in Medium breakpoint </ins>

![Before Medium Breakpoint](https://github.com/user-attachments/assets/99c0c1cc-26e5-4cbf-be91-1034060c399d)

<ins> After for Small & Medium: </ins>

![After Small Breakpoint](https://github.com/user-attachments/assets/6fd24b17-d418-455d-b481-4c648b9779a3)


![After Medium Breakpoint](https://github.com/user-attachments/assets/70fc346d-4ba2-46d5-8785-4f8e5a7c30ed)
