### PR TITLE
Update CPEx scraper for AY24/25 S2

### DIFF
--- a/scrapers/cpex-scraper/src/index.ts
+++ b/scrapers/cpex-scraper/src/index.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 import env from '../env.json';
 
-const TERM = '2410';
+const TERM = '2420';
 
 // Sanity check to see if there are at least this many modules before overwriting cpexModules.json
 // The last time I ran this fully there were 3418 modules


### PR DESCRIPTION
Update `TERM` constant to the correct term `2420`.