### PR TITLE
Update maintenance guide with CPEx instructions

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -22,4 +22,22 @@ Reference PRs: [PR #3286](https://github.com/nusmodifications/nusmods/pull/3286)
 - [ ] Update semester in `website/src/config/app-config.json`
 - [ ] In `app-config.json`, add semester to `examAvailability` to indicate exam information is available for the semester
 - [ ] Update the ModReg schedule in `website/src/data/modreg-schedule.json`, and make sure the correct version is pointed to in `website/src/config/index.ts`  
-       - Reference PR: [PR #2764](https://github.com/nusmodifications/nusmods/pull/2764)
+  - Reference PR: [PR #2764](https://github.com/nusmodifications/nusmods/pull/2764)
+
+## CPEx
+
+- Before
+  - [ ] Update `TERM` in `scrapers/cpex-scraper/src/index.ts` and `MPE_SEMESTER` in `website/src/views/mpe/constants.ts` to be the semester you're configuring CPEx for (usually the next semester)
+  - [ ] Update the displayed dates in `website/src/views/mpe/MpeContainer.tsx` and any new requirements/descriptions
+  - [ ] Enable the `enabledCPEx` flag in `website/src/featureFlags.ts`
+  - [ ] Add a new entry in the ModReg schedule in `website/src/data/modreg-schedule.json`
+    - Reference PR: [PR #3832](https://github.com/nusmodifications/nusmods/pull/3832)
+  - [ ] Once merged into `master`, visit https://latest.nusmods.com/cpex and verify that NUS authentication is working
+  - [ ] Prepare PR to enable the `showCPExTab` flag in `website/src/featureFlags.ts`
+- During
+  - [ ] Enable the `showCPExTab` flag in `website/src/featureFlags.ts`
+  - [ ] Deploy latest `master` to `production`
+  - [ ] Prepare PR to disable the `enabledCPEx` and `showCPExTab` flags in `website/src/featureFlags.ts`
+- After
+  - [ ] Remove CPEx from the ModReg schedule in `website/src/data/modreg-schedule.json`
+  - [ ] Disable the `enabledCPEx` and `showCPExTab` flags in `website/src/featureFlags.ts`

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -33,11 +33,15 @@ Reference PRs: [PR #3286](https://github.com/nusmodifications/nusmods/pull/3286)
   - [ ] Add a new entry in the ModReg schedule in `website/src/data/modreg-schedule.json`
     - Reference PR: [PR #3832](https://github.com/nusmodifications/nusmods/pull/3832)
   - [ ] Once merged into `master`, visit https://latest.nusmods.com/cpex and verify that NUS authentication is working
+  - [ ] Deploy latest `master` to `production`
   - [ ] Prepare PR to enable the `showCPExTab` flag in `website/src/featureFlags.ts`
 - During
   - [ ] Enable the `showCPExTab` flag in `website/src/featureFlags.ts`
+  - [ ] Merge into `master`
   - [ ] Deploy latest `master` to `production`
   - [ ] Prepare PR to disable the `enabledCPEx` and `showCPExTab` flags in `website/src/featureFlags.ts`
 - After
-  - [ ] Remove CPEx from the ModReg schedule in `website/src/data/modreg-schedule.json`
   - [ ] Disable the `enabledCPEx` and `showCPExTab` flags in `website/src/featureFlags.ts`
+  - [ ] Remove CPEx from the ModReg schedule in `website/src/data/modreg-schedule.json`
+  - [ ] Merge into `master`
+  - [ ] Deploy latest `master` to `production`


### PR DESCRIPTION
## Context

We don't have a runbook on how to set up CPEx each semester, which takes up not-insignificant maintainer time.

## Implementation

Added the runbook into the `MAINTENANCE.md` guide which already details how to re-configure NUSMods each semester.