### PR TITLE
Add handler for failed CPEX logins

### DIFF
--- a/website/api/nus/auth/sso.ts
+++ b/website/api/nus/auth/sso.ts
@@ -31,7 +31,7 @@ const handleGet: Handler = async (req, res) => {
       res.json({
         message: 'Request needs a referer',
       });
-    } else if (err.message === errors.failedSamlLogin) {
+    } else if (err.name === errors.failedSamlLogin) {
       res.json({
         message:
           'Request failed to login. Login requires NUSID. Please see instructions on NUS VAFS page.',

--- a/website/api/nus/auth/sso.ts
+++ b/website/api/nus/auth/sso.ts
@@ -9,6 +9,7 @@ import {
 
 const errors = {
   noCallbackUrl: 'ERR_NO_REFERER',
+  failedSamlLogin: 'ERR_FAILED_STATUS',
 };
 
 function getCallbackUrl(callback: string | string[] | undefined) {
@@ -29,6 +30,11 @@ const handleGet: Handler = async (req, res) => {
     if (err.message === errors.noCallbackUrl) {
       res.json({
         message: 'Request needs a referer',
+      });
+    } else if (err.message === errors.failedSamlLogin) {
+      res.json({
+        message:
+          'Request failed to login. Login requires NUSID. Please see instructions on NUS VAFS page.',
       });
     } else {
       throw err;


### PR DESCRIPTION
## Context
Receive a "Unexpected error has occurred" message when trying to login to CPEX page

## Implementation
Add extra handler.  `defaultRescue` should not occur instead?