### PR TITLE
Zehata/website module page/3202/toggleable left to right prerequisites trees

### DIFF
--- a/website/src/actions/settings.ts
+++ b/website/src/actions/settings.ts
@@ -92,3 +92,11 @@ export function setLoadDisqusManually(status: boolean) {
     payload: status,
   };
 }
+
+export const TOGGLE_PREREQ_TREE_DIRECTION = 'TOGGLE_PREREQ_TREE_DIRECTION' as const;
+export function togglePreReqTreeDirection(status: boolean) {
+  return {
+    type: TOGGLE_PREREQ_TREE_DIRECTION,
+    payload: status,
+  };
+}

--- a/website/src/reducers/settings.test.ts
+++ b/website/src/reducers/settings.test.ts
@@ -25,6 +25,7 @@ const initialState: SettingsState = {
   moduleTableOrder: 'exam',
   loadDisqusManually: false,
   beta: false,
+  prereqTreeOnLeft: true,
 };
 const settingsWithNewStudent: SettingsState = { ...initialState, newStudent: true };
 const faculty = 'School of Computing';

--- a/website/src/reducers/settings.ts
+++ b/website/src/reducers/settings.ts
@@ -16,6 +16,7 @@ import {
   TOGGLE_BETA_TESTING_STATUS,
   TOGGLE_MODREG_NOTIFICATION_GLOBALLY,
   SET_MODREG_SCHEDULE_TYPE,
+  TOGGLE_PREREQ_TREE_DIRECTION,
 } from 'actions/settings';
 import { SET_EXPORTED_DATA } from 'actions/constants';
 import { DIMENSIONS, withTracker } from 'bootstrapping/matomo';
@@ -40,6 +41,7 @@ const defaultSettingsState: SettingsState = {
   moduleTableOrder: 'exam',
   beta: false,
   loadDisqusManually: false,
+  prereqTreeOnLeft: true,
 };
 
 function settings(state: SettingsState = defaultSettingsState, action: Actions): SettingsState {
@@ -112,6 +114,12 @@ function settings(state: SettingsState = defaultSettingsState, action: Actions):
       return {
         ...state,
         loadDisqusManually: action.payload,
+      };
+
+    case TOGGLE_PREREQ_TREE_DIRECTION:
+      return {
+        ...state,
+        prereqTreeOnLeft: action.payload,
       };
 
     case REHYDRATE: {

--- a/website/src/types/reducers.ts
+++ b/website/src/types/reducers.ts
@@ -104,6 +104,7 @@ export type SettingsState = {
   readonly moduleTableOrder: ModuleTableOrder;
   readonly beta?: boolean;
   readonly loadDisqusManually: boolean;
+  readonly prereqTreeOnLeft: boolean;
 };
 
 /* timetables.js */

--- a/website/src/views/components/ConditionalReverse.tsx
+++ b/website/src/views/components/ConditionalReverse.tsx
@@ -1,0 +1,12 @@
+import { FC, ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode[];
+  reverse: boolean;
+};
+
+const ConditionalReverse: FC<Props> = ({ children, reverse }) => (
+  <>{reverse ? [...children].reverse() : children}</>
+);
+
+export default ConditionalReverse;

--- a/website/src/views/modules/ModuleTree.scss
+++ b/website/src/views/modules/ModuleTree.scss
@@ -121,7 +121,7 @@ $connector-size: 0.75rem;
   }
 }
 
-.prereqBranch {
+.leftBranch {
   justify-content: flex-end;
   
   &::before,
@@ -131,7 +131,7 @@ $connector-size: 0.75rem;
   }
 }
 
-.prereqNode {
+.leftNode {
   margin: 0 $connector-size 1px 0;
 
   &::before {

--- a/website/src/views/modules/ModuleTree.scss
+++ b/website/src/views/modules/ModuleTree.scss
@@ -29,6 +29,7 @@ $connector-size: 0.75rem;
 .tree,
 .prereqTree {
   position: relative;
+  flex-shrink: 0;
   list-style: none;
   padding: 0;
   margin: 0.125rem 0;
@@ -121,6 +122,8 @@ $connector-size: 0.75rem;
 }
 
 .prereqBranch {
+  justify-content: flex-end;
+  
   &::before,
   &::after {
     right: 0;

--- a/website/src/views/modules/ModuleTree.test.tsx
+++ b/website/src/views/modules/ModuleTree.test.tsx
@@ -64,6 +64,20 @@ describe(ModuleTreeComponent, () => {
     expect(component).toMatchSnapshot('CS3244');
   });
 
+  test('should render prereq tree to the right when tree direction is set to right', () => {
+    const component = render(
+      <ModuleTreeComponent
+        moduleCode="PC2193"
+        getModuleCondensed={getModuleCondensed({ moduleBank: { moduleCodes: {} } } as any)}
+        prereqTreeOnLeft={false}
+        prereqTree="PC1101"
+        fulfillRequirements={['PC3193']}
+      />,
+    );
+
+    expect(component).toMatchSnapshot('PC2193');
+  });
+
   // Test that modules which are in moduleBank have appropriate colours,
   // and modules that aren't are greyed out
 

--- a/website/src/views/modules/ModuleTree.test.tsx
+++ b/website/src/views/modules/ModuleTree.test.tsx
@@ -12,7 +12,7 @@ describe(ModuleTreeComponent, () => {
       <ModuleTreeComponent
         moduleCode="ACC1002"
         getModuleCondensed={getModuleCondensed({ moduleBank: { moduleCodes: {} } } as any)}
-        prereqTreeOnLeft={false}
+        prereqTreeOnLeft
         fulfillRequirements={[
           'ACC1006',
           'ACC2002',
@@ -41,7 +41,7 @@ describe(ModuleTreeComponent, () => {
         moduleCode="CS3244"
         getModuleCondensed={getModuleCondensed({ moduleBank: { moduleCodes: {} } } as any)}
         fulfillRequirements={['CS5242', 'CS5339', 'CS6281']}
-        prereqTreeOnLeft={false}
+        prereqTreeOnLeft
         prereqTree={{
           and: [
             {
@@ -115,7 +115,7 @@ describe(ModuleTreeComponent, () => {
         moduleCode="CS4243"
         getModuleCondensed={getModuleCondensed({ moduleBank: { moduleCodes: testModules } } as any)}
         fulfillRequirements={['CS6240', 'CS3281', 'CS4243R']}
-        prereqTreeOnLeft={false}
+        prereqTreeOnLeft
         prereqTree={{
           and: [
             {

--- a/website/src/views/modules/ModuleTree.test.tsx
+++ b/website/src/views/modules/ModuleTree.test.tsx
@@ -12,6 +12,7 @@ describe(ModuleTreeComponent, () => {
       <ModuleTreeComponent
         moduleCode="ACC1002"
         getModuleCondensed={getModuleCondensed({ moduleBank: { moduleCodes: {} } } as any)}
+        prereqTreeOnLeft={false}
         fulfillRequirements={[
           'ACC1006',
           'ACC2002',
@@ -40,6 +41,7 @@ describe(ModuleTreeComponent, () => {
         moduleCode="CS3244"
         getModuleCondensed={getModuleCondensed({ moduleBank: { moduleCodes: {} } } as any)}
         fulfillRequirements={['CS5242', 'CS5339', 'CS6281']}
+        prereqTreeOnLeft={false}
         prereqTree={{
           and: [
             {
@@ -99,6 +101,7 @@ describe(ModuleTreeComponent, () => {
         moduleCode="CS4243"
         getModuleCondensed={getModuleCondensed({ moduleBank: { moduleCodes: testModules } } as any)}
         fulfillRequirements={['CS6240', 'CS3281', 'CS4243R']}
+        prereqTreeOnLeft={false}
         prereqTree={{
           and: [
             {

--- a/website/src/views/modules/ModuleTree.tsx
+++ b/website/src/views/modules/ModuleTree.tsx
@@ -91,7 +91,7 @@ const Branch: React.FC<{
   <ul className={styles.tree}>
     {props.nodes.map((child, idx) => (
       <li
-        className={classnames(styles.branch, { [styles.prereqBranch]: props.prereqTreeOnLeft })}
+        className={classnames(styles.branch, { [styles.leftBranch]: props.prereqTreeOnLeft })}
         key={typeof child === 'string' ? nodeName(child).name : idx}
       >
         <Tree
@@ -136,7 +136,7 @@ const Tree: React.FC<TreeDisplay> = (props) => {
     <div
       className={classnames(styles.node, styles.moduleNode, {
         [`hoverable color-${layer}`]: !!moduleActive,
-        [styles.prereqNode]: prereqTreeOnLeft,
+        [styles.leftNode]: prereqTreeOnLeft,
       })}
     >
       {prefix && <span className={styles.prefix}>{prefix}</span>}
@@ -155,7 +155,7 @@ export const ModuleTreeComponent: React.FC<Props> = (props) => {
           <ul className={classnames(styles.tree, styles.root)}>
             <li
               className={classnames(styles.branch, {
-                [styles.prereqBranch]: prereqTreeOnLeft,
+                [styles.leftBranch]: prereqTreeOnLeft,
               })}
             >
               <ConditionalReverse reverse={!prereqTreeOnLeft}>
@@ -181,7 +181,7 @@ export const ModuleTreeComponent: React.FC<Props> = (props) => {
                   <li
                     key={fulfilledModule}
                     className={classnames(styles.branch, {
-                      [styles.prereqBranch]: !prereqTreeOnLeft,
+                      [styles.leftBranch]: !prereqTreeOnLeft,
                     })}
                   >
                     <Tree

--- a/website/src/views/modules/ModuleTree.tsx
+++ b/website/src/views/modules/ModuleTree.tsx
@@ -152,7 +152,7 @@ export const ModuleTreeComponent: React.FC<Props> = (props) => {
     <>
       <div className={styles.container}>
         <ConditionalReverse reverse={!prereqTreeOnLeft}>
-          <ul className={classnames(styles.tree, styles.root)}>
+          <ul className={classnames(styles.prereqTree, styles.root)}>
             <li
               className={classnames(styles.branch, {
                 [styles.leftBranch]: prereqTreeOnLeft,
@@ -176,7 +176,7 @@ export const ModuleTreeComponent: React.FC<Props> = (props) => {
               <div className={classnames(styles.node, styles.conditional)}>
                 {prereqTreeOnLeft ? `unlocks` : `needs`}
               </div>
-              <ul className={styles.prereqTree}>
+              <ul className={styles.tree}>
                 {fulfillRequirements.map((fulfilledModule) => (
                   <li
                     key={fulfilledModule}

--- a/website/src/views/modules/ModuleTree.tsx
+++ b/website/src/views/modules/ModuleTree.tsx
@@ -10,12 +10,14 @@ import { State } from 'types/state';
 import { notNull } from 'types/utils';
 
 import LinkModuleCodes from 'views/components/LinkModuleCodes';
+import ConditionalReverse from 'views/components/ConditionalReverse';
 import styles from './ModuleTree.scss';
 
 type Props = {
   moduleCode: ModuleCode;
   fulfillRequirements?: readonly ModuleCode[];
   prereqTree?: PrereqTree;
+  prereqTreeOnLeft: boolean;
 
   getModuleCondensed: (moduleCode: ModuleCode) => ModuleCondensed | undefined;
 };
@@ -23,7 +25,7 @@ type Props = {
 interface TreeDisplay {
   layer: number;
   node: PrereqTree;
-  isPrereq?: boolean;
+  prereqTreeOnLeft?: boolean;
 
   getModuleCondensed: (moduleCode: ModuleCode) => ModuleCondensed | undefined;
 }
@@ -32,16 +34,16 @@ const GRADE_REQUIREMENT_SEPARATOR = ':';
 const MODULE_NAME_WILDCARD = '%';
 const PASSING_GRADE = 'D';
 
-const formatConditional = (node: PrereqTree) => {
+const formatConditional = (node: PrereqTree, prereqTreeOnLeft?: boolean) => {
   if (typeof node === 'string') return node;
   if ('nOf' in node) {
     const requiredNum = node.nOf[0];
-    return `at least ${requiredNum} of`;
+    return prereqTreeOnLeft ? `take at least ${requiredNum}` : `at least ${requiredNum} of`;
   }
   if ('or' in node) {
-    return 'one of';
+    return prereqTreeOnLeft ? 'take one' : `one of`;
   }
-  return 'all of';
+  return prereqTreeOnLeft ? 'take all' : `all of`;
 };
 
 type NodeName = {
@@ -83,39 +85,45 @@ const unwrapLayer = (node: PrereqTree) => {
 const Branch: React.FC<{
   nodes: PrereqTree[];
   layer: number;
+  prereqTreeOnLeft?: boolean;
   getModuleCondensed: (moduleCode: ModuleCode) => ModuleCondensed | undefined;
 }> = (props) => (
   <ul className={styles.tree}>
     {props.nodes.map((child, idx) => (
-      <li className={styles.branch} key={typeof child === 'string' ? nodeName(child).name : idx}>
-        <Tree node={child} layer={props.layer} getModuleCondensed={props.getModuleCondensed} />
+      <li
+        className={classnames(styles.branch, { [styles.prereqBranch]: props.prereqTreeOnLeft })}
+        key={typeof child === 'string' ? nodeName(child).name : idx}
+      >
+        <Tree
+          node={child}
+          layer={props.layer}
+          prereqTreeOnLeft={props.prereqTreeOnLeft}
+          getModuleCondensed={props.getModuleCondensed}
+        />
       </li>
     ))}
   </ul>
 );
 
 const Tree: React.FC<TreeDisplay> = (props) => {
-  const { layer, node, isPrereq } = props;
+  const { layer, node, prereqTreeOnLeft } = props;
 
   const isConditional = typeof node !== 'string';
   const { prefix, name } = nodeName(node);
 
   if (isConditional) {
     return (
-      <>
-        <div
-          className={classnames(styles.node, styles.conditional, {
-            [styles.prereqNode]: isPrereq,
-          })}
-        >
-          {formatConditional(node)}
-        </div>
+      <ConditionalReverse reverse={!prereqTreeOnLeft}>
         <Branch
           nodes={unwrapLayer(node)}
           layer={layer + 1}
+          prereqTreeOnLeft={prereqTreeOnLeft}
           getModuleCondensed={props.getModuleCondensed}
         />
-      </>
+        <div className={classnames(styles.node, styles.conditional)}>
+          {formatConditional(node, prereqTreeOnLeft)}
+        </div>
+      </ConditionalReverse>
     );
   }
 
@@ -128,7 +136,7 @@ const Tree: React.FC<TreeDisplay> = (props) => {
     <div
       className={classnames(styles.node, styles.moduleNode, {
         [`hoverable color-${layer}`]: !!moduleActive,
-        [styles.prereqNode]: isPrereq,
+        [styles.prereqNode]: prereqTreeOnLeft,
       })}
     >
       {prefix && <span className={styles.prefix}>{prefix}</span>}
@@ -138,46 +146,56 @@ const Tree: React.FC<TreeDisplay> = (props) => {
 };
 
 export const ModuleTreeComponent: React.FC<Props> = (props) => {
-  const { fulfillRequirements, prereqTree, moduleCode } = props;
+  const { fulfillRequirements, prereqTree, moduleCode, prereqTreeOnLeft } = props;
 
   return (
     <>
       <div className={styles.container}>
-        {fulfillRequirements && fulfillRequirements.length > 0 && (
-          <>
-            <ul className={styles.prereqTree}>
-              {fulfillRequirements.map((fulfilledModule) => (
-                <li
-                  key={fulfilledModule}
-                  className={classnames(styles.branch, styles.prereqBranch)}
-                >
-                  <Tree
-                    layer={0}
-                    node={fulfilledModule}
-                    isPrereq
+        <ConditionalReverse reverse={!prereqTreeOnLeft}>
+          <ul className={classnames(styles.tree, styles.root)}>
+            <li
+              className={classnames(styles.branch, {
+                [styles.prereqBranch]: prereqTreeOnLeft,
+              })}
+            >
+              <ConditionalReverse reverse={!prereqTreeOnLeft}>
+                {prereqTree && (
+                  <Branch
+                    nodes={[prereqTree]}
+                    layer={2}
+                    prereqTreeOnLeft={prereqTreeOnLeft}
                     getModuleCondensed={props.getModuleCondensed}
                   />
-                </li>
-              ))}
-            </ul>
-
-            <div className={classnames(styles.node, styles.conditional)}>needs</div>
-          </>
-        )}
-
-        <ul className={classnames(styles.tree, styles.root)}>
-          <li className={classnames(styles.branch)}>
-            <Tree layer={1} node={moduleCode} getModuleCondensed={props.getModuleCondensed} />
-
-            {prereqTree && (
-              <Branch
-                nodes={[prereqTree]}
-                layer={2}
-                getModuleCondensed={props.getModuleCondensed}
-              />
-            )}
-          </li>
-        </ul>
+                )}
+                <Tree layer={1} node={moduleCode} getModuleCondensed={props.getModuleCondensed} />
+              </ConditionalReverse>
+            </li>
+          </ul>
+          {fulfillRequirements && fulfillRequirements.length > 0 && (
+            <ConditionalReverse reverse={!prereqTreeOnLeft}>
+              <div className={classnames(styles.node, styles.conditional)}>
+                {prereqTreeOnLeft ? `unlocks` : `needs`}
+              </div>
+              <ul className={styles.prereqTree}>
+                {fulfillRequirements.map((fulfilledModule) => (
+                  <li
+                    key={fulfilledModule}
+                    className={classnames(styles.branch, {
+                      [styles.prereqBranch]: !prereqTreeOnLeft,
+                    })}
+                  >
+                    <Tree
+                      layer={0}
+                      node={fulfilledModule}
+                      prereqTreeOnLeft={!prereqTreeOnLeft}
+                      getModuleCondensed={props.getModuleCondensed}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </ConditionalReverse>
+          )}
+        </ConditionalReverse>
       </div>
 
       {/* <p className="alert alert-warning">
@@ -208,6 +226,7 @@ export const ModuleTreeComponent: React.FC<Props> = (props) => {
 
 const mapStateToProps = connect((state: State) => ({
   getModuleCondensed: getModuleCondensed(state),
+  prereqTreeOnLeft: state.settings.prereqTreeOnLeft,
 }));
 
 export default mapStateToProps(ModuleTreeComponent);

--- a/website/src/views/modules/__snapshots__/ModuleTree.test.tsx.snap
+++ b/website/src/views/modules/__snapshots__/ModuleTree.test.tsx.snap
@@ -9,10 +9,10 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
       class="prereqTree"
     >
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode hoverable color-0 prereqNode"
+          class="node moduleNode hoverable color-0 leftNode"
         >
           <mockedlink
             class="link"
@@ -22,10 +22,10 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -35,10 +35,10 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -277,10 +277,10 @@ exports[`ModuleTreeComponent should render prereq tree of module: CS3244 1`] = `
       class="prereqTree"
     >
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -290,10 +290,10 @@ exports[`ModuleTreeComponent should render prereq tree of module: CS3244 1`] = `
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -303,10 +303,10 @@ exports[`ModuleTreeComponent should render prereq tree of module: CS3244 1`] = `
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -649,10 +649,10 @@ exports[`ModuleTreeComponent should render prereq tree to the right when tree di
       class="prereqTree"
     >
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -735,10 +735,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
       class="prereqTree"
     >
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -748,10 +748,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -761,10 +761,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -774,10 +774,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -787,10 +787,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -800,10 +800,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -813,10 +813,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -826,10 +826,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -839,10 +839,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -852,10 +852,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -865,10 +865,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -878,10 +878,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -891,10 +891,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"
@@ -904,10 +904,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
         </div>
       </li>
       <li
-        class="branch prereqBranch"
+        class="branch leftBranch"
       >
         <div
-          class="node moduleNode prereqNode"
+          class="node moduleNode leftNode"
         >
           <mockedlink
             class="link"

--- a/website/src/views/modules/__snapshots__/ModuleTree.test.tsx.snap
+++ b/website/src/views/modules/__snapshots__/ModuleTree.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
     class="container"
   >
     <ul
-      class="tree root"
+      class="prereqTree root"
     >
       <li
         class="branch leftBranch"
@@ -201,7 +201,7 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
       unlocks
     </div>
     <ul
-      class="prereqTree"
+      class="tree"
     >
       <li
         class="branch"
@@ -274,7 +274,7 @@ exports[`ModuleTreeComponent should render prereq tree of module: CS3244 1`] = `
     class="container"
   >
     <ul
-      class="tree root"
+      class="prereqTree root"
     >
       <li
         class="branch leftBranch"
@@ -573,7 +573,7 @@ exports[`ModuleTreeComponent should render prereq tree of module: CS3244 1`] = `
       unlocks
     </div>
     <ul
-      class="prereqTree"
+      class="tree"
     >
       <li
         class="branch"
@@ -646,7 +646,7 @@ exports[`ModuleTreeComponent should render prereq tree to the right when tree di
     class="container"
   >
     <ul
-      class="prereqTree"
+      class="tree"
     >
       <li
         class="branch leftBranch"
@@ -668,7 +668,7 @@ exports[`ModuleTreeComponent should render prereq tree to the right when tree di
       needs
     </div>
     <ul
-      class="tree root"
+      class="prereqTree root"
     >
       <li
         class="branch"
@@ -732,7 +732,7 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
     class="container"
   >
     <ul
-      class="tree root"
+      class="prereqTree root"
     >
       <li
         class="branch leftBranch"
@@ -754,7 +754,7 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
       unlocks
     </div>
     <ul
-      class="prereqTree"
+      class="tree"
     >
       <li
         class="branch"

--- a/website/src/views/modules/__snapshots__/ModuleTree.test.tsx.snap
+++ b/website/src/views/modules/__snapshots__/ModuleTree.test.tsx.snap
@@ -6,98 +6,31 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
     class="container"
   >
     <ul
-      class="prereqTree"
-    >
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode hoverable color-0 leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            CS6240
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            CS3281
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            CS4243R
-          </mockedlink>
-        </div>
-      </li>
-    </ul>
-    <div
-      class="node conditional"
-    >
-      needs
-    </div>
-    <ul
       class="tree root"
     >
       <li
-        class="branch"
+        class="branch leftBranch"
       >
-        <div
-          class="node moduleNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            CS4243
-          </mockedlink>
-        </div>
         <ul
           class="tree"
         >
           <li
-            class="branch"
+            class="branch leftBranch"
           >
-            <div
-              class="node conditional"
-            >
-              all of
-            </div>
             <ul
               class="tree"
             >
               <li
-                class="branch"
+                class="branch leftBranch"
               >
-                <div
-                  class="node conditional"
-                >
-                  one of
-                </div>
                 <ul
                   class="tree"
                 >
                   <li
-                    class="branch"
+                    class="branch leftBranch"
                   >
                     <div
-                      class="node moduleNode"
+                      class="node moduleNode leftNode"
                     >
                       <mockedlink
                         class="link"
@@ -107,10 +40,10 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
                     </div>
                   </li>
                   <li
-                    class="branch"
+                    class="branch leftBranch"
                   >
                     <div
-                      class="node moduleNode hoverable color-4"
+                      class="node moduleNode hoverable color-4 leftNode"
                     >
                       <mockedlink
                         class="link"
@@ -120,10 +53,10 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
                     </div>
                   </li>
                   <li
-                    class="branch"
+                    class="branch leftBranch"
                   >
                     <div
-                      class="node moduleNode"
+                      class="node moduleNode leftNode"
                     >
                       <mockedlink
                         class="link"
@@ -133,32 +66,22 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
                     </div>
                   </li>
                   <li
-                    class="branch"
+                    class="branch leftBranch"
                   >
-                    <div
-                      class="node conditional"
-                    >
-                      all of
-                    </div>
                     <ul
                       class="tree"
                     >
                       <li
-                        class="branch"
+                        class="branch leftBranch"
                       >
-                        <div
-                          class="node conditional"
-                        >
-                          one of
-                        </div>
                         <ul
                           class="tree"
                         >
                           <li
-                            class="branch"
+                            class="branch leftBranch"
                           >
                             <div
-                              class="node moduleNode hoverable color-6"
+                              class="node moduleNode hoverable color-6 leftNode"
                             >
                               <mockedlink
                                 class="link"
@@ -168,10 +91,10 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
                             </div>
                           </li>
                           <li
-                            class="branch"
+                            class="branch leftBranch"
                           >
                             <div
-                              class="node moduleNode"
+                              class="node moduleNode leftNode"
                             >
                               <mockedlink
                                 class="link"
@@ -181,10 +104,10 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
                             </div>
                           </li>
                           <li
-                            class="branch"
+                            class="branch leftBranch"
                           >
                             <div
-                              class="node moduleNode hoverable color-6"
+                              class="node moduleNode hoverable color-6 leftNode"
                             >
                               <mockedlink
                                 class="link"
@@ -194,23 +117,23 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
                             </div>
                           </li>
                         </ul>
-                      </li>
-                      <li
-                        class="branch"
-                      >
                         <div
                           class="node conditional"
                         >
-                          one of
+                          take one
                         </div>
+                      </li>
+                      <li
+                        class="branch leftBranch"
+                      >
                         <ul
                           class="tree"
                         >
                           <li
-                            class="branch"
+                            class="branch leftBranch"
                           >
                             <div
-                              class="node moduleNode hoverable color-6"
+                              class="node moduleNode hoverable color-6 leftNode"
                             >
                               <mockedlink
                                 class="link"
@@ -220,10 +143,10 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
                             </div>
                           </li>
                           <li
-                            class="branch"
+                            class="branch leftBranch"
                           >
                             <div
-                              class="node moduleNode"
+                              class="node moduleNode leftNode"
                             >
                               <mockedlink
                                 class="link"
@@ -233,14 +156,91 @@ exports[`ModuleTreeComponent should grey out modules that are not in module bank
                             </div>
                           </li>
                         </ul>
+                        <div
+                          class="node conditional"
+                        >
+                          take one
+                        </div>
                       </li>
                     </ul>
+                    <div
+                      class="node conditional"
+                    >
+                      take all
+                    </div>
                   </li>
                 </ul>
+                <div
+                  class="node conditional"
+                >
+                  take one
+                </div>
               </li>
             </ul>
+            <div
+              class="node conditional"
+            >
+              take all
+            </div>
           </li>
         </ul>
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            CS4243
+          </mockedlink>
+        </div>
+      </li>
+    </ul>
+    <div
+      class="node conditional"
+    >
+      unlocks
+    </div>
+    <ul
+      class="prereqTree"
+    >
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode hoverable color-0"
+        >
+          <mockedlink
+            class="link"
+          >
+            CS6240
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            CS3281
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            CS4243R
+          </mockedlink>
+        </div>
       </li>
     </ul>
   </div>,
@@ -274,44 +274,295 @@ exports[`ModuleTreeComponent should render prereq tree of module: CS3244 1`] = `
     class="container"
   >
     <ul
-      class="prereqTree"
+      class="tree root"
     >
       <li
         class="branch leftBranch"
       >
+        <ul
+          class="tree"
+        >
+          <li
+            class="branch leftBranch"
+          >
+            <ul
+              class="tree"
+            >
+              <li
+                class="branch leftBranch"
+              >
+                <ul
+                  class="tree"
+                >
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        CS2010
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        CS2020
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        CS2040
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        CS2040C
+                      </mockedlink>
+                    </div>
+                  </li>
+                </ul>
+                <div
+                  class="node conditional"
+                >
+                  take one
+                </div>
+              </li>
+              <li
+                class="branch leftBranch"
+              >
+                <ul
+                  class="tree"
+                >
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        ESP1107
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        ESP2107
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        ST1232
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        ST2131
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        ST2132
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        ST2334
+                      </mockedlink>
+                    </div>
+                  </li>
+                </ul>
+                <div
+                  class="node conditional"
+                >
+                  take one
+                </div>
+              </li>
+              <li
+                class="branch leftBranch"
+              >
+                <ul
+                  class="tree"
+                >
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        MA1101R
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        MA1311
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        MA1506
+                      </mockedlink>
+                    </div>
+                  </li>
+                </ul>
+                <div
+                  class="node conditional"
+                >
+                  take one
+                </div>
+              </li>
+              <li
+                class="branch leftBranch"
+              >
+                <ul
+                  class="tree"
+                >
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        MA1102R
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        MA1505
+                      </mockedlink>
+                    </div>
+                  </li>
+                  <li
+                    class="branch leftBranch"
+                  >
+                    <div
+                      class="node moduleNode leftNode"
+                    >
+                      <mockedlink
+                        class="link"
+                      >
+                        MA1521
+                      </mockedlink>
+                    </div>
+                  </li>
+                </ul>
+                <div
+                  class="node conditional"
+                >
+                  take one
+                </div>
+              </li>
+            </ul>
+            <div
+              class="node conditional"
+            >
+              take all
+            </div>
+          </li>
+        </ul>
         <div
-          class="node moduleNode leftNode"
+          class="node moduleNode"
         >
           <mockedlink
             class="link"
           >
-            CS5242
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            CS5339
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            CS6281
+            CS3244
           </mockedlink>
         </div>
       </li>
@@ -319,10 +570,10 @@ exports[`ModuleTreeComponent should render prereq tree of module: CS3244 1`] = `
     <div
       class="node conditional"
     >
-      needs
+      unlocks
     </div>
     <ul
-      class="tree root"
+      class="prereqTree"
     >
       <li
         class="branch"
@@ -333,286 +584,35 @@ exports[`ModuleTreeComponent should render prereq tree of module: CS3244 1`] = `
           <mockedlink
             class="link"
           >
-            CS3244
+            CS5242
           </mockedlink>
         </div>
-        <ul
-          class="tree"
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
         >
-          <li
-            class="branch"
+          <mockedlink
+            class="link"
           >
-            <div
-              class="node conditional"
-            >
-              all of
-            </div>
-            <ul
-              class="tree"
-            >
-              <li
-                class="branch"
-              >
-                <div
-                  class="node conditional"
-                >
-                  one of
-                </div>
-                <ul
-                  class="tree"
-                >
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        CS2010
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        CS2020
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        CS2040
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        CS2040C
-                      </mockedlink>
-                    </div>
-                  </li>
-                </ul>
-              </li>
-              <li
-                class="branch"
-              >
-                <div
-                  class="node conditional"
-                >
-                  one of
-                </div>
-                <ul
-                  class="tree"
-                >
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        ESP1107
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        ESP2107
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        ST1232
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        ST2131
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        ST2132
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        ST2334
-                      </mockedlink>
-                    </div>
-                  </li>
-                </ul>
-              </li>
-              <li
-                class="branch"
-              >
-                <div
-                  class="node conditional"
-                >
-                  one of
-                </div>
-                <ul
-                  class="tree"
-                >
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        MA1101R
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        MA1311
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        MA1506
-                      </mockedlink>
-                    </div>
-                  </li>
-                </ul>
-              </li>
-              <li
-                class="branch"
-              >
-                <div
-                  class="node conditional"
-                >
-                  one of
-                </div>
-                <ul
-                  class="tree"
-                >
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        MA1102R
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        MA1505
-                      </mockedlink>
-                    </div>
-                  </li>
-                  <li
-                    class="branch"
-                  >
-                    <div
-                      class="node moduleNode"
-                    >
-                      <mockedlink
-                        class="link"
-                      >
-                        MA1521
-                      </mockedlink>
-                    </div>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </li>
-        </ul>
+            CS5339
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            CS6281
+          </mockedlink>
+        </div>
       </li>
     </ul>
   </div>,
@@ -732,187 +732,18 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
     class="container"
   >
     <ul
-      class="prereqTree"
+      class="tree root"
     >
       <li
         class="branch leftBranch"
       >
         <div
-          class="node moduleNode leftNode"
+          class="node moduleNode"
         >
           <mockedlink
             class="link"
           >
-            ACC1006
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            ACC2002
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            ACC3601
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            ACC3603
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            ACC3605
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            ACC3616
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            FIN2004
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            FIN2004X
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            FIN3113
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            FIN3130
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            IS5116
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            ACC3611
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            FIN3132
-          </mockedlink>
-        </div>
-      </li>
-      <li
-        class="branch leftBranch"
-      >
-        <div
-          class="node moduleNode leftNode"
-        >
-          <mockedlink
-            class="link"
-          >
-            FIN4115
+            ACC1002
           </mockedlink>
         </div>
       </li>
@@ -920,10 +751,10 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
     <div
       class="node conditional"
     >
-      needs
+      unlocks
     </div>
     <ul
-      class="tree root"
+      class="prereqTree"
     >
       <li
         class="branch"
@@ -934,7 +765,176 @@ exports[`ModuleTreeComponent should render requirements fulfilled tree of module
           <mockedlink
             class="link"
           >
-            ACC1002
+            ACC1006
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            ACC2002
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            ACC3601
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            ACC3603
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            ACC3605
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            ACC3616
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            FIN2004
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            FIN2004X
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            FIN3113
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            FIN3130
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            IS5116
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            ACC3611
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            FIN3132
+          </mockedlink>
+        </div>
+      </li>
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            FIN4115
           </mockedlink>
         </div>
       </li>

--- a/website/src/views/modules/__snapshots__/ModuleTree.test.tsx.snap
+++ b/website/src/views/modules/__snapshots__/ModuleTree.test.tsx.snap
@@ -640,6 +640,92 @@ exports[`ModuleTreeComponent should render prereq tree of module: CS3244 1`] = `
 ]
 `;
 
+exports[`ModuleTreeComponent should render prereq tree to the right when tree direction is set to right: PC2193 1`] = `
+[
+  <div
+    class="container"
+  >
+    <ul
+      class="prereqTree"
+    >
+      <li
+        class="branch prereqBranch"
+      >
+        <div
+          class="node moduleNode prereqNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            PC3193
+          </mockedlink>
+        </div>
+      </li>
+    </ul>
+    <div
+      class="node conditional"
+    >
+      needs
+    </div>
+    <ul
+      class="tree root"
+    >
+      <li
+        class="branch"
+      >
+        <div
+          class="node moduleNode"
+        >
+          <mockedlink
+            class="link"
+          >
+            PC2193
+          </mockedlink>
+        </div>
+        <ul
+          class="tree"
+        >
+          <li
+            class="branch"
+          >
+            <div
+              class="node moduleNode"
+            >
+              <mockedlink
+                class="link"
+              >
+                PC1101
+              </mockedlink>
+            </div>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>,
+  <p
+    class="alert alert-warning"
+  >
+    This new version of the prerequisite tree is being tested and may not be accurate. Viewers are encouraged to double check details with the prerequisite text above. To report bugs with the new tree, please post a bug report on GitHub (preferred) at 
+    <a
+      href="https://github.com/nusmodifications/nusmods/issues/new/choose"
+      rel="noopener noreferrer nofollow"
+      target="_blank"
+    >
+      our repository
+    </a>
+     or send an email to 
+    <a
+      href="mailto:bugs@nusmods.com"
+      rel="noopener noreferrer nofollow"
+      target="_blank"
+    >
+      bugs@nusmods.com
+    </a>
+    .
+  </p>,
+]
+`;
+
 exports[`ModuleTreeComponent should render requirements fulfilled tree of module: ACC1002 1`] = `
 [
   <div

--- a/website/src/views/settings/SettingsContainer.tsx
+++ b/website/src/views/settings/SettingsContainer.tsx
@@ -20,6 +20,7 @@ import {
   setModRegScheduleType,
   toggleBetaTesting,
   toggleModRegNotificationGlobally,
+  togglePreReqTreeDirection,
 } from 'actions/settings';
 import Timetable from 'views/timetable/Timetable';
 import Title from 'views/components/Title';
@@ -46,6 +47,7 @@ type Props = {
   betaTester: boolean;
   loadDisqusManually: boolean;
   modRegNotification: ModRegNotificationSettings;
+  prereqTreeOnLeft: boolean;
 
   selectTheme: (theme: ThemeId) => void;
   selectColorScheme: (colorScheme: ColorSchemePreference) => void;
@@ -57,6 +59,8 @@ type Props = {
   toggleModRegNotificationGlobally: (enabled: boolean) => void;
   enableModRegNotification: (round: RegPeriod) => void;
   dismissModregNotification: (round: RegPeriod) => void;
+
+  togglePreReqTreeDirection: (status: boolean) => void;
 };
 
 const SettingsContainer: React.FC<Props> = ({
@@ -65,6 +69,7 @@ const SettingsContainer: React.FC<Props> = ({
   betaTester,
   loadDisqusManually,
   modRegNotification,
+  prereqTreeOnLeft,
   ...props
 }) => {
   const [allowTracking, setAllowTracking] = useState(true);
@@ -142,6 +147,26 @@ const SettingsContainer: React.FC<Props> = ({
             onSelectTheme={props.selectTheme}
           />
         ))}
+      </div>
+
+      <hr />
+
+      <h4 id="prereqTreeDirection">Prerequisite Tree Direction</h4>
+
+      <div className={styles.toggleRow}>
+        <div className={styles.toggleDescription}>
+          <p>
+            You can choose whether prequisites for a course will appear to the left or to the right
+            of the prerequisite tree when viewing a course.
+          </p>
+        </div>
+        <div className={styles.toggle}>
+          <Toggle
+            labels={['Left', 'Right']}
+            isOn={prereqTreeOnLeft}
+            onChange={props.togglePreReqTreeDirection}
+          />
+        </div>
       </div>
 
       <hr />
@@ -299,6 +324,7 @@ const mapStateToProps = (state: StoreState) => ({
   betaTester: state.settings.beta || false,
   loadDisqusManually: state.settings.loadDisqusManually,
   modRegNotification: state.settings.modRegNotification,
+  prereqTreeOnLeft: state.settings.prereqTreeOnLeft,
 });
 
 const connectedSettings = connect(mapStateToProps, {
@@ -311,6 +337,7 @@ const connectedSettings = connect(mapStateToProps, {
   dismissModregNotification,
   enableModRegNotification,
   setModRegScheduleType,
+  togglePreReqTreeDirection,
 })(SettingsContainer);
 
 export default deferComponentRender(connectedSettings);


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
Fixes #3202 Prerequisite tree right-to-left progression is confusing
<!-- Or provide a brief explanation about the problem -->

## Implementation
<!-- Explain how your solution solves the problem -->
This PR extends PR #3840's implementation and adds a toggle for the user to choose whether they prefer the prerequisite to appear on the left or the right. Setting defaults to prerequisites on the left, which is the requested specifications for #3202.

While Issue #3203 specifications does not ask for ability to toggle, some users like myself may have already gotten used to prerequisites on the right. However, I do agree that the prerequisites on the right seems to be more intuitive.

I also took the chance to fix some confusing naming in the code, like the trees having class names that were opposite of what they contained. The fix for the [truncation bug](https://github.com/nusmodifications/nusmods/pull/3840#issuecomment-2431408972) in PR #3840 is also carried over.

Credits to @sciffany for copywriting and initial implementation, to @li-kai for implementation feedback and to @alvynben for implementation and test cases.

## UI tests
<!-- If it affects UI, an image or gif is greatly encouraged. -->
### Settings toggle:
![image](https://github.com/user-attachments/assets/5c5a90f5-3196-476e-ae17-10814a98ae76)

### Single prerequisite/dependents:
**Left**
![image](https://github.com/user-attachments/assets/6b8c55cb-f219-4b59-8745-b1faede74645)

**Right**, i.e. original layout (unchanged)
![image](https://github.com/user-attachments/assets/21525c80-6037-4632-b089-a7e5c8263775)

### Complex prerequisite/dependents with uneven layers and uneven letters in module codes
**Left**
![image](https://github.com/user-attachments/assets/10c126d5-369d-4327-bb60-cd68305c1092)

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
#### Any questions you may have
Is there a tele group specific for development?
#### Letting us know that you're new to this (so we know how much to help out)
Again, been almost 3 years since I touched any web dev. Sorry in advance if I had missed out anything.