### PR TITLE
website: Add exam duration to timetable

### DIFF
--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -18,7 +18,13 @@ import {
   selectModuleColor,
   showLessonInTimetable,
 } from 'actions/timetables';
-import { getExamDate, getFormattedExamDate, renderMCs, getExamDuration, renderExamDuration } from 'utils/modules';
+import {
+  getExamDate,
+  getFormattedExamDate,
+  renderMCs,
+  getExamDuration,
+  renderExamDuration,
+} from 'utils/modules';
 import { intersperse } from 'utils/array';
 import { BULLET_NBSP } from 'utils/react';
 import { modulePage } from 'views/routes/paths';
@@ -100,18 +106,15 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
     // Second row of text consists of the exam date and the MCs
     const secondRowText = [renderMCs(module.moduleCredit)];
     if (config.examAvailabilitySet.has(semester)) {
-  
-      const examDuration = getExamDuration(module,semester);
+      const examDuration = getExamDuration(module, semester);
       const examDate = getExamDate(module, semester);
 
       if (examDuration) {
-        secondRowText.unshift(renderExamDuration(examDuration))
+        secondRowText.unshift(renderExamDuration(examDuration));
       }
 
       secondRowText.unshift(
-        examDate
-          ? `Exam: ${getFormattedExamDate(module, semester)}`
-          : 'No Exam',
+        examDate ? `Exam: ${getFormattedExamDate(module, semester)}` : 'No Exam',
       );
     }
 

--- a/website/src/views/timetable/TimetableModulesTable.tsx
+++ b/website/src/views/timetable/TimetableModulesTable.tsx
@@ -18,7 +18,7 @@ import {
   selectModuleColor,
   showLessonInTimetable,
 } from 'actions/timetables';
-import { getExamDate, getFormattedExamDate, renderMCs } from 'utils/modules';
+import { getExamDate, getFormattedExamDate, renderMCs, getExamDuration, renderExamDuration } from 'utils/modules';
 import { intersperse } from 'utils/array';
 import { BULLET_NBSP } from 'utils/react';
 import { modulePage } from 'views/routes/paths';
@@ -100,8 +100,16 @@ export const TimetableModulesTableComponent: React.FC<Props> = (props) => {
     // Second row of text consists of the exam date and the MCs
     const secondRowText = [renderMCs(module.moduleCredit)];
     if (config.examAvailabilitySet.has(semester)) {
+  
+      const examDuration = getExamDuration(module,semester);
+      const examDate = getExamDate(module, semester);
+
+      if (examDuration) {
+        secondRowText.unshift(renderExamDuration(examDuration))
+      }
+
       secondRowText.unshift(
-        getExamDate(module, semester)
+        examDate
           ? `Exam: ${getFormattedExamDate(module, semester)}`
           : 'No Exam',
       );


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
Fixes #3876 
Exam duration was not shown in the timetable and that annoyed me

## Implementation
Rendered exam duration if it exists 

<img width="516" alt="exam_duration" src="https://github.com/user-attachments/assets/5c3583c7-5b69-42e1-a607-38a217791034">


## Other Information

[cdda6d72c8ea67e40a408629aa9c86fe](https://github.com/user-attachments/assets/e696d921-1c80-4206-9abb-9c4059c670f9)

