### PR TITLE
Fix TA mode for lecture lessons

### DIFF
--- a/export/src/types.ts
+++ b/export/src/types.ts
@@ -12,9 +12,11 @@ export type ThemeState = Readonly<{
 }>;
 export type ColorScheme = 'LIGHT_COLOR_SCHEME' | 'DARK_COLOR_SCHEME';
 export type Semester = number;
-export type ClassNo = string; // E.g. "1", "A"
-export type LessonType = string; // E.g. "Lecture", "Tutorial"
 export type ModuleCode = string; // E.g. "CS3216"
+export type LessonType = string; // E.g. "Lecture", "Tutorial"
+export type ClassNo = string; // E.g. "1", "A"
+export type StartTime = string;
+export type DayText = string;
 export type SemTimetableConfig = {
   [moduleCode: ModuleCode]: ModuleLessonConfig;
 };
@@ -22,7 +24,12 @@ export interface ModuleLessonConfig {
   [lessonType: LessonType]: ClassNo;
 }
 export type TaModulesConfig = {
-  [moduleCode: ModuleCode]: [lessonType: LessonType, classNo: ClassNo][];
+  [moduleCode: ModuleCode]: [
+    lessonType: LessonType,
+    classNo: ClassNo,
+    startTime: StartTime,
+    day: DayText,
+  ][];
 };
 
 // `ExportData` is duplicated from `website/src/types/export.ts`.

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -9,7 +9,15 @@ import type {
 } from 'types/timetables';
 import type { Dispatch, GetState } from 'types/redux';
 import type { ColorMapping } from 'types/reducers';
-import type { ClassNo, LessonType, Module, ModuleCode, Semester } from 'types/modules';
+import type {
+  ClassNo,
+  DayText,
+  LessonType,
+  Module,
+  ModuleCode,
+  Semester,
+  StartTime,
+} from 'types/modules';
 
 import { fetchModule } from 'actions/moduleBank';
 import { openNotification } from 'actions/app';
@@ -279,10 +287,12 @@ export function addTaLessonInTimetable(
   moduleCode: ModuleCode,
   lessonType: LessonType,
   classNo: ClassNo,
+  startTime: StartTime,
+  day: DayText,
 ) {
   return {
     type: ADD_TA_LESSON_IN_TIMETABLE,
-    payload: { semester, moduleCode, lessonType, classNo },
+    payload: { semester, moduleCode, lessonType, classNo, startTime, day },
   };
 }
 
@@ -292,10 +302,12 @@ export function removeTaLessonInTimetable(
   moduleCode: ModuleCode,
   lessonType: LessonType,
   classNo: ClassNo,
+  startTime: StartTime,
+  day: DayText,
 ) {
   return {
     type: REMOVE_TA_LESSON_IN_TIMETABLE,
-    payload: { semester, moduleCode, lessonType, classNo },
+    payload: { semester, moduleCode, lessonType, classNo, startTime, day },
   };
 }
 

--- a/website/src/reducers/index.test.ts
+++ b/website/src/reducers/index.test.ts
@@ -30,7 +30,7 @@ const exportData: ExportData = {
   },
   hidden: ['PC1222'],
   ta: {
-    CS1010S: [['Tutorial', '1']],
+    CS1010S: [['Tutorial', '1', '0900', 'Monday']],
   },
   theme: {
     id: 'google',
@@ -79,7 +79,7 @@ test('reducers should set export data state', () => {
     hidden: { [1]: ['PC1222'] },
     ta: {
       [1]: {
-        CS1010S: [['Tutorial', '1']],
+        CS1010S: [['Tutorial', '1', '0900', 'Monday']],
       },
     },
     academicYear: expect.any(String),

--- a/website/src/reducers/timetables.test.ts
+++ b/website/src/reducers/timetables.test.ts
@@ -129,16 +129,22 @@ describe('hidden module reducer', () => {
 describe('TA module reducer', () => {
   const withTaModules: TimetablesState = {
     ...initialState,
-    ta: { [1]: { CS1010S: [['Tutorial', '1']] }, [2]: { CS1010S: [['Tutorial', '1']] } },
+    ta: {
+      [1]: { CS1010S: [['Tutorial', '1', '0900', 'Monday']] },
+      [2]: { CS1010S: [['Tutorial', '1', '0900', 'Monday']] },
+    },
   };
 
   test('should update TA modules', () => {
     expect(
-      reducer(initialState, addTaLessonInTimetable(1, 'CS3216', 'Tutorial', '1')),
-    ).toHaveProperty('ta.1', { CS3216: [['Tutorial', '1']] });
+      reducer(initialState, addTaLessonInTimetable(1, 'CS3216', 'Tutorial', '1', '0900', 'Monday')),
+    ).toHaveProperty('ta.1', { CS3216: [['Tutorial', '1', '0900', 'Monday']] });
 
     expect(
-      reducer(initialState, removeTaLessonInTimetable(1, 'CS1010S', 'Tutorial', '1')),
+      reducer(
+        initialState,
+        removeTaLessonInTimetable(1, 'CS1010S', 'Tutorial', '1', '0900', 'Monday'),
+      ),
     ).toMatchObject({
       ta: {
         [1]: {},
@@ -146,11 +152,14 @@ describe('TA module reducer', () => {
     });
 
     expect(
-      reducer(withTaModules, removeTaLessonInTimetable(1, 'CS1010S', 'Tutorial', '1')),
+      reducer(
+        withTaModules,
+        removeTaLessonInTimetable(1, 'CS1010S', 'Tutorial', '1', '0900', 'Monday'),
+      ),
     ).toMatchObject({
       ta: {
         [1]: {},
-        [2]: { CS1010S: [['Tutorial', '1']] },
+        [2]: { CS1010S: [['Tutorial', '1', '0900', 'Monday']] },
       },
     });
   });
@@ -160,14 +169,17 @@ describe('TA module reducer', () => {
       reducer(
         {
           ...initialState,
-          ta: { [1]: { CS1010S: [['Tutorial', '1']] }, [2]: { CS1010S: [['Tutorial', '1']] } },
+          ta: {
+            [1]: { CS1010S: [['Tutorial', '1', '0900', 'Monday']] },
+            [2]: { CS1010S: [['Tutorial', '1', '0900', 'Monday']] },
+          },
         },
         removeModule(1, 'CS1010S'),
       ),
     ).toMatchObject({
       ta: {
         [1]: {},
-        [2]: { CS1010S: [['Tutorial', '1']] },
+        [2]: { CS1010S: [['Tutorial', '1', '0900', 'Monday']] },
       },
     });
   });

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -192,6 +192,13 @@ function semTaModules(state = DEFAULT_TA_STATE, action: Actions): TaModulesConfi
     case ADD_TA_LESSON_IN_TIMETABLE: {
       const { moduleCode, lessonType, classNo } = action.payload;
       if (!(moduleCode && lessonType && classNo)) return state;
+      // Prevent duplicate lessons
+      if (moduleCode in state) {
+        const isDuplicate = state[moduleCode].some((lesson) =>
+          isEqual(lesson, [lessonType, classNo]),
+        );
+        if (isDuplicate) return state;
+      }
       return {
         ...state,
         [moduleCode]: [...(state[moduleCode] ?? []), [lessonType, classNo]],

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -49,9 +49,18 @@ export const persistConfig = {
       // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
       _persist: state?._persist!,
     }),
+    3: (state) => ({
+      ...state,
+      ta: {},
+      // FIXME: Remove the next line when _persist is optional again.
+      // Cause: https://github.com/rt2zz/redux-persist/pull/919
+      // Issue: https://github.com/rt2zz/redux-persist/pull/1170
+      // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
+      _persist: state?._persist!,
+    }),
   }),
   /* eslint-enable */
-  version: 2,
+  version: 3,
 
   // Our own state reconciler archives old timetables if the acad year is different,
   // otherwise use the persisted timetable state
@@ -190,27 +199,27 @@ function semTaModules(state = DEFAULT_TA_STATE, action: Actions): TaModulesConfi
 
   switch (action.type) {
     case ADD_TA_LESSON_IN_TIMETABLE: {
-      const { moduleCode, lessonType, classNo } = action.payload;
+      const { moduleCode, lessonType, classNo, startTime, day } = action.payload;
       if (!(moduleCode && lessonType && classNo)) return state;
       // Prevent duplicate lessons
       if (moduleCode in state) {
-        const isDuplicate = state[moduleCode].some((lesson) =>
-          isEqual(lesson, [lessonType, classNo]),
+        const isDuplicate = state[moduleCode].some((existingConfig) =>
+          isEqual(existingConfig, [lessonType, classNo, startTime, day]),
         );
         if (isDuplicate) return state;
       }
       return {
         ...state,
-        [moduleCode]: [...(state[moduleCode] ?? []), [lessonType, classNo]],
+        [moduleCode]: [...(state[moduleCode] ?? []), [lessonType, classNo, startTime, day]],
       };
     }
     case REMOVE_TA_LESSON_IN_TIMETABLE: {
-      const { moduleCode, lessonType, classNo } = action.payload;
+      const { moduleCode, lessonType, classNo, startTime, day } = action.payload;
       if (!(moduleCode && lessonType && classNo)) return state;
       return {
         ...state,
         [moduleCode]: state[moduleCode]?.filter(
-          (lesson) => !isEqual(lesson, [lessonType, classNo]),
+          (lesson) => !isEqual(lesson, [lessonType, classNo, startTime, day]),
         ),
       };
     }

--- a/website/src/types/timetables.ts
+++ b/website/src/types/timetables.ts
@@ -1,4 +1,12 @@
-import { ClassNo, LessonType, ModuleCode, ModuleTitle, RawLesson } from './modules';
+import {
+  ClassNo,
+  DayText,
+  LessonType,
+  ModuleCode,
+  ModuleTitle,
+  RawLesson,
+  StartTime,
+} from './modules';
 
 //  ModuleLessonConfig is a mapping of lessonType to ClassNo for a module.
 export type ModuleLessonConfig = {
@@ -11,8 +19,14 @@ export type SemTimetableConfig = {
 };
 
 // TaModulesConfig is a mapping of moduleCode to the TA's lesson types.
+// startTime and day are needed since some modules (e.g. CS2103T) map a single classNo to multiple lessons.
 export type TaModulesConfig = {
-  [moduleCode: ModuleCode]: [lessonType: LessonType, classNo: ClassNo][];
+  [moduleCode: ModuleCode]: [
+    lessonType: LessonType,
+    classNo: ClassNo,
+    startTime: StartTime,
+    day: DayText,
+  ][];
 };
 
 //  ModuleLessonConfigWithLessons is a mapping of lessonType to an array of Lessons for a module.
@@ -67,9 +81,11 @@ export type TimetableArrangement = {
 // Represents the lesson which the user is currently hovering over.
 // Used to highlight lessons which have the same classNo
 export type HoverLesson = {
-  readonly classNo: ClassNo;
   readonly moduleCode: ModuleCode;
   readonly lessonType: LessonType;
+  readonly classNo: ClassNo;
+  readonly startTime: StartTime;
+  readonly day: DayText;
 };
 
 export type ColorIndex = number;

--- a/website/src/utils/ical.test.ts
+++ b/website/src/utils/ical.test.ts
@@ -366,7 +366,7 @@ describe(iCalForTimetable, () => {
       CS3216,
     };
     const actual = iCalForTimetable(1, mockTimetable, moduleData, [], {
-      CS1010S: [['Tutorial', '1']],
+      CS1010S: [['Tutorial', '1', '0800', 'Monday']],
     });
     // 5 lesson types for cs1010s, 1 for cs3216 (1 exam for cs1010s will be excluded)
     expect(actual).toHaveLength(6);

--- a/website/src/utils/timetables.test.ts
+++ b/website/src/utils/timetables.test.ts
@@ -108,9 +108,9 @@ test('hydrateTaModulesConfigWithLessons should replace ClassNo with lessons', ()
   const modules: ModulesMap = { [moduleCode]: CS1010S };
   const taModules: TaModulesConfig = {
     [moduleCode]: [
-      ['Tutorial', '1'],
-      ['Tutorial', '8'],
-      ['Recitation', '4'],
+      ['Tutorial', '1', '0900', 'Monday'],
+      ['Tutorial', '8', '1600', 'Monday'],
+      ['Recitation', '4', '1700', 'Thursday'],
     ],
   };
 
@@ -120,8 +120,14 @@ test('hydrateTaModulesConfigWithLessons should replace ClassNo with lessons', ()
     sem,
   );
   expect(configWithLessons[moduleCode].Tutorial[0].classNo).toBe('1');
+  expect(configWithLessons[moduleCode].Tutorial[0].startTime).toBe('0900');
+  expect(configWithLessons[moduleCode].Tutorial[0].day).toBe('Monday');
   expect(configWithLessons[moduleCode].Tutorial[1].classNo).toBe('8');
+  expect(configWithLessons[moduleCode].Tutorial[1].startTime).toBe('1600');
+  expect(configWithLessons[moduleCode].Tutorial[1].day).toBe('Monday');
   expect(configWithLessons[moduleCode].Recitation[0].classNo).toBe('4');
+  expect(configWithLessons[moduleCode].Recitation[0].startTime).toBe('1700');
+  expect(configWithLessons[moduleCode].Recitation[0].day).toBe('Thursday');
   expect(configWithLessons[moduleCode]).not.toHaveProperty('Lecture');
 });
 

--- a/website/src/utils/timetables.ts
+++ b/website/src/utils/timetables.ts
@@ -153,12 +153,17 @@ export function hydrateTaModulesConfigWithLessons(
           module,
           semester,
         );
-        if (!(lessonType in moduleLessonConfigWithLessons)) {
-          moduleLessonConfigWithLessons[lessonType] = [];
-        }
+
         const moduleConfigForLessonType = moduleConfigWithLessons[lessonType].filter(
           (lesson) => lesson.startTime === startTime && lesson.day === day,
         );
+        if (isEmpty(moduleConfigForLessonType)) {
+          return;
+        }
+
+        if (!(lessonType in moduleLessonConfigWithLessons)) {
+          moduleLessonConfigWithLessons[lessonType] = [];
+        }
         moduleLessonConfigWithLessons[lessonType].push(...moduleConfigForLessonType);
       });
       return moduleLessonConfigWithLessons;

--- a/website/src/views/timetable/ModulesTableFooter.test.tsx
+++ b/website/src/views/timetable/ModulesTableFooter.test.tsx
@@ -20,7 +20,7 @@ describe(countShownMCs, () => {
     const modules = [BFS1001, CS1010S, CS3216];
     const taInTimetable: TaModulesConfig = {
       [CS1010S.moduleCode]: [],
-      [CS3216.moduleCode]: [['Tutorial', '1']],
+      [CS3216.moduleCode]: [['Tutorial', '1', '0900', 'Monday']],
     };
     expect(countShownMCs(modules, [], taInTimetable)).toEqual(4);
   });

--- a/website/src/views/timetable/ShareTimetable.test.tsx
+++ b/website/src/views/timetable/ShareTimetable.test.tsx
@@ -164,14 +164,14 @@ describe('ShareTimetable', () => {
         timetable={timetable}
         hiddenModules={[]}
         taModules={{
-          MA1521: [['Tutorial', '1']],
+          MA1521: [['Tutorial', '1', '0800', 'Monday']],
           CS1010S: [
-            ['Tutorial', '1'],
-            ['Laboratory', '1'],
+            ['Tutorial', '1', '0800', 'Tuesday'],
+            ['Laboratory', '1', '1000', 'Wednesday'],
           ],
-          CS1231S: [
-            ['Tutorial', '2'],
-            ['Tutorial', '3'],
+          CS2103T: [
+            ['Lecture', 'G12', '0800', 'Thursday'],
+            ['Lecture', 'G12', '1700', 'Friday'],
           ],
         }}
       />,
@@ -180,7 +180,7 @@ describe('ShareTimetable', () => {
     await openAndWait(wrapper);
 
     expect(wrapper.find('input').prop('value')).toContain(
-      'ta=MA1521(TUT:1),CS1010S(TUT:1,LAB:1),CS1231S(TUT:2,TUT:3)',
+      'ta=MA1521(TUT:1:0800:0),CS1010S(TUT:1:0800:1,LAB:1:1000:2),CS2103T(LEC:G12:0800:3,LEC:G12:1700:4)',
     );
   });
 

--- a/website/src/views/timetable/TimetableCell.test.tsx
+++ b/website/src/views/timetable/TimetableCell.test.tsx
@@ -65,8 +65,10 @@ describe(TimetableCell, () => {
     const { wrapper } = make({
       hoverLesson: {
         moduleCode: 'CS1010',
-        classNo: '1',
         lessonType: 'Lecture',
+        classNo: '1',
+        startTime: '1000',
+        day: 'Wednesday',
       },
     });
 
@@ -80,8 +82,10 @@ describe(TimetableCell, () => {
     button = make({
       hoverLesson: {
         moduleCode: 'CS1010',
-        classNo: '1',
         lessonType: 'Tutorial',
+        classNo: '1',
+        startTime: '0900',
+        day: 'Monday',
       },
     })
       .wrapper.find('button')
@@ -94,6 +98,8 @@ describe(TimetableCell, () => {
         moduleCode: 'CS1010',
         classNo: '2',
         lessonType: 'Lecture',
+        startTime: '0900',
+        day: 'Monday',
       },
     })
       .wrapper.find('button')
@@ -106,6 +112,8 @@ describe(TimetableCell, () => {
         moduleCode: 'CS1101S',
         classNo: '1',
         lessonType: 'Lecture',
+        startTime: '0900',
+        day: 'Monday',
       },
     })
       .wrapper.find('button')

--- a/website/src/views/timetable/TimetableCell.tsx
+++ b/website/src/views/timetable/TimetableCell.tsx
@@ -140,6 +140,7 @@ const TimetableCell: React.FC<Props> = (props) => {
           </div>
 
           {lesson.isTaInTimetable &&
+            onClick &&
             isHoveredOver &&
             hoverLesson &&
             (lesson.isActive || !lesson.isOptionInTimetable ? (

--- a/website/src/views/timetable/TimetableCell.tsx
+++ b/website/src/views/timetable/TimetableCell.tsx
@@ -91,7 +91,11 @@ const TimetableCell: React.FC<Props> = (props) => {
 
   const moduleName = showTitle ? `${lesson.moduleCode} ${lesson.title}` : lesson.moduleCode;
   const Cell = props.onClick ? 'button' : 'div';
-  const isHoveredOver = isEqual(getHoverLesson(lesson), hoverLesson);
+  const isHoveredOver = lesson.isTaInTimetable
+    ? isEqual(getHoverLesson(lesson), hoverLesson)
+    : lesson.moduleCode === hoverLesson?.moduleCode &&
+      lesson.lessonType === hoverLesson.lessonType &&
+      lesson.classNo === hoverLesson.classNo;
 
   const conditionalProps = onClick
     ? {


### PR DESCRIPTION
## Context

Fixes #3929. 

## Implementation

Previously, TA mode will filter out all lectures. However, some mods (e.g. CS2103T) only have lecture lessons, so this PR makes all lessons togglable.

`TaModulesConfig` now stores `[lessonType, classNo, startTime, day]` instead of `[lessonType, classNo]`.

```
export type TaModulesConfig = {
  [moduleCode: ModuleCode]: [
    lessonType: LessonType,
    classNo: ClassNo,
    startTime: StartTime,
    day: DayText,
  ][];
};
```

For the migration, I'm not sure on how `startTime` and `day` data can be pulled. Right now, I am wiping the existing TA config to avoid conflicts. Let me know if there's a better way to do this?