### PR TITLE
Fix Lecture Slots Rendering

### DIFF
--- a/website/src/utils/modules.test.ts
+++ b/website/src/utils/modules.test.ts
@@ -17,6 +17,7 @@ import {
   renderExamDuration,
   getExamDuration,
   canTa,
+  areLessonsDuplicate,
 } from 'utils/modules';
 import { noBreak } from 'utils/react';
 
@@ -68,8 +69,9 @@ test('areLessonsSameClass should identify identity lessons as same class', () =>
   expect(areLessonsSameClass(mockLesson, deepClonedLesson)).toBe(true);
 });
 
-test('areLessonsSameClass should identify lessons from the same ClassNo but ' +
-  'with different timings as same class',
+test(
+  'areLessonsSameClass should identify lessons from the same ClassNo but ' +
+    'with different timings as same class',
   () => {
     const otherLesson: Lesson = lessonWithDifferentProperty(mockLesson, 'startTime', '0000');
     const otherLesson2: Lesson = lessonWithDifferentProperty(otherLesson, 'endTime', '2300');
@@ -93,12 +95,13 @@ test('areLessonsSameClass should identify lessons with different lessonType as d
 });
 
 
-test('areLessonsDuplicate should identify lessons from the same ClassNo but ' +
-  'with different timings as non duplicates',
+test(
+  'areLessonsDuplicate should identify lessons from the same ClassNo but ' +
+    'with different timings as non duplicates',
   () => {
     const otherLesson: Lesson = lessonWithDifferentProperty(mockLesson, 'startTime', '0000');
     const otherLesson2: Lesson = lessonWithDifferentProperty(otherLesson, 'endTime', '2300');
-    expect(areLessonsSameClass(mockLesson, otherLesson2)).toBe(false);
+    expect(areLessonsDuplicate(mockLesson, otherLesson2)).toBe(false);
   },
 );
 

--- a/website/src/utils/modules.test.ts
+++ b/website/src/utils/modules.test.ts
@@ -99,8 +99,16 @@ test(
     'with different timings as non duplicates',
   () => {
     const otherLesson: Lesson = lessonWithDifferentProperty(mockLesson, 'startTime', '0000');
-    const otherLesson2: Lesson = lessonWithDifferentProperty(otherLesson, 'endTime', '2300');
-    expect(areLessonsDuplicate(mockLesson, otherLesson2)).toBe(false);
+    expect(areLessonsDuplicate(mockLesson, otherLesson)).toBe(false);
+  },
+);
+
+test(
+  'areLessonsDuplicate should identify lessons from the same ClassNo but ' +
+    'with different day as non duplicates',
+  () => {
+    const otherLesson: Lesson = lessonWithDifferentProperty(mockLesson, 'day', 'Monday');
+    expect(areLessonsDuplicate(mockLesson, otherLesson)).toBe(false);
   },
 );
 

--- a/website/src/utils/modules.test.ts
+++ b/website/src/utils/modules.test.ts
@@ -68,9 +68,8 @@ test('areLessonsSameClass should identify identity lessons as same class', () =>
   expect(areLessonsSameClass(mockLesson, deepClonedLesson)).toBe(true);
 });
 
-test(
-  'areLessonsSameClass should identify lessons from the same ClassNo but ' +
-    'with different timings as same class',
+test('areLessonsSameClass should identify lessons from the same ClassNo but ' +
+  'with different timings as same class',
   () => {
     const otherLesson: Lesson = lessonWithDifferentProperty(mockLesson, 'startTime', '0000');
     const otherLesson2: Lesson = lessonWithDifferentProperty(otherLesson, 'endTime', '2300');
@@ -92,6 +91,16 @@ test('areLessonsSameClass should identify lessons with different lessonType as d
   const otherLesson: Lesson = lessonWithDifferentProperty(mockLesson, 'lessonType');
   expect(areLessonsSameClass(mockLesson, otherLesson)).toBe(false);
 });
+
+
+test('areLessonsDuplicate should identify lessons from the same ClassNo but ' +
+  'with different timings as non duplicates',
+  () => {
+    const otherLesson: Lesson = lessonWithDifferentProperty(mockLesson, 'startTime', '0000');
+    const otherLesson2: Lesson = lessonWithDifferentProperty(otherLesson, 'endTime', '2300');
+    expect(areLessonsSameClass(mockLesson, otherLesson2)).toBe(false);
+  },
+);
 
 test('formatExamDate should format an exam date string correctly', () => {
   expect(formatExamDate('2016-11-23T01:00:00.000Z')).toBe('23-Nov-2016 9:00\u00a0AM');

--- a/website/src/utils/modules.test.ts
+++ b/website/src/utils/modules.test.ts
@@ -94,7 +94,6 @@ test('areLessonsSameClass should identify lessons with different lessonType as d
   expect(areLessonsSameClass(mockLesson, otherLesson)).toBe(false);
 });
 
-
 test(
   'areLessonsDuplicate should identify lessons from the same ClassNo but ' +
     'with different timings as non duplicates',

--- a/website/src/utils/modules.ts
+++ b/website/src/utils/modules.ts
@@ -44,6 +44,17 @@ export function areLessonsSameClass(lesson1: Lesson, lesson2: Lesson): boolean {
   );
 }
 
+// Are the two lessons exact duplicates of one another
+export function areLessonsDuplicate(lesson1: Lesson, lesson2: Lesson): boolean {
+  return (
+    lesson1.moduleCode === lesson2.moduleCode &&
+    lesson1.classNo === lesson2.classNo &&
+    lesson1.lessonType === lesson2.lessonType &&
+    lesson1.day === lesson2.day &&
+    lesson1.startTime === lesson2.startTime
+  );
+}
+
 /**
  * Convert exam in ISO format to 12-hour date/time format.
  */

--- a/website/src/views/timetable/TimetableContent.tsx
+++ b/website/src/views/timetable/TimetableContent.tsx
@@ -26,6 +26,7 @@ import {
   resetTimetable,
 } from 'actions/timetables';
 import {
+  areLessonsDuplicate,
   areLessonsSameClass,
   canTa,
   formatExamDate,
@@ -378,7 +379,7 @@ class TimetableContent extends React.Component<Props, State> {
 
         // Prevent multiple versions of the same lesson
         if (
-          timetableLessons.some((curLesson) => areLessonsSameClass(modifiableLesson, curLesson))
+          timetableLessons.some((curLesson) => areLessonsDuplicate(modifiableLesson, curLesson))
         ) {
           return;
         }


### PR DESCRIPTION
## Context
Resolves #3964 of lecture slots not being shown properly

## Implementation
PR #3942 used `areLessonsSameClass` to prevent the duplicate TA lessons but this also caused different lecture timings for the same lecture group to be filtered out as duplicates since it identifies lessons from the same ClassNo but with different timings as same class.

To fix this, a new function `areLessonsDuplicate` is introduced with the additional check of day and startTime for filtering out the duplicate TA lessons while making sure lecture  slots are rendering correctly

Before:
![Screenshot (1118)](https://github.com/user-attachments/assets/eea76ebb-6f13-4580-b0d2-8957de7ac00c)

After:
![Screenshot (1117)](https://github.com/user-attachments/assets/885f92df-5f0c-4481-9ad7-3ca52f1b910f)

