### PR TITLE
fix(tests): make ModuleArchiveContainer test more reliable

### DIFF
--- a/website/src/views/modules/ModuleArchiveContainer.test.tsx
+++ b/website/src/views/modules/ModuleArchiveContainer.test.tsx
@@ -82,7 +82,9 @@ describe(ModuleArchiveContainerComponent, () => {
   test('should show 404 page when the course code does not exist', async () => {
     mockAxiosRequest.mockRejectedValue(notFoundError);
     make('/archive/CS1234/2017-2018');
-    expect(await screen.findByText(/course CS1234 not found/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/course CS1234 not found/, { exact: false }),
+    ).toBeInTheDocument();
   });
 
   test('should redirect to canonical URL', async () => {


### PR DESCRIPTION
## Context
Fixes #3873 

## Implementation
Updated  flaky `ModuleArchiveContainer` test by passing in `{ exact: false }` into `findByText`, following the approach that @zwliew suggested in the comments of #3873.

Verified that the tests were working by running the test repeatedly, without any failures.