### PR TITLE
chore(deps): ignore updates to samlify

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,7 +65,7 @@
       "groupName": "definitelyTyped"
     }
   ],
-  "ignoreDeps": ["@material/snackbar", "@material/fab", "puppeteer", "searchkit"],
+  "ignoreDeps": ["@material/snackbar", "@material/fab", "puppeteer", "searchkit", "samlify"],
   "pathRules": [
     {
       "paths": ["packages/**"],


### PR DESCRIPTION
## Context

An upgrade to `samlify` in 278024035973b6ae842a34d8e9634367ba204e11 broke our NUS auth. We reverted it in 0b8b091922dea151563079daede7fd703997be7b in order to prepare for CPEx this sem.

This config change will ensure the dependency doesn't get automatically updated again, until we properly investigated the cause.

I've filed an issue in https://github.com/nusmodifications/nusmods/issues/4031 to investigate the problem.
