### PR TITLE
allow multi-module selection in timetable

### DIFF
--- a/website/src/views/timetable/ModulesSelect.test.tsx
+++ b/website/src/views/timetable/ModulesSelect.test.tsx
@@ -61,16 +61,49 @@ describe(ModulesSelect, () => {
     expect(result.find('.badge').exists()).toBe(true);
   });
 
-  it('should call onChange when module is selected', () => {
+  it('should call onChange and close dropdown on regular click', () => {
     const wrapper = mount(<ModulesSelect {...commonProps} />);
     const input = wrapper.find('input');
     input.simulate('focus');
     input.simulate('change', { target: { value: 'T' } });
-    wrapper.find('li').first().simulate('click');
+
+    // Verify dropdown is open
+    expect(wrapper.find(Downshift).prop('isOpen')).toBe(true);
+
+    // Regular click (no shift key)
+    wrapper.find('li').first().simulate('click', { shiftKey: false });
+
     expect(commonProps.onChange).toHaveBeenCalledWith(modules[0].moduleCode);
-    // remain open
-    const downShift = wrapper.find(Downshift);
-    expect(downShift.prop('isOpen')).toBe(true);
+
+    // Check that dropdown is closed after regular click
+    wrapper.update();
+    expect(wrapper.find(Downshift).prop('isOpen')).toBe(false);
+
+    // Check that input is cleared
+    expect(wrapper.find('input').prop('value')).toBe('');
+  });
+
+  it('should call onChange but keep dropdown open on shift+click', () => {
+    const wrapper = mount(<ModulesSelect {...commonProps} />);
+    const input = wrapper.find('input');
+    input.simulate('focus');
+    input.simulate('change', { target: { value: 'T' } });
+
+    // Verify dropdown is open
+    expect(wrapper.find(Downshift).prop('isOpen')).toBe(true);
+
+    // Shift+click
+    wrapper.find('li').first().simulate('mousedown', { shiftKey: true });
+    wrapper.find('li').first().simulate('click', { shiftKey: true });
+
+    expect(commonProps.onChange).toHaveBeenCalledWith(modules[0].moduleCode);
+
+    // Check that dropdown remains open after shift+click
+    wrapper.update();
+    expect(wrapper.find(Downshift).prop('isOpen')).toBe(true);
+
+    // Check that input value is preserved
+    expect(wrapper.find('input').prop('value')).toBe('T');
   });
 
   describe('when it does not matchBreakpoint', () => {

--- a/website/src/views/timetable/ModulesSelect.tsx
+++ b/website/src/views/timetable/ModulesSelect.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useState } from 'react';
+import { FC, useCallback, useState, useRef } from 'react';
 import { omit } from 'lodash';
 import Downshift, {
   ChildrenFunction,
@@ -42,6 +42,8 @@ const ModulesSelect: FC<Props> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
 
+  const isShiftClickRef = useRef(false);
+
   const matchBreakpoint = useMediaQuery(breakpointUp('md'));
 
   const openSelect = useCallback(() => setIsOpen(true), []);
@@ -76,8 +78,19 @@ const ModulesSelect: FC<Props> = ({
           return changes;
 
         case Downshift.stateChangeTypes.keyDownEnter:
+          closeSelectAndEmptyInput();
+          return changes;
+
         case Downshift.stateChangeTypes.clickItem:
-          setInputValue('');
+          // Shift click or Shift enter: keep dropdown open
+          if (isShiftClickRef.current) {
+            isShiftClickRef.current = false;
+            return {
+              ...changes,
+              isOpen: true,
+            };
+          }
+          closeSelectAndEmptyInput();
           return changes;
 
         case Downshift.stateChangeTypes.mouseUp:
@@ -135,6 +148,10 @@ const ModulesSelect: FC<Props> = ({
                   key: module.moduleCode,
                   item: module.moduleCode,
                   disabled: module.isAdded || module.isAdding,
+                  onMouseDown: (event) => {
+                    // Capture shift state before click event
+                    isShiftClickRef.current = event.shiftKey;
+                  },
                 })}
                 className={classnames(styles.option, {
                   [styles.optionDisabled]: module.isAdded || module.isAdding,


### PR DESCRIPTION
## Context
Resolves issue #4082 by adding shift click to module selection

## Implementation
Added isShiftClickRef to track when Shift key is held during mouse clicks
Modified stateReducer to handle clickItem events differently based on whether shift key was pressed
