### PR TITLE
Adds max consecutive hours feature in Optimiser

### DIFF
--- a/website/api/optimiser/_constants/constants.go
+++ b/website/api/optimiser/_constants/constants.go
@@ -41,3 +41,4 @@ var NO_LUNCH_PENALTY      = 300.0
 var GAP_PENALTY_THRESHOLD = 120 // 2 hours in minutes
 var GAP_PENALTY_RATE      = 100.0
 var LUNCH_REQUIRED_TIME   = 60 // 1 hour in minutes
+var CONSECUTIVE_HOURS_PENALTY_RATE = 100

--- a/website/api/optimiser/_models/models.go
+++ b/website/api/optimiser/_models/models.go
@@ -7,15 +7,16 @@ import (
 )
 
 type OptimiserRequest struct {
-	Modules      []string `json:"modules"`      // Format: ["CS1010S", "CS2030S"]
-	Recordings   []string `json:"recordings"`   // Format: ["CS1010S Lecture", "CS2030S Laboratory"]
-	FreeDays     []string `json:"freeDays"`     // Format: ["Monday", "Tuesday"]
-	EarliestTime string   `json:"earliestTime"` // Format: "1504" (HHMM)
-	LatestTime   string   `json:"latestTime"`   // Format: "1504" (HHMM)
-	AcadYear     string   `json:"acadYear"`     // Format: "2024-2025" (YYYY-YYYY)
-	AcadSem      int      `json:"acadSem"`      // Format: 1 for sem 1, 2 for sem 2
-	LunchStart   string   `json:"lunchStart"`   // Format: "1504" (HHMM)
-	LunchEnd     string   `json:"lunchEnd"`     // Format: "1500" (HHMM)
+	Modules      		[]string `json:"modules"`      // Format: ["CS1010S", "CS2030S"]
+	Recordings   		[]string `json:"recordings"`   // Format: ["CS1010S Lecture", "CS2030S Laboratory"]
+	FreeDays     		[]string `json:"freeDays"`     // Format: ["Monday", "Tuesday"]
+	EarliestTime 		string   `json:"earliestTime"` // Format: "1504" (HHMM)
+	LatestTime   		string   `json:"latestTime"`   // Format: "1504" (HHMM)
+	AcadYear     		string   `json:"acadYear"`     // Format: "2024-2025" (YYYY-YYYY)
+	AcadSem      		int      `json:"acadSem"`      // Format: 1 for sem 1, 2 for sem 2
+	MaxConsecutiveHours int 	 `json:"maxConsecutiveHours"` // Maximum consecutive hours of study
+	LunchStart   		string   `json:"lunchStart"`   // Format: "1504" (HHMM)
+	LunchEnd     		string   `json:"lunchEnd"`     // Format: "1500" (HHMM)
 }
 
 type TimetableState struct {

--- a/website/api/optimiser/_solver/solver.go
+++ b/website/api/optimiser/_solver/solver.go
@@ -257,6 +257,36 @@ func calculateLunchGap(physicalSlots []models.ModuleSlot, optimiserRequest model
 	return bestGap
 }
 
+func scoreConsecutiveHoursofStudy(physicalSlots []models.ModuleSlot, maxConsecutiveHours int) int {
+	if len(physicalSlots) == 0 {
+		return 0
+	}
+
+	score := 0
+	consecutiveMinutes := physicalSlots[0].EndMin - physicalSlots[0].StartMin 
+
+	for i := 1; i < len(physicalSlots); i++ {
+		prevSlot := physicalSlots[i-1]
+		currentSlot := physicalSlots[i]
+
+		if currentSlot.StartMin == prevSlot.EndMin {
+			consecutiveMinutes += currentSlot.EndMin - currentSlot.StartMin
+		} else {
+			// Currently penalise for more than 4 hours
+			if consecutiveMinutes > maxConsecutiveHours*60 {
+				score += (consecutiveMinutes/60 - maxConsecutiveHours) * 20
+			}
+			consecutiveMinutes = currentSlot.EndMin - currentSlot.StartMin
+		}
+	}
+
+	if consecutiveMinutes > maxConsecutiveHours*60 {
+		score += (consecutiveMinutes/60 - maxConsecutiveHours) * constants.CONSECUTIVE_HOURS_PENALTY_RATE
+	}
+
+	return score
+}
+
 /*
 scoreTimetableState assigns a heuristic score to a complete timetable state.
 Lower score means a better (more preferred) timetable.
@@ -283,6 +313,9 @@ func scoreTimetableState(state models.TimetableState, recordings map[string]bool
 		if largestGap > constants.GAP_PENALTY_THRESHOLD {
 			totalScore += constants.GAP_PENALTY_RATE * float64(largestGap-constants.GAP_PENALTY_THRESHOLD) / 60
 		}
+
+		// Apply penalty for more than max consecutive hours of study
+		totalScore += float64(scoreConsecutiveHoursofStudy(physicalSlots, optimiserRequest.MaxConsecutiveHours))
 	}
 
 	// Add penalty for walking distance

--- a/website/src/apis/optimiser.ts
+++ b/website/src/apis/optimiser.ts
@@ -12,6 +12,7 @@ export interface OptimiseRequest {
   recordings: string[];
   lunchStart: string;
   lunchEnd: string;
+  maxConsecutiveHours: number;
 }
 
 export interface LessonSlot {

--- a/website/src/views/optimiser/OptimiserContent.tsx
+++ b/website/src/views/optimiser/OptimiserContent.tsx
@@ -32,6 +32,7 @@ const OptimiserContent: React.FC = () => {
   const [unAssignedLessons, setUnAssignedLessons] = useState<LessonOption[]>([]);
   const [shareableLink, setShareableLink] = useState<string>('');
   const [hasSaturday, setHasSaturday] = useState<boolean>(false);
+  const [maxConsecutiveHours, setMaxConsecutiveHours] = useState<number>(4);
 
   // button
   const [isOptimising, setIsOptimising] = useState<boolean>(false);
@@ -184,6 +185,7 @@ const OptimiserContent: React.FC = () => {
       recordings,
       lunchStart: earliestLunchTime,
       lunchEnd: latestLunchTime,
+      maxConsecutiveHours,
     };
 
     sendOptimiseRequest(params)
@@ -242,12 +244,14 @@ const OptimiserContent: React.FC = () => {
         latestLunchTime={latestLunchTime}
         freeDayConflicts={freeDayConflicts}
         hasSaturday={hasSaturday}
+        maxConsecutiveHours={maxConsecutiveHours}
         onToggleLessonSelection={toggleLessonSelection}
         onToggleFreeDay={toggleFreeDay}
         onEarliestTimeChange={setEarliestTime}
         onLatestTimeChange={setLatestTime}
         onEarliestLunchTimeChange={setEarliestLunchTime}
         onLatestLunchTimeChange={setLatestLunchTime}
+        onMaxConsecutiveHoursChange={setMaxConsecutiveHours}
       />
 
       {/* Optimiser button */}

--- a/website/src/views/optimiser/OptimiserForm.scss
+++ b/website/src/views/optimiser/OptimiserForm.scss
@@ -304,3 +304,67 @@
 .infoIcon {
   color: #69707a;
 } 
+
+// Priority notice section
+.priorityNotice {
+  margin-top: 2rem;
+  border-top: 1px solid var(--gray-lighter);
+  padding-top: 1rem;
+  font-size: 1.1rem;
+
+  .prioritised {
+    color: #ff5138;
+    opacity: 0.85;
+    font-weight: bold;
+  }
+
+  .notGuaranteed {
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-color: #ff5138;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 2px;
+  }
+} 
+
+.maxConsecutiveHours {
+  display: flex;
+  align-items: center;
+  margin-top: 2rem;
+  font-size: 1rem;
+  gap: 0.5rem;
+}
+
+.maxConsecutiveHoursGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.maxConsecutiveHoursHeader {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  font-size: 1rem;
+  gap: 0.5rem;
+}
+
+.maxConsecutiveHoursInput {
+  width: 4.1rem;
+  padding: 0.25rem 0.75rem;
+  padding-left: 0.9rem;
+  border: 1px solid var(--gray-lighter);
+  border-radius: 0.25rem;
+  outline: none;
+  font-size: 1.3rem;
+  font-family: monospace;
+  color: inherit;
+  background-image: url("data:image/svg+xml;charset=US-ASCII,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'><path fill='%23666' d='M2 0L0 2h4zm0 5L0 3h4z'/></svg>");
+  background-position: right 0.7rem center;
+  background-size: 0.85rem;
+  background-repeat: no-repeat;
+  background-color: transparent;
+  appearance: none;
+  cursor: pointer;
+}

--- a/website/src/views/optimiser/OptimiserForm.tsx
+++ b/website/src/views/optimiser/OptimiserForm.tsx
@@ -14,13 +14,15 @@ interface OptimiserFormProps {
   earliestLunchTime: string;
   latestLunchTime: string;
   freeDayConflicts: FreeDayConflict[];
+  hasSaturday: boolean;
+  maxConsecutiveHours: number;
   onToggleLessonSelection: (option: LessonOption) => void;
   onToggleFreeDay: (day: string) => void;
   onEarliestTimeChange: (time: string) => void;
   onLatestTimeChange: (time: string) => void;
   onEarliestLunchTimeChange: (time: string) => void;
   onLatestLunchTimeChange: (time: string) => void;
-  hasSaturday: boolean;
+  onMaxConsecutiveHoursChange: (hours: number) => void;
 }
 
 const OptimiserForm: React.FC<OptimiserFormProps> = ({
@@ -32,13 +34,15 @@ const OptimiserForm: React.FC<OptimiserFormProps> = ({
   earliestLunchTime,
   latestLunchTime,
   freeDayConflicts,
+  hasSaturday,
+  maxConsecutiveHours,
   onToggleLessonSelection,
   onToggleFreeDay,
   onEarliestTimeChange,
   onLatestTimeChange,
   onEarliestLunchTimeChange,
   onLatestLunchTimeChange,
-  hasSaturday,
+  onMaxConsecutiveHoursChange,
 }) => {
   const toggleLessonSelection = useCallback(
     (option: LessonOption) => {
@@ -288,12 +292,39 @@ const OptimiserForm: React.FC<OptimiserFormProps> = ({
         </div>
       </div>
 
+      <div className={styles.priorityNotice}>
+        The following constraints will be <strong className={styles.prioritised}>heavily prioritised</strong> but <strong className={styles.notGuaranteed}>not guaranteed</strong> :
+      </div>
+
+      <div className={styles.maxConsecutiveHours}>
+        <div className={styles.maxConsecutiveHoursGroup}>
+          <div className={styles.maxConsecutiveHoursHeader}>
+            <div>
+              Select maximum consecutive hours of live lessons
+              <Tooltip content="Prioritises having less than this number of consecutive hours of live lessons" placement="right">
+                <Info className={`${styles.tag} ${styles.infoIcon}`} style={{ marginLeft: '0.5rem' }} size={15} />
+              </Tooltip>
+            </div>
+          </div>
+          <select 
+            value={maxConsecutiveHours}
+            onChange={(e) => onMaxConsecutiveHoursChange(parseInt(e.target.value))}
+            className={classnames('form-select', styles.maxConsecutiveHoursInput)}>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+          </select>
+        </div>
+      </div>
       <div className={styles.lunchControls}>
         <div className={styles.lunchControlGroup}>
           <div className={styles.lunchControlHeader}>
             Select range for preferred lunch break timings
             <Tooltip
-              content="Prioritises 1-hour lunch breaks in this range, if possible"
+              content="Prioritises 1-hour lunch breaks in this range"
               placement="right"
             >
               <Info className={`${styles.tag} ${styles.infoIcon}`} size={15} />


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
Closes #4086

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
Added in max consecutive hours of study as a heavily prioritised constraint like lunch timings
<img width="631" alt="image" src="https://github.com/user-attachments/assets/bec9f2b7-fcdb-46e6-9b2c-de01376d4742" />
The optimiser now also punishes if there are back to back lessons that exceed user specified max hours. Therefore the timetable returned will take this into account and try to minimise this as much as possible.
