### PR TITLE
fix: layout overflow in Course Not Found page

### DIFF
--- a/website/src/views/errors/ErrorPage.scss
+++ b/website/src/views/errors/ErrorPage.scss
@@ -40,8 +40,8 @@
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  gap: 0.8rem 1rem;
   margin-bottom: 2rem;
+  gap: 0.8rem 1rem;
 
   @include media-breakpoint-up(sm) {
     flex-direction: row;


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context

In the "Course Not Found" page, the list of AY archives did not wrap and overflowed its container.

Closes #4089

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

Added `flex-wrap: wrap;` to allow the list to wrap properly and `gap` to space the elements instead of margins.

<img width="330" alt="Screenshot 2025-07-09 at 8 07 48 p m" src="https://github.com/user-attachments/assets/7c04f561-a721-4ea0-a3b7-ad2c7aac4977" />

The `.buttons` class is used in the `ModuleFinderNoHits` component, so I verified that the styles still render correctly there as well:

<img width="320" alt="Screenshot 2025-07-09 at 8 06 39 p m" src="https://github.com/user-attachments/assets/cf576f00-2230-44d0-85da-a8e34a6a0757" />

I also set a `min-width` on the elements to prevent layout issues where rows would end up with different numbers of buttons. The following image shows how it looked **before** adding the `min-width` property:

<img width="320" alt="image" src="https://github.com/user-attachments/assets/b9fd5974-626e-4af8-ac08-35723632b75f" />