### PR TITLE
feat(planner): add setting to include exempted module credits in total calculation

### DIFF
--- a/website/src/actions/planner.ts
+++ b/website/src/actions/planner.ts
@@ -35,6 +35,14 @@ export function setIgnorePrerequisitesCheck(prereqsCheck: boolean) {
   };
 }
 
+export const SET_INCLUDE_EXEMPTED_MODULE_CREDITS = 'SET_INCLUDE_EXEMPTED_MODULE_CREDITS' as const;
+export function setIncludeExemptedModuleCredits(includeExempted: boolean) {
+  return {
+    type: SET_INCLUDE_EXEMPTED_MODULE_CREDITS,
+    payload: includeExempted,
+  };
+}
+
 export const ADD_PLANNER_MODULE = 'ADD_PLANNER_MODULE' as const;
 export function addPlannerModule(year: string, semester: Semester, module: AddModuleData) {
   return {

--- a/website/src/reducers/planner.test.ts
+++ b/website/src/reducers/planner.test.ts
@@ -6,6 +6,7 @@ import {
   SET_PLANNER_MAX_YEAR,
   SET_PLANNER_IBLOCS,
   SET_IGNORE_PREREQUISITES_CHECK,
+  SET_INCLUDE_EXEMPTED_MODULE_CREDITS,
   addPlannerModule,
   movePlannerModule,
   removePlannerModule,
@@ -13,6 +14,7 @@ import {
   setPlannerMaxYear,
   setPlannerIBLOCs,
   setIgnorePrerequisitesCheck,
+  setIncludeExemptedModuleCredits,
   IMPORT_PLANNER,
   importPlanner,
   CLEAR_PLANNER,
@@ -86,6 +88,15 @@ describe(SET_IGNORE_PREREQUISITES_CHECK, () => {
     expect(reducer(defaultState, setIgnorePrerequisitesCheck(true))).toEqual({
       ...defaultState,
       ignorePrereqCheck: true,
+    });
+  });
+});
+
+describe(SET_INCLUDE_EXEMPTED_MODULE_CREDITS, () => {
+  test('should set includeExemptedModuleCredits status', () => {
+    expect(reducer(defaultState, setIncludeExemptedModuleCredits(true))).toEqual({
+      ...defaultState,
+      includeExemptedModuleCredits: true,
     });
   });
 });

--- a/website/src/reducers/planner.ts
+++ b/website/src/reducers/planner.ts
@@ -16,6 +16,7 @@ import {
   SET_PLANNER_MAX_YEAR,
   SET_PLANNER_MIN_YEAR,
   SET_IGNORE_PREREQUISITES_CHECK,
+  SET_INCLUDE_EXEMPTED_MODULE_CREDITS,
   IMPORT_PLANNER,
   CLEAR_PLANNER,
 } from 'actions/planner';
@@ -27,6 +28,7 @@ export const defaultPlannerState: PlannerState = {
   maxYear: config.academicYear,
   iblocs: false,
   ignorePrereqCheck: false,
+  includeExemptedModuleCredits: false,
 
   modules: {},
   custom: {},
@@ -81,6 +83,9 @@ export default function planner(
 
     case SET_IGNORE_PREREQUISITES_CHECK:
       return { ...state, ignorePrereqCheck: action.payload };
+
+    case SET_INCLUDE_EXEMPTED_MODULE_CREDITS:
+      return { ...state, includeExemptedModuleCredits: action.payload };
 
     case ADD_PLANNER_MODULE: {
       const { payload } = action;

--- a/website/src/types/reducers.ts
+++ b/website/src/types/reducers.ts
@@ -165,6 +165,7 @@ export type PlannerState = Readonly<{
   maxYear: string;
   iblocs: boolean;
   ignorePrereqCheck?: boolean; // To turn checking of prerequisites on/off
+  includeExemptedModuleCredits?: boolean; // To include exempted modules in total MC calculation
 
   modules: { [id: string]: PlannerTime };
   custom: CustomModuleData;

--- a/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
+++ b/website/src/views/planner/PlannerContainer/PlannerContainer.tsx
@@ -51,6 +51,7 @@ export type Props = Readonly<{
   planToTake: PlannerModuleInfo[];
   iblocsModules: PlannerModuleInfo[];
   iblocs: boolean;
+  includeExemptedModuleCredits?: boolean;
 
   // Actions
   fetchModule: (moduleCode: ModuleCode) => Promise<Module>;
@@ -151,7 +152,11 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
   closeSettingsModal = () => this.setState({ showSettings: false });
 
   renderHeader() {
-    const modules = [...this.props.iblocsModules, ...flatten(flatMap(this.props.modules, values))];
+    const modules = [
+      ...this.props.iblocsModules,
+      ...flatten(flatMap(this.props.modules, values)),
+      ...(this.props.includeExemptedModuleCredits ? this.props.exemptions : []),
+    ];
     const credits = getTotalMC(modules);
     const count = modules.length;
 
@@ -307,6 +312,7 @@ export class PlannerContainerComponent extends PureComponent<Props, State> {
 
 const mapStateToProps = (state: StoreState) => ({
   iblocs: state.planner.iblocs,
+  includeExemptedModuleCredits: state.planner.includeExemptedModuleCredits,
 
   modules: getAcadYearModules(state),
   exemptions: getExemptions(state),

--- a/website/src/views/planner/PlannerSettings.tsx
+++ b/website/src/views/planner/PlannerSettings.tsx
@@ -10,6 +10,7 @@ import {
   setPlannerMaxYear,
   setPlannerMinYear,
   setIgnorePrerequisitesCheck,
+  setIncludeExemptedModuleCredits,
 } from 'actions/planner';
 import ExternalLink from 'views/components/ExternalLink';
 import Toggle from 'views/components/Toggle';
@@ -22,6 +23,7 @@ type Props = {
   readonly maxYear: string;
   readonly iblocs: boolean;
   readonly ignorePrereqCheck?: boolean;
+  readonly includeExemptedModuleCredits?: boolean;
 
   // Actions
   readonly onCloseButtonClicked: () => void;
@@ -29,6 +31,7 @@ type Props = {
   readonly setMaxYear: (str: string) => void;
   readonly setIBLOCs: (boolean: boolean) => void;
   readonly setPrereqsCheck: (boolean: boolean) => void;
+  readonly setIncludeExempted: (boolean: boolean) => void;
 };
 
 const MIN_YEARS = -5; // Studying year 6
@@ -151,6 +154,22 @@ export const PlannerSettingsComponent: React.FC<Props> = (props) => {
           onChange={(checked) => props.setPrereqsCheck(checked)}
         />
       </section>
+
+      <section className={styles.toggleSection}>
+        <div>
+          <h2 className={styles.label}>Include Exempted Module Credits</h2>
+
+          <p>
+            When enabled, exempted modules will be included in the total module credits calculation
+            shown in the planner header.
+          </p>
+        </div>
+
+        <Toggle
+          isOn={props.includeExemptedModuleCredits}
+          onChange={(checked) => props.setIncludeExempted(checked)}
+        />
+      </section>
     </div>
   );
 };
@@ -161,12 +180,14 @@ const PlannerSettings = connect(
     maxYear: state.planner.maxYear,
     iblocs: state.planner.iblocs,
     ignorePrereqCheck: state.planner.ignorePrereqCheck,
+    includeExemptedModuleCredits: state.planner.includeExemptedModuleCredits,
   }),
   {
     setMaxYear: setPlannerMaxYear,
     setMinYear: setPlannerMinYear,
     setIBLOCs: setPlannerIBLOCs,
     setPrereqsCheck: setIgnorePrerequisitesCheck,
+    setIncludeExempted: setIncludeExemptedModuleCredits,
   },
 )(PlannerSettingsComponent);
 


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
I was planning my mods but had quite a few exemptions and realised the credit calculation didn't include exempted modules. So I thought it would be useful to have it as a setting

## Implementation
- Added setting to include exempted module credits in the calculation
- Updated total MC calculation to conditionally include exempted modules based on the setting

