### PR TITLE
feat(website): Sync state changes across tabs

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -63,6 +63,7 @@
     "@types/react-router-dom": "5.3.3",
     "@types/react-scrollspy": "3.3.9",
     "@types/redux-mock-store": "1.5.0",
+    "@types/redux-state-sync": "^3.1.10",
     "@types/use-subscription": "1.0.2",
     "@types/webpack-env": "1.18.5",
     "@typescript-eslint/eslint-plugin": "4.33.0",
@@ -168,6 +169,7 @@
     "react-scrollspy": "3.4.3",
     "redux": "4.2.1",
     "redux-persist": "6.0.0",
+    "redux-state-sync": "^3.1.4",
     "redux-thunk": "2.4.2",
     "reselect": "4.1.8",
     "samlify": "2.7.7",
@@ -179,6 +181,7 @@
     "extends browserslist-config-nusmods"
   ],
   "resolutions": {
+    "broadcast-channel": "5.3.0",
     "cheerio": "1.0.0-rc.12"
   }
 }

--- a/website/src/bootstrapping/configure-store.ts
+++ b/website/src/bootstrapping/configure-store.ts
@@ -6,6 +6,7 @@ import { setAutoFreeze } from 'immer';
 import rootReducer from 'reducers';
 import requestsMiddleware from 'middlewares/requests-middleware';
 import ravenMiddleware from 'middlewares/raven-middleware';
+import stateSyncMiddleware from 'middlewares/state-sync-middleware';
 import getLocalStorage from 'storage/localStorage';
 
 import type { GetState } from 'types/redux';
@@ -25,7 +26,7 @@ export default function configureStore(defaultState?: State) {
   // to reduce the amount of data NUSMods is using
   getLocalStorage().removeItem('reduxState');
 
-  const middlewares = [ravenMiddleware, thunk, requestsMiddleware];
+  const middlewares = [ravenMiddleware, thunk, requestsMiddleware, stateSyncMiddleware];
 
   if (NUSMODS_ENV === 'development') {
     // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-extraneous-dependencies

--- a/website/src/middlewares/state-sync-middleware.ts
+++ b/website/src/middlewares/state-sync-middleware.ts
@@ -1,0 +1,27 @@
+import type { AnyAction } from 'redux';
+import { PERSIST, PURGE, REHYDRATE } from 'redux-persist';
+import { createStateSyncMiddleware } from 'redux-state-sync';
+
+const reduxStateSyncConfig = {
+  predicate: (action: AnyAction) => {
+    // Reference: https://github.com/aohua/redux-state-sync/issues/53
+    const blacklist = [PERSIST, PURGE, REHYDRATE];
+
+    // redux-state-sync relies on BroadcastChannel, which only supports
+    // objects that are clonable by `structuredClone`
+    if (typeof action === 'function') {
+      return false;
+    }
+
+    // Request actions starting with `FETCH_` are excluded as well
+    if (action.type.toString().startsWith('FETCH_')) {
+      return false;
+    }
+
+    return !blacklist.includes(action.type);
+  },
+};
+
+const stateSyncMiddleware = createStateSyncMiddleware(reduxStateSyncConfig);
+
+export default stateSyncMiddleware;

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1083,6 +1083,13 @@
     "@babel/plugin-transform-modules-commonjs" "^7.25.9"
     "@babel/plugin-transform-typescript" "^7.25.9"
 
+"@babel/runtime@7.22.10":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
+  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.21.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
@@ -2509,6 +2516,14 @@
   dependencies:
     redux "^4.0.5"
 
+"@types/redux-state-sync@^3.1.10":
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/@types/redux-state-sync/-/redux-state-sync-3.1.10.tgz#70d08d986bfb8bfcff56c18876cccec6afddb3d8"
+  integrity sha512-75F3eH50H/r90xuVMg6JGpC6Xha2DWY73XzhfhuCwW8uVHbDI34ZHsRm8WmpOFfa1eh/Z63iY9849khFGxL4aA==
+  dependencies:
+    broadcast-channel "^2.1.8"
+    redux "^4.0.1"
+
 "@types/retry@0.12.2":
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
@@ -3628,6 +3643,16 @@ braces@^3.0.3, braces@~3.0.2:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
+
+broadcast-channel@5.3.0, broadcast-channel@^2.1.8, broadcast-channel@^3.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-5.3.0.tgz#9d9e55fb8db2a1dbbe436ae6d51382a354e76fc3"
+  integrity sha512-0PmDYc/iUGZ4QbnCnV7u+WleygiS1bZ4oV6t4rANXYtSgEFtGhB5jimJPLOVpPtce61FVxrH8CYylfO5g7OLKw==
+  dependencies:
+    "@babel/runtime" "7.22.10"
+    oblivious-set "1.1.1"
+    p-queue "6.6.2"
+    unload "2.4.1"
 
 browser-stdout@1.3.0:
   version "1.3.0"
@@ -9297,6 +9322,11 @@ object.values@^1.2.0, object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+oblivious-set@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.1.1.tgz#d9d38e9491d51f27a5c3ec1681d2ba40aa81e98b"
+  integrity sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w==
+
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
@@ -10732,12 +10762,19 @@ redux-persist@6.0.0:
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
   integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
 
+redux-state-sync@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/redux-state-sync/-/redux-state-sync-3.1.4.tgz#b3a0a92a0c26d05b798c3e39e0ef215031a41323"
+  integrity sha512-nhJBzaXVXPXvUhQJ7m0LdoXBnrcw+cTYQ8bzW9DeJKdq6UNYynXwQWAlVUvsbT/hDV+vB6BC4DMLXkUVGpF2yQ==
+  dependencies:
+    broadcast-channel "^3.1.0"
+
 redux-thunk@2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.2.tgz#b9d05d11994b99f7a91ea223e8b04cf0afa5ef3b"
   integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
 
-redux@4.2.1, redux@^4.0.0, redux@^4.0.4, redux@^4.0.5:
+redux@4.2.1, redux@^4.0.0, redux@^4.0.1, redux@^4.0.4, redux@^4.0.5:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
   integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
@@ -12594,6 +12631,11 @@ universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
+
+unload@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.4.1.tgz#b0c5b7fb44e17fcbf50dcb8fb53929c59dd226a5"
+  integrity sha512-IViSAm8Z3sRBYA+9wc0fLQmU9Nrxb16rcDmIiR6Y9LJSZzI7QY5QsDhqPpKOjAn0O9/kfK1TfNEMMAGPTIraPw==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Context
Previously, changes to a redux state were not reflected in other tabs. This causes 2 main issues:
1. **Major** issue: Scenario where 2 tabs are opened to different modules. Clicking "Add to Semester ..." button in 1 tab, followed by the "Add to Semester ..." button in the other tab, will only cause the 2nd module to be added. (The change in the second tab overrode the change in the first tab).
2. _Minor_ issue: Scenario where 2 tabs are opened, 1 to the timetable and another tab to a module. After clicking "Add to Semester..." button in the module tab, you have to manually refresh the timetable tab for this module to appear.

## Implementation
Uses [`redux-state-sync`](https://github.com/AOHUA/redux-state-sync) to sync redux states across tabs, which uses a polyfilled [`BroadcastChannel`](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API) under the hood.

## Other Information
Another option I looked at was [`redux-persist-crosstab`](https://github.com/rt2zz/redux-persist-crosstab), which is unmaintained and incompatible with the current version of `redux-persist`.

Additionally, I had to forcefully resolve `broadcast-channel` to version `5.3.0`.