### PR TITLE
website: timetables: Fix deserialization of TA courses in share link …

### DIFF
--- a/website/src/utils/timetables.test.ts
+++ b/website/src/utils/timetables.test.ts
@@ -33,6 +33,7 @@ import {
   areOtherClassesAvailable,
   arrangeLessonsForWeek,
   arrangeLessonsWithinDay,
+  deserializeTa,
   deserializeTimetable,
   doLessonsOverlap,
   findExamClashes,
@@ -676,5 +677,19 @@ describe(getEndTimeAsDate, () => {
     const date = new Date(2018, 5, 10);
     const lesson = createGenericLesson('Monday', '0830', '1045');
     expect(getEndTimeAsDate(lesson, date)).toEqual(new Date(2018, 5, 10, 10, 45));
+  });
+});
+
+describe(deserializeTa, () => {
+  test('should deserialize TA modules string into object', () => {
+    expect(deserializeTa('?')).toEqual({});
+    expect(deserializeTa('?CS1010S=REC:1,TUT:8')).toEqual({});
+    expect(deserializeTa('?CS1010S=REC:1,TUT:8&ta=CS3210(TUT:02)')).toEqual({
+      CS3210: [['Tutorial', '02']],
+    });
+    expect(deserializeTa('?CS1010S=REC:1,TUT:8&ta=CS3210(TUT:02),CS3219(TUT:15)')).toEqual({
+      CS3210: [['Tutorial', '02']],
+      CS3219: [['Tutorial', '15']],
+    });
   });
 });

--- a/website/src/utils/timetables.ts
+++ b/website/src/utils/timetables.ts
@@ -625,7 +625,7 @@ export function deserializeTa(serialized: string): TaModulesConfig {
   // If user manually enters multiple TA query keys, use latest one
   const ta = Array.isArray(params.ta) ? last(params.ta) : params.ta;
   if (!ta) return deserialized;
-  ta.split(`)${LESSON_SEP}`).forEach((moduleConfig) => {
+  ta.split(LESSON_SEP).forEach((moduleConfig) => {
     const moduleCodeMatches = moduleConfig.match(/(.*)\(/);
     if (moduleCodeMatches === null) {
       return;


### PR DESCRIPTION
…(#4214)

Currently, the `deserializeTa` function does not correctly parse share links with multiple TA-ed courses.

Fix it and add some unit tests for the function.

Fixes #4171

<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
