### PR TITLE
[Planner] Allow all conflict checks so that future mods correctly flag Prereq check failure 

### DIFF
--- a/website/src/selectors/planner.ts
+++ b/website/src/selectors/planner.ts
@@ -136,12 +136,9 @@ function mapModuleToInfo(
   }
 
   if (moduleCode) {
-    // Only continue checking until the first conflict is found
-    let index = 0;
-    while (!moduleInfo.conflict && index < conflictChecks.length) {
-      moduleInfo.conflict = conflictChecks[index](moduleCode);
-      index += 1;
-    }
+    // Check every conflict
+    const conflicts = conflictChecks.flatMap((check) => check(moduleCode) ?? []);
+    moduleInfo.conflicts = conflicts.length > 0 ? conflicts : null;
 
     // Insert customInfo and moduleInfo
     moduleInfo.moduleInfo = modulesMap[moduleCode];

--- a/website/src/types/planner.ts
+++ b/website/src/types/planner.ts
@@ -55,7 +55,7 @@ export type PlannerModuleInfo = {
   // Custom info added by the student to override our data or to fill in the blanks
   // This is a separate field for easier typing
   customInfo?: CustomModule | null;
-  conflict?: Conflict | null;
+  conflicts?: Conflict[] | null;
   moduleCode?: ModuleCode;
   placeholder?: PlannerPlaceholder;
 };

--- a/website/src/views/planner/PlannerSemester.tsx
+++ b/website/src/views/planner/PlannerSemester.tsx
@@ -4,7 +4,7 @@ import AddCalendarIcon from 'img/icons/add-calendar.svg';
 import classnames from 'classnames';
 
 import { Semester, ModuleCode } from 'types/modules';
-import { AddModuleData, PlannerModuleInfo } from 'types/planner';
+import { AddModuleData, PlannerModuleInfo, Conflict } from 'types/planner';
 import { Dispatch } from 'types/redux';
 import config from 'config';
 import { getExamDate, renderMCs } from 'utils/modules';
@@ -78,16 +78,22 @@ const PlannerSemester: React.FC<Props> = ({
   const dispatch = useDispatch<Dispatch>();
 
   const renderModule = (plannerModule: PlannerModuleInfo, index: number) => {
-    const { id, moduleCode, moduleInfo, conflict, placeholder } = plannerModule;
+    const { id, moduleCode, moduleInfo, conflicts, placeholder } = plannerModule;
 
     const showExamDate = showModuleMeta && config.academicYear === year;
 
     const isModuleInTimetable = moduleCode !== undefined && moduleCode in timetable;
 
-    const displayedConflict =
-      year === config.academicYear || (conflict && ['prereq', 'duplicate'].includes(conflict.type))
-        ? conflict
-        : null;
+    let displayedConflict: Conflict | null = null;
+
+    if (conflicts?.length) {
+      displayedConflict =
+        year === config.academicYear
+          ? conflicts[0] // Topmost conflict if correc year
+          : conflicts.find((c) => c.type === 'prereq') ||
+            conflicts.find((c) => c.type === 'duplicate') ||
+            null; // either prereq or duplicate or none if not same year
+    }
 
     return (
       <PlannerModule


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

Calculate all conflicts so that prereq and duplicate checks for future sems do not get shadowed.

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

Fixes #4231 

<img width="2568" height="1472" alt="image" src="https://github.com/user-attachments/assets/9960b270-abcb-4968-a6dc-374fc0025cc6" />

If a module in the future fails `semesterCheck`, it will not ignore `prereqCheck` or `duplicateCheck` warnings. This allows for the intended case of only showing Prerequisites / Duplicates warnings regardless of whether Module is currently offered in that semester. 

Correct Future Sem? | Prereqs fail? | Duplicates? | result
--|--|--|--
No | No | No | ✅ Green Light
No | Yes | No | ⚠️ Prereq Error 
No | Yes | Yes | ⚠️ Prereq Error 
No | No | Yes | ⚠️ Duplicate Error
Yes | No | No | ✅  Green Light
Yes | Yes | No | ⚠️ Prereq Error
Yes | Yes | Yes | ⚠️ Prereq Error
Yes | No | Yes | ⚠️ Duplicate Error


## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

- `ModuleInfo` now takes an array of `Conflict` instead of just a single one
- All conflict checks are done, instead of terminating at the first non-null conflict
- The `displayedConflict` will either be the first conflict in the `Conflicts` array if current year, or else either Prerequisite or Duplicate conflict for non-current years

## Assumptions:
- conflict-checking functions are added into the conflictChecks array in sequence of priority
- prerequisites takes precedence over duplicates
- future semesters do not include `Semester` conflicts due to possible changes in future timetable


## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
- Not sure if I need to edit any test files
- please ignore banana cursor in screenshot