### PR TITLE
feat(export): increase exporter timeout to 15s for larger timetables

### DIFF
--- a/export/vercel.json
+++ b/export/vercel.json
@@ -6,5 +6,13 @@
       "status": 404,
       "dest": "/404.html"
     }
-  ]
+  ],
+  "functions": {
+    "api/export/image.ts": {
+      "maxDuration": 15
+    },
+    "api/export/pdf.ts": {
+      "maxDuration": 15
+    }
+  }
 }


### PR DESCRIPTION
Following the [Telegram chat](https://t.me/NUSMods/13035), we received timeout errors on larger timetables. We can increase the Vercel function timeout just to be safe. Ideally, we should find a way to optimize this, but this approach should suffice