### PR TITLE
Patch for #4225

### DIFF
--- a/website/src/reducers/timetables.test.ts
+++ b/website/src/reducers/timetables.test.ts
@@ -363,15 +363,3 @@ describe('import timetable', () => {
     });
   });
 });
-
-describe('migrate v1 config', () => {
-  test('should migrate config to new format', () => {
-    expect(
-      reducer(initialState, Internal.setTimetables({ [1]: { CS1010S: {} } }, { [1]: ['CS1010S'] })),
-    ).toStrictEqual({
-      ...initialState,
-      lessons: { [1]: { CS1010S: {} } },
-      ta: { [1]: ['CS1010S'] },
-    });
-  });
-});

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -24,7 +24,6 @@ import {
   SET_TIMETABLE,
   SHOW_LESSON_IN_TIMETABLE,
   REMOVE_TA_MODULE,
-  SET_TIMETABLES,
 } from 'actions/timetables';
 import { getNewColor } from 'utils/colors';
 import { SET_EXPORTED_DATA } from 'actions/constants';
@@ -250,15 +249,6 @@ function timetables(
   }
 
   switch (action.type) {
-    case SET_TIMETABLES: {
-      const { lessons, taModules } = action.payload;
-      return {
-        ...state,
-        lessons,
-        ta: taModules,
-      };
-    }
-
     case SET_TIMETABLE: {
       const { semester, timetable, colors, hiddenModules, taModules } = action.payload;
 

--- a/website/src/utils/timetables.ts
+++ b/website/src/utils/timetables.ts
@@ -46,7 +46,6 @@ import {
   ModuleLessonConfigV1,
   SemTimetableConfigV1,
   TaModulesConfigV1,
-  TimetableConfigV1,
   ColoredLesson,
   HoverLesson,
   InteractableLesson,
@@ -56,13 +55,12 @@ import {
   ModuleLessonConfigWithLessons,
   SemTimetableConfig,
   SemTimetableConfigWithLessons,
-  TimetableConfig,
   TimetableDayArrangement,
   TimetableDayFormat,
   TimetableArrangement,
 } from 'types/timetables';
 
-import { TaModulesMapV1, ModuleCodeMap, ModulesMap, TaModulesMap } from 'types/reducers';
+import { ModuleCodeMap, ModulesMap } from 'types/reducers';
 import { ExamClashes } from 'types/views';
 
 import { getTimeAsDate } from './timify';
@@ -1236,75 +1234,6 @@ export function migrateSemTimetableConfig(
       alreadyMigrated: boolean;
     },
   );
-}
-
-/**
- * Checks the current timetable config and migrate it to v2 format if it is not\
- * Migrates all semesters' timetable config in this academic year
- * @param lessons the academic year's timetables
- * @param ta the academic year's TA modules config
- * @param modules modules in the moduleBank state to use for migration
- * @returns
- * - the migrated timetable config
- * - the migrated TA modules config
- * - whether it was previously migrated, to signal to skip dispatch
- */
-export function migrateTimetableConfigs(
-  lessons: TimetableConfig | TimetableConfigV1,
-  ta: TaModulesMap | TaModulesMapV1,
-  modules: ModulesMap,
-): {
-  lessons: TimetableConfig;
-  ta: TaModulesMap;
-  alreadyMigrated: boolean;
-} {
-  const {
-    config: migratedLessons,
-    ta: migratedTa,
-    alreadyMigrated,
-  } = reduce(
-    lessons,
-    (accumulated, semTimetableConfig, semesterString) => {
-      const semester = parseInt(semesterString, 10);
-      const taModulesConfig = get(ta, semester, {});
-
-      const getModuleSemesterTimetable = (moduleCode: ModuleCode) =>
-        modules[moduleCode] ? getModuleTimetable(modules[moduleCode], semester) : [];
-
-      const migrated = migrateSemTimetableConfig(
-        semTimetableConfig,
-        taModulesConfig,
-        getModuleSemesterTimetable,
-      );
-
-      return {
-        config: {
-          ...accumulated.config,
-          [semester]: migrated.migratedSemTimetableConfig,
-        },
-        ta: {
-          ...accumulated.ta,
-          [semester]: migrated.migratedTaModulesConfig,
-        },
-        alreadyMigrated: migrated.alreadyMigrated && accumulated.alreadyMigrated,
-      };
-    },
-    {
-      config: {},
-      ta: {},
-      alreadyMigrated: true,
-    } as {
-      config: TimetableConfig;
-      ta: TaModulesMap;
-      alreadyMigrated: boolean;
-    },
-  );
-
-  return {
-    lessons: migratedLessons,
-    ta: migratedTa,
-    alreadyMigrated,
-  };
 }
 
 /**


### PR DESCRIPTION
@leslieyip02 @jloh02 Patch for #4225, for the issue reported on the morning of 16 Dec by LH (https://t.me/NUSMods/13136)

**Important Note**: While this patch preserves the current behavior of the app, I think it is more prudent to add more error checking to the migration process, and to stop the migration if an error is encountered, because migrating the config is an inherently destructive process (it overwrites the old config). ~~I am currently working on that.~~ This patch should be considered superseded by #4272 

1. When the app fetches the timetable modules, it populates the lesson indices which allows the migration of the module config to the new schema
https://github.com/nusmodifications/nusmods/blob/d31261e060e45bcd79b07d251f0ffe2403905dee/website/src/reducers/moduleBank.ts#L47-L60

2. The issue was caused by
https://github.com/nusmodifications/nusmods/blob/d31261e060e45bcd79b07d251f0ffe2403905dee/website/src/views/AppShell.tsx#L64-L66
calling
https://github.com/nusmodifications/nusmods/blob/d31261e060e45bcd79b07d251f0ffe2403905dee/website/src/actions/timetables.ts#L231-L239

When `validateTimetable(1)` is called when the app successfully fetches the module data for semester 1, it calls `migrateTimetableConfigs` which migrates the configs for _all_ semesters, including semester 2. Since the request for semester 2 has not returned, the lesson indices has not been populated for semester 2 (see point 1). Trying to migrate the config for semester 2 will thus fail.

This patch fixes this issue by removing the `migrateTimetableConfigs` function and instead migrates each semester's timetable config as data is fetched for each of the semester.