### PR TITLE
Fix indefinite loading when share string is empty

### DIFF
--- a/website/src/views/timetable/TimetableContainer.test.tsx
+++ b/website/src/views/timetable/TimetableContainer.test.tsx
@@ -125,6 +125,20 @@ describe(TimetableContainerComponent, () => {
     await expectRedirectToHomepageFrom('/timetable/2017-2018/v1');
   });
 
+  test('should display blank timetable if share string to import is empty', async () => {
+    make('/timetable/sem-1/share?');
+
+    // Expect no spinner when share string is empty
+    expect(screen.queryByText(/Loading/)).not.toBeInTheDocument();
+
+    // Expect import header to be present
+    expect(await screen.findByRole('button', { name: 'Import' })).toBeInTheDocument();
+
+    // Expect page to load
+    expect(screen.getByText(/Semester 1/)).toBeInTheDocument();
+    expect(screen.getByText(/No courses added./)).toBeInTheDocument();
+  });
+
   test('should eventually display imported timetable if there is one', async () => {
     const semester = 1;
     const importedTimetable = {

--- a/website/src/views/timetable/TimetableContainer.tsx
+++ b/website/src/views/timetable/TimetableContainer.tsx
@@ -221,7 +221,9 @@ export const TimetableContainerComponent: FC = () => {
 
     const importedModuleCodes = [...keys(omit(parsedQuery, ['ta', 'hidden'])), ...taModuleCodes];
 
-    if (!importedModuleCodes.length) return;
+    if (!importedModuleCodes.length) {
+      setLoading(false);
+    }
 
     const moduleCodes = keys(modules);
 
@@ -234,7 +236,6 @@ export const TimetableContainerComponent: FC = () => {
       setLoading(false);
       return;
     }
-    setLoading(true);
     dispatch(fetchModules(new Set(modulesToFetch)));
   }, [semester, params.action, location.search, modules, isValidModule, dispatch]);
 


### PR DESCRIPTION
Skips loading entirely when the share string is empty

<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
This is a patch to resolve https://github.com/nusmodifications/nusmods/issues/4275

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
- The bug occurs because the loading flag is set true by default and if the imported module length is empty it early returns without setting the loading flag to false
- Since the loading flag is true by default, I also removed the unnecessary `setLoading(true)`
- Added tests to ensure that the page loads when the share string is empty
