### PR TITLE
chore(cpex): update wording

### DIFF
--- a/website/src/views/modules/ReportError.tsx
+++ b/website/src/views/modules/ReportError.tsx
@@ -206,8 +206,9 @@ const ReportError = memo<Props>(({ module }) => {
         <CloseButton onClick={() => setIsOpen(false)} />
         <h2 className={styles.heading}>Reporting an issue with {module.moduleCode}</h2>
         <p>
-          NUSMods updates its information from the Registrar's Office every few hours. Please wait
-          up to 24 hours for information to be updated before reporting any issues.
+          NUSMods updates its information from the Office of the University Registrar every few
+          hours. Please wait up to 24 hours for information to be updated before reporting any
+          issues.
         </p>
         <p>
           This form will send an email about this course to the faculty. If you think the issue is a

--- a/website/src/views/mpe/MpeContainer.tsx
+++ b/website/src/views/mpe/MpeContainer.tsx
@@ -162,14 +162,14 @@ const MpeContainer: React.FC = () => {
           <p>
             Participation in the CPEx will be used as <strong>one of the tie-breakers</strong>{' '}
             during the CourseReg Exercise, in cases where the demand exceeds the available quota and
-            students have the same Priority Score for a particular module.
+            students have the same Priority Score for a particular course.
           </p>
           <p>
             For further questions, please refer to this{' '}
             <ExternalLink href="https://www.nus.edu.sg/registrar/docs/info/cpex/cpex-faqs.pdf">
               FAQ
             </ExternalLink>{' '}
-            provided by NUS Registrar's Office.
+            provided by NUS Office of the University Registrar.
           </p>
           <div>
             {isLoggedIn ? (


### PR DESCRIPTION
## Context
Requested text changes for the Course Planning Exercise (CPEx) by the Office of the University Registrar (OUR).

## Implementation
1. Changed "module" to "course" in the CPEx tie-breaker description (`MpeContainer.tsx`).
2. Changed "Registrar's Office" to "Office of the University Registrar" in:
   - CPEx page FAQ link (`MpeContainer.tsx`)
   - Module error reporting modal (`ReportError.tsx`)

## Screenshots

**CPEx Page (Old)**

<img width="860" height="923" alt="cpex-old" src="https://github.com/user-attachments/assets/16520f9c-c2cc-402b-bfc2-0a3ae65a7f98" />

**CPEx Page (New)**

<img width="860" height="923" alt="cpex-new" src="https://github.com/user-attachments/assets/d02edf4e-9d53-4b4c-a352-4ce2d7c6ff6c" />

**Report Error Modal (Old)**

<img width="860" height="923" alt="report-error-old" src="https://github.com/user-attachments/assets/ec591ee4-f319-4da5-a627-576347c25883" />

**Report Error Modal (New)**

<img width="860" height="923" alt="report-error-new" src="https://github.com/user-attachments/assets/6836e273-0258-4743-9f52-3a121b6a1214" />

