### PR TITLE
[WIP] Rebase lessonIndex drift

### DIFF
--- a/website/src/actions/timetables.test.ts
+++ b/website/src/actions/timetables.test.ts
@@ -140,7 +140,7 @@ describe('fillTimetableBlanks', () => {
     ...initialState,
     lessons: { [semester]: timetable },
   });
-  const action = actions.validateTimetable(semester);
+  const action = actions.validateTimetable(semester, () => []);
 
   test('do nothing if timetable is already full', async () => {
     const timetable = {

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -10,7 +10,14 @@ import type {
 } from 'types/timetables';
 import type { Dispatch, GetState } from 'types/redux';
 import type { TaModulesMapV1, ColorMapping, TaModulesMap } from 'types/reducers';
-import type { LessonIndex, LessonType, Module, ModuleCode, Semester } from 'types/modules';
+import type {
+  LessonIndex,
+  LessonType,
+  Module,
+  ModuleCode,
+  RawLessonWithIndex,
+  Semester,
+} from 'types/modules';
 
 import { fetchModule } from 'actions/moduleBank';
 import { openNotification } from 'actions/app';
@@ -220,7 +227,10 @@ export function setTimetable(
  * Valid TA modules configs must have lesson indices that belong to the correct lesson type
  * @param semester Semester of the timetable config to validate
  */
-export function validateTimetable(semester: Semester) {
+export function validateTimetable(
+  semester: Semester,
+  getStoredModuleSemesterTimetable: (moduleCode: ModuleCode) => readonly RawLessonWithIndex[],
+) {
   return async (dispatch: Dispatch, getState: GetState) => {
     const { timetables, moduleBank } = getState();
 
@@ -240,7 +250,12 @@ export function validateTimetable(semester: Semester) {
       migratedTaModulesConfig: ta,
       alreadyMigrated,
     } = await Promise.resolve(
-      migrateSemTimetableConfig(semTimetableConfig, taModulesConfig, getModuleSemesterTimetable),
+      migrateSemTimetableConfig(
+        semTimetableConfig,
+        taModulesConfig,
+        getModuleSemesterTimetable,
+        getStoredModuleSemesterTimetable,
+      ),
     );
 
     if (!alreadyMigrated) {

--- a/website/src/views/AppShell.tsx
+++ b/website/src/views/AppShell.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { FC, PropsWithChildren } from 'react';
 import type { SemTimetableConfig } from 'types/timetables';
-import type { Semester } from 'types/modules';
+import type { ModuleCode, Semester } from 'types/modules';
 import { DARK_COLOR_SCHEME } from 'types/settings';
 
 import { Helmet } from 'react-helmet';
@@ -31,6 +31,7 @@ import Logo from 'img/nusmods-logo.svg';
 import type { Dispatch } from 'types/redux';
 import type { State } from 'types/state';
 import type { Actions } from 'types/actions';
+import { getModuleTimetable } from 'utils/modules';
 import LoadingSpinner from './components/LoadingSpinner';
 import FeedbackModal from './components/FeedbackModal';
 import KeyboardShortcuts from './components/KeyboardShortcuts';
@@ -62,8 +63,12 @@ function useFetchModuleListAndTimetableModules(): {
 
   const fetchTimetableModules = useCallback(
     function fetchTimetableModulesImpl(timetable: SemTimetableConfig, semester: Semester) {
+      const storedModules = { ...store.getState().moduleBank.modules };
+      const getStoredModuleSemesterTimetable = (moduleCode: ModuleCode) =>
+        storedModules[moduleCode] ? getModuleTimetable(storedModules[moduleCode], semester) : [];
+
       dispatch(fetchTimetableModulesAction([timetable]))
-        .then(() => dispatch(validateTimetable(semester)))
+        .then(() => dispatch(validateTimetable(semester, getStoredModuleSemesterTimetable)))
         .catch((error) => {
           captureException(error);
           dispatch(
@@ -76,7 +81,7 @@ function useFetchModuleListAndTimetableModules(): {
           );
         });
     },
-    [dispatch],
+    [dispatch, store],
   );
 
   const fetchModuleListAndTimetableModules = useCallback(() => {


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
Fixes #4283.

## Implementation
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
- Store the info of selected mods before refreshing the module bank
- When validating the timetable, check that the mod to lesson index mapping is still valid by comparison the stored index and the new index of the mod
- This is implemented by creating a signature for each mod (basically serializes all fields in a `RawLesson`) because the signature lets us look up the new index

## Other Information
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
I've written unit tests but I haven't figured out how to actually test this.