### PR TITLE
fix(timetable): prevent lesson text overflow in timetable cell

### DIFF
--- a/website/src/views/timetable/TimetableCell.scss
+++ b/website/src/views/timetable/TimetableCell.scss
@@ -81,11 +81,10 @@ $cell-opacity: 0.5;
 }
 
 .moduleName {
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   min-width: 0;
   font-weight: 600;
   font-size: $font-size-xs;
-  word-break: break-word;
 }
 
 .weeksSpecial {


### PR DESCRIPTION
## Context
Fixes timetable lesson card text overflow at certain narrow/intermediate viewport widths.
Closes #4306 

## Implementation
Updated  to improve flex/text wrapping behavior in lesson cells:

- Added min-width: 0 to `.cellHeaader` so flex children can shrink.
- Added min-width: 0 to `.moduleName`.
- Added wrapping rules on `.moduleName`:
  - `overflow-wrap: anywhere`
  - `word-break: break-word`

This keeps long module titles within the timetable cell at awkward viewport sizes.

<img width="604" height="383" alt="image" src="https://github.com/user-attachments/assets/27eef65c-0f8f-4968-914d-b02445ce549d" />
