### PR TITLE
chore(build): update vercel ignore build config

### DIFF
--- a/scripts/vercel_ignore_build.sh
+++ b/scripts/vercel_ignore_build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 if [ "$VERCEL_GIT_COMMIT_REF" != "master" ] && [ "$VERCEL_GIT_COMMIT_REF" != "production" ] && [ "$VERCEL_GIT_COMMIT_REF" != "cpex-staging" ]; then 
     exit 0; 
 else 


### PR DESCRIPTION
Instead of configuring vercel on the platform, we can use this bash script instead