### PR TITLE
fix(website): reduce Vitest test flakiness

### DIFF
--- a/website/src/config/config.test.ts
+++ b/website/src/config/config.test.ts
@@ -27,17 +27,24 @@ flatten(Object.values(config.modRegSchedule)).forEach((round) => {
 });
 
 test('getSemesterKey() should be unique for every acad year / semester', () => {
+  const originalAcademicYear = config.academicYear;
+  const originalSemester = config.semester;
   const keys = new Set();
 
-  range(0, 40).forEach((offset) => {
-    const year = 2010 + offset;
-    config.academicYear = `${year}/${year + 1}`;
+  try {
+    range(0, 40).forEach((offset) => {
+      const year = 2010 + offset;
+      config.academicYear = `${year}/${year + 1}`;
 
-    Semesters.forEach((semester) => {
-      config.semester = semester;
+      Semesters.forEach((semester) => {
+        config.semester = semester;
 
-      expect(keys.has(config.getSemesterKey())).toBe(false);
-      keys.add(config.getSemesterKey());
+        expect(keys.has(config.getSemesterKey())).toBe(false);
+        keys.add(config.getSemesterKey());
+      });
     });
-  });
+  } finally {
+    config.academicYear = originalAcademicYear;
+    config.semester = originalSemester;
+  }
 });

--- a/website/src/storage/localStorage.test.ts
+++ b/website/src/storage/localStorage.test.ts
@@ -1,4 +1,33 @@
-import getLocalStorage, { createLocalStorageShim, canUseBrowserLocalStorage } from './localStorage';
+import { createLocalStorageShim } from './localStorage';
+
+async function loadLocalStorageModule() {
+  vi.resetModules();
+  return import('./localStorage');
+}
+
+function setWindowLocalStorage(localStorage?: Storage) {
+  if (localStorage) {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: localStorage,
+    });
+    return;
+  }
+
+  delete (window as Window & { localStorage?: Storage }).localStorage;
+}
+
+let originalLocalStorage: Storage;
+
+beforeEach(() => {
+  originalLocalStorage = window.localStorage;
+});
+
+afterEach(() => {
+  setWindowLocalStorage(originalLocalStorage);
+});
 
 describe(createLocalStorageShim, () => {
   test('should store and return data', () => {
@@ -36,47 +65,46 @@ describe(createLocalStorageShim, () => {
 });
 
 describe('#canUseBrowserLocalStorage', () => {
-  let localStorage: typeof window.localStorage;
-  beforeEach(() => {
-    localStorage = window.localStorage;
-    delete (window as any).localStorage;
-  });
-
-  afterEach(() => {
-    (window as any).localStorage = localStorage;
-  });
-
-  test('should return false if localStorage is undefined', () => {
+  test('should return false if localStorage is undefined', async () => {
+    const { canUseBrowserLocalStorage } = await loadLocalStorageModule();
+    setWindowLocalStorage();
     expect(canUseBrowserLocalStorage()).toEqual(false);
   });
 
-  test('should return false if localStorage throws when writing on iOS <=10 on private browsing', () => {
-    (window as any).localStorage = {
+  test('should return false if localStorage throws when writing on iOS <=10 on private browsing', async () => {
+    const { canUseBrowserLocalStorage } = await loadLocalStorageModule();
+    setWindowLocalStorage({
       ...createLocalStorageShim(),
       // the length is set here because canUseBrowserLocalStorage uses a hack to detect private browsing
       length: 0,
       setItem: () => {
         throw new Error();
       },
-    };
+    } as Storage);
     expect(canUseBrowserLocalStorage()).toEqual(false);
   });
 
-  test('should return true if localStorage is localStorage-like object', () => {
-    (window as any).localStorage = createLocalStorageShim();
+  test('should return true if localStorage is localStorage-like object', async () => {
+    const { canUseBrowserLocalStorage } = await loadLocalStorageModule();
+    setWindowLocalStorage(createLocalStorageShim());
 
     expect(canUseBrowserLocalStorage()).toEqual(true);
   });
 });
 
-describe(getLocalStorage, () => {
-  test("should return the actual browser's localStorage if the browser can use localStorage", () => {
+describe('getLocalStorage', () => {
+  test('should return window.localStorage if it can be used', async () => {
+    const { canUseBrowserLocalStorage, default: getLocalStorage } = await loadLocalStorageModule();
+    const localStorage = createLocalStorageShim();
+    setWindowLocalStorage(localStorage);
+
     expect(canUseBrowserLocalStorage()).toEqual(true);
     expect(getLocalStorage()).toBe(window.localStorage);
   });
 
-  test('should return a shim if browser cannot use localStorage', () => {
-    delete (window as any).localStorage;
+  test('should return a shim if browser cannot use localStorage', async () => {
+    const { canUseBrowserLocalStorage, default: getLocalStorage } = await loadLocalStorageModule();
+    setWindowLocalStorage();
 
     expect(canUseBrowserLocalStorage()).toEqual(false);
     expect(getLocalStorage()).toMatchObject(

--- a/website/src/views/modules/ModuleArchiveContainer.test.tsx
+++ b/website/src/views/modules/ModuleArchiveContainer.test.tsx
@@ -15,6 +15,9 @@ import { ModuleArchiveContainerComponent } from './ModuleArchiveContainer';
 const jest = vi;
 vi.mock('views/components/RandomKawaii');
 vi.mock('utils/error');
+vi.mock('views/modules/ModulePageContent', () => ({
+  default: ({ module }: { module: { description?: string } }) => <div>{module.description}</div>,
+}));
 
 const cs1010sResponse: AxiosResponse = {
   data: CS1010S,

--- a/website/src/views/modules/ModulePageContainer.test.tsx
+++ b/website/src/views/modules/ModulePageContainer.test.tsx
@@ -15,6 +15,9 @@ import { ModulePageContainerComponent } from './ModulePageContainer';
 const jest = vi;
 vi.mock('views/components/RandomKawaii');
 vi.mock('utils/error');
+vi.mock('views/modules/ModulePageContent', () => ({
+  default: ({ module }: { module: { description?: string } }) => <div>{module.description}</div>,
+}));
 
 const cs1010sResponse: AxiosResponse = {
   data: CS1010S,


### PR DESCRIPTION
## Summary
- restore mutated config state in 
- isolate  tests from module-level cached state and window mutations
- mock  in container tests so they don't depend on the real lazy import path

## Testing
- 
 RUN  v4.0.18 /Users/yangshun/Developer/nusmods/website/src

 ✓ storage/localStorage.test.ts > createLocalStorageShim > should store and return data 2ms
 ✓ storage/localStorage.test.ts > createLocalStorageShim > should remove keys and clear 1ms
 ✓ storage/localStorage.test.ts > createLocalStorageShim > should return null when getting nonexistent data 1ms
 ✓ storage/localStorage.test.ts > createLocalStorageShim > should not throw when removing nonexistent key 1ms
 ✓ storage/localStorage.test.ts > #canUseBrowserLocalStorage > should return false if localStorage is undefined 1ms
 ✓ storage/localStorage.test.ts > #canUseBrowserLocalStorage > should return false if localStorage throws when writing on iOS <=10 on private browsing 1ms
 ✓ storage/localStorage.test.ts > #canUseBrowserLocalStorage > should return true if localStorage is localStorage-like object 0ms
 ✓ storage/localStorage.test.ts > getLocalStorage > should return window.localStorage if it can be used 0ms
 ✓ storage/localStorage.test.ts > getLocalStorage > should return a shim if browser cannot use localStorage 1ms
 ✓ config/config.test.ts > Academic calendar should have start dates for the current academic year 1ms
 ✓ config/config.test.ts > Every ModReg round has unique keys 1ms
 ✓ config/config.test.ts > Select Courses 1 should end after it starts 0ms
 ✓ config/config.test.ts > Select Courses 2 should end after it starts 0ms
 ✓ config/config.test.ts > Select Courses 3 should end after it starts 0ms
 ✓ config/config.test.ts > Select Tutorials / Labs 1 should end after it starts 0ms
 ✓ config/config.test.ts > Select Tutorials / Labs 2 should end after it starts 0ms
 ✓ config/config.test.ts > Add / Swap Tutorials  should end after it starts 0ms
 ✓ config/config.test.ts > Course Planning Exercise (CPEx)  should end after it starts 0ms
 ✓ config/config.test.ts > Select Courses 1 should end after it starts 0ms
 ✓ config/config.test.ts > Select Courses 2 should end after it starts 0ms
 ✓ config/config.test.ts > Select Courses 3 should end after it starts 0ms
 ✓ config/config.test.ts > Select Tutorials / Labs 1 should end after it starts 0ms
 ✓ config/config.test.ts > Select Tutorials / Labs 2 should end after it starts 0ms
 ✓ config/config.test.ts > Add / Swap Tutorials  should end after it starts 0ms
 ✓ config/config.test.ts > Course Planning Exercise (CPEx)  should end after it starts 0ms
 ✓ config/config.test.ts > getSemesterKey() should be unique for every acad year / semester 2ms
 ✓ views/modules/ModuleArchiveContainer.test.tsx > ModuleArchiveContainerComponent > should show 404 page when the course code does not exist 34ms
 ✓ views/modules/ModuleArchiveContainer.test.tsx > ModuleArchiveContainerComponent > should redirect to canonical URL 7ms
 ✓ views/modules/ModuleArchiveContainer.test.tsx > ModuleArchiveContainerComponent > should fetch module 6ms
 ✓ views/modules/ModuleArchiveContainer.test.tsx > ModuleArchiveContainerComponent > should show error if module fetch failed 7ms
 ✓ views/modules/ModulePageContainer.test.tsx > ModulePageContainerComponent > should show 404 page when the module code does not exist 35ms
 ✓ views/modules/ModulePageContainer.test.tsx > ModulePageContainerComponent > should redirect to canonical URL 8ms
 ✓ views/modules/ModulePageContainer.test.tsx > ModulePageContainerComponent > should fetch module 5ms
 ✓ views/modules/ModulePageContainer.test.tsx > ModulePageContainerComponent > should show error if module fetch failed 6ms

 Test Files  4 passed (4)
      Tests  34 passed (34)
   Start at  20:39:52
   Duration  2.36s (transform 909ms, setup 1.17s, import 2.44s, tests 122ms, environment 1.95s)

## Notes
- I also ran the repo's flaky stress script during investigation; these changes address the shared-state failures that were reproducible in the targeted tests.