### PR TITLE
fix(scraper): fix build output path and yargs compatibility with pnpm

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,8 +277,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       yargs:
-        specifier: 16.2.0
-        version: 16.2.0
+        specifier: 17.7.2
+        version: 17.7.2
     devDependencies:
       '@nkzw/eslint-plugin':
         specifier: ^2.0.0
@@ -317,7 +317,7 @@ importers:
         specifier: 0.30.2
         version: 0.30.2
       '@types/yargs':
-        specifier: 17.0.33
+        specifier: '17'
         version: 17.0.33
       '@vitest/coverage-v8':
         specifier: ^4.0.18

--- a/scrapers/nus-v2/package.json
+++ b/scrapers/nus-v2/package.json
@@ -35,7 +35,7 @@
     "promise-queue": "2.2.5",
     "ramda": "0.30.1",
     "romanify": "1.0.0",
-    "yargs": "16.2.0"
+    "yargs": "17.7.2"
   },
   "devDependencies": {
     "@nkzw/eslint-plugin": "^2.0.0",
@@ -50,7 +50,7 @@
     "@types/oboe": "2.1.4",
     "@types/promise-queue": "2.2.3",
     "@types/ramda": "0.30.2",
-    "@types/yargs": "17.0.33",
+    "@types/yargs": "17",
     "@vitest/coverage-v8": "^4.0.18",
     "antlr4ts-cli": "^0.5.0-alpha.4",
     "eslint-plugin-no-only-tests": "^3.3.0",

--- a/scrapers/nus-v2/tsconfig.prod.json
+++ b/scrapers/nus-v2/tsconfig.prod.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["**/*.test.ts", "**/__mocks__"],
+  "exclude": ["**/*.test.ts", "**/__mocks__", "vitest.config.ts"],
   "compilerOptions": {
     "sourceMap": true,
     "inlineSources": true,


### PR DESCRIPTION
## Summary
- Exclude `vitest.config.ts` from `tsconfig.prod.json` to fix build output path (`build/src/index.js` → `build/index.js`). With the file included, TypeScript inferred `rootDir` as the project root instead of `src/`.
- Upgrade yargs from v16 to v17 since `parseAsync()` is only available in v17. Previously resolved via yarn's hoisting, but pnpm's stricter resolution exposed the mismatch.

## Test plan
- [x] Run `pnpm build` in `scrapers/nus-v2` and verify output is at `build/index.js`
- [x] Run `pnpm scrape` and verify the scraper starts without `parseAsync` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)