### PR TITLE
fix: close browser after export

### DIFF
--- a/export/src/handler.ts
+++ b/export/src/handler.ts
@@ -75,7 +75,7 @@ export function makeExportHandler<T>(
         // Export
         await performExport(response, page, data);
       } finally {
-        await browser?.close();
+        await browser.close();
       }
     } catch (error) {
       const eventId = Sentry.captureException(error.original || error);

--- a/export/src/handler.ts
+++ b/export/src/handler.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/node';
 import type { VercelApiHandler, VercelRequest, VercelResponse } from '@vercel/node';
-import type { Page } from 'puppeteer-core';
+import type { Browser, Page } from 'puppeteer-core';
 
 import * as render from './render-serverless';
 import config from './config';
@@ -56,9 +56,10 @@ export function makeExportHandler<T>(
 
       // Prepare browser for export
       const url = config.page;
+      let browser: Browser;
       let page: Page;
       try {
-        page = await render.open(url);
+        ({ browser, page } = await render.open(url));
       } catch (error) {
         if (error.message.includes('ERR_CONNECTION_REFUSED')) {
           throw new HttpError(
@@ -70,11 +71,12 @@ export function makeExportHandler<T>(
         throw new HttpError(500, 'Cannot start browser', error);
       }
 
-      // Export
-      await performExport(response, page, data);
-
-      // Cleanup
-      await page.close();
+      try {
+        // Export
+        await performExport(response, page, data);
+      } finally {
+        await browser?.close();
+      }
     } catch (error) {
       const eventId = Sentry.captureException(error.original || error);
 

--- a/export/src/render-serverless.ts
+++ b/export/src/render-serverless.ts
@@ -1,5 +1,5 @@
 import chromium from '@sparticuz/chromium';
-import puppeteer, { Page } from 'puppeteer-core';
+import puppeteer, { Browser, Page } from 'puppeteer-core';
 
 import { resolveChromeExecutable } from './chrome-executable';
 import { getModules } from './data';
@@ -23,7 +23,7 @@ async function setViewport(page: Page, options: ViewportOptions = {}) {
   });
 }
 
-export async function open(url: string) {
+export async function open(url: string): Promise<{ browser: Browser; page: Page }> {
   const executablePath = await resolveChromeExecutable(() => chromium.executablePath());
 
   chromium.setGraphicsMode = false;
@@ -35,11 +35,16 @@ export async function open(url: string) {
     headless: 'shell',
   });
 
-  const page = await browser.newPage();
-  await page.goto(url, { waitUntil: 'load' });
-  await setViewport(page);
+  try {
+    const page = await browser.newPage();
+    await page.goto(url, { waitUntil: 'load' });
+    await setViewport(page);
 
-  return page;
+    return { browser, page };
+  } catch (error) {
+    await browser.close();
+    throw error;
+  }
 }
 
 async function injectData(page: Page, data: ExportData) {


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context

<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

The serverless export service [opens a browser](https://github.com/nusmodifications/nusmods/blob/master/export/src/render-serverless.ts#L31) but only [returns the page handler](https://github.com/nusmodifications/nusmods/blob/master/export/src/render-serverless.ts#L42)

Then, cleanup only [closes the page](https://github.com/nusmodifications/nusmods/blob/master/export/src/handler.ts#L77), leaving the browser handle open.

## Implementation

<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

- Return both the browser and page handle in the `open` function
- Close the browser after the export completes, this closes the page as well
<img width="649" height="169" alt="image" src="https://github.com/user-attachments/assets/03bd8206-dfab-4953-81e4-f6bc61401752" />

## Other Information

<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
Disclaimer: 
I found this leak with [Codex Security](https://developers.openai.com/codex/security) and told @ravern about it!
