### PR TITLE
chore(venue): add maintenance instructions for venue issues

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -4,6 +4,10 @@ Create a new issue on GitHub with this checklist after the finals every semester
 
 ## Every Year
 
+### Around End of Semester 2
+
+- [ ] Venue issues are created by [Cloudflare workers](https://github.com/nusmodifications/serverless-functions), and the GitHub access token expires after 366 days. Update the personal access token on the Cloudflare dashboard and grant write permissions under [Issues](https://docs.github.com/en/rest/issues/issues?apiVersion=2026-03-10#create-an-issue) for the `nusmods` repository.
+
 ### 1 week before NUS IT Data Update
 
 - **Prepare "PR1"**
@@ -39,16 +43,19 @@ Reference PRs: [PR #3286](https://github.com/nusmodifications/nusmods/pull/3286)
 ## CPEx
 
 ### Before CPEx Testing
-  - [ ] Update `ACADEMIC_YEAR` in `scrapers/cpex-scraper/src/index.ts`. It should be for the **next** semester
-  - [ ] Create PR and merge to production
-  - [ ] Run scraper
+
+- [ ] Update `ACADEMIC_YEAR` in `scrapers/cpex-scraper/src/index.ts`. It should be for the **next** semester
+- [ ] Create PR and merge to production
+- [ ] Run scraper
 
 ### During CPEx Testing
+
 For `cpex-staging` deployment
-  - [ ] Update `MPE_SEMESTER` in `website/src/views/mpe/constants.ts` to be the semester you're configuring CPEx for (usually the next semester)
-  - [ ] Update dates in the ModReg schedule in `website/src/data/modreg-schedule.json`
-  - [ ] Enable the `enableCPExforProd` and `showCPExTab` flags in `website/src/featureFlags.ts`
-  - [ ] Push onto `cpex-staging` branch (Ensure synced with `master` branch first), then visit https://cpex-staging.nusmods.com/cpex and verify that NUS authentication is working
+
+- [ ] Update `MPE_SEMESTER` in `website/src/views/mpe/constants.ts` to be the semester you're configuring CPEx for (usually the next semester)
+- [ ] Update dates in the ModReg schedule in `website/src/data/modreg-schedule.json`
+- [ ] Enable the `enableCPExforProd` and `showCPExTab` flags in `website/src/featureFlags.ts`
+- [ ] Push onto `cpex-staging` branch (Ensure synced with `master` branch first), then visit https://cpex-staging.nusmods.com/cpex and verify that NUS authentication is working
 
 ```bash
 git checkout master
@@ -59,10 +66,12 @@ git push
 ```
 
 ### During CPEx
+
 - [ ] Merge `cpex-staging` into `master` via PR
 - [ ] Deploy latest `master` to `production`
 
 ### After CPEx
+
 - [ ] Disable the `enableCPExforProd` and `showCPExTab` flags in `website/src/featureFlags.ts`
 - [ ] Merge into `master`
 - [ ] Deploy latest `master` to `production`


### PR DESCRIPTION
## Context

Closes #4362. Venue updates stopped working a while ago, but this was due to their GitHub tokens expiring. I have generated a new token and updated the maintenance instructions.

Closes #4395.
Closes #4396.
Closes #4397.
