### PR TITLE
fix: limit build times for export and website to 5m

### DIFF
--- a/export/vercel.json
+++ b/export/vercel.json
@@ -1,4 +1,6 @@
 {
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "timeout 5m pnpm build",
   "routes": [
     { "handle": "filesystem" },
     {

--- a/export/vercel.json
+++ b/export/vercel.json
@@ -1,6 +1,6 @@
 {
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "timeout 5m pnpm build",
+  "buildCommand": "timeout --kill-after=30s 5m pnpm build",
   "routes": [
     { "handle": "filesystem" },
     {

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,6 +1,6 @@
 {
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm build",
+  "buildCommand": "timeout 5m pnpm build",
   "functions": {
     "api/**/*.ts": {
       "excludeFiles": "./tsconfig.json",

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,6 +1,6 @@
 {
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "timeout 5m pnpm build",
+  "buildCommand": "timeout --kill-after=30s 5m pnpm build",
   "functions": {
     "api/**/*.ts": {
       "excludeFiles": "./tsconfig.json",


### PR DESCRIPTION
Closes #4368 

We should limit our build times in order not to incur fees for additional builds and handle long builds accordingly