### PR TITLE
fix: irregular WeekRange tooltip by appending to document.body

### DIFF
--- a/website/src/views/timetable/TimetableCell.tsx
+++ b/website/src/views/timetable/TimetableCell.tsx
@@ -100,7 +100,7 @@ function formatWeekRange(weekRange: WeekRange) {
   );
 
   return (
-    <Tooltip content={table} interactive arrow>
+    <Tooltip content={table} interactive arrow appendTo={() => document.body}>
       <span className={styles.weeksSpecial}>{dateRange}</span>
     </Tooltip>
   );


### PR DESCRIPTION
<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context

<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
closes #4385 

irregular WeekRange tooltip in timetable cells was cut off visually, likely due to "interactive" property which made it mount into the reference's parent container. This caused the tooltip to get clipped off at the container boundary instead of just floating freely.

## Implementation

<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

fixed it by appending tooltip to the document.body instead of scrollable timetable parent.

<img width="768" height="354" alt="Screenshot 2026-05-25 at 12 16 25 AM" src="https://github.com/user-attachments/assets/1e14f911-2337-48ff-9259-e70e21e466c9" />

## Other Information

<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
