### PR TITLE
Refactor serialization/deserialization tests

### DIFF
--- a/website/src/utils/timetables/shareLinks.test.ts
+++ b/website/src/utils/timetables/shareLinks.test.ts
@@ -18,219 +18,244 @@ describe('timetable serialization/deserialization', () => {
   const mockGetModuleSemesterTimetable = (moduleCode: ModuleCode): readonly RawLessonWithIndex[] =>
     get(mockSemesterTimetable, moduleCode);
 
-  test('timetable serialization/deserialization', () => {
-    const configs: SemTimetableConfig[] = [
-      {},
-      { CS1010S: {} },
-      {
-        GER1000: { Tutorial: [13] },
-      },
-      {
-        CS4243: { Laboratory: [2], Lecture: [5] },
-        GER1000: { Tutorial: [13] },
-      },
-    ];
+  const deserialize = (serializedConfig: string) =>
+    deserializeTimetable(serializedConfig, mockGetModuleSemesterTimetable);
 
-    configs.forEach((config) => {
-      expect(
-        deserializeTimetable(serializeTimetable(config), mockGetModuleSemesterTimetable)
-          .semTimetableConfig,
-      ).toEqual(config);
-    });
-  });
+  describe('deserialized config should be identical to config that was serialized', () => {
+    const serializeThenDeserialize = (config: SemTimetableConfig) =>
+      deserialize(serializeTimetable(config)).semTimetableConfig;
 
-  test('deserializing timetable with ta and hidden modules', () => {
-    expect(
-      deserializeTimetable(
-        'CS1010S=LEC:(0)&CS3216=LEC:(0)&ta=CS1010S&hidden=CS3216',
-        mockGetModuleSemesterTimetable,
-      ),
-    ).toEqual({
-      semTimetableConfig: {
-        CS1010S: {
-          Lecture: [0],
+    test('timetable serialization/deserialization', () => {
+      const configs: SemTimetableConfig[] = [
+        {},
+        { CS1010S: {} },
+        {
+          GER1000: { Tutorial: [13] },
         },
-        CS3216: {
-          Lecture: [0],
+        {
+          CS4243: { Laboratory: [2], Lecture: [5] },
+          GER1000: { Tutorial: [13] },
         },
-      },
-      ta: ['CS1010S'],
-      hidden: ['CS3216'],
-    });
-  });
+      ];
 
-  describe('deserializing edge cases', () => {
-    test('duplicate module code', () => {
-      expect(
-        deserializeTimetable('CS1010S=LEC:(0)&CS1010S=REC:(1)', mockGetModuleSemesterTimetable)
-          .semTimetableConfig,
-      ).toEqual({
-        CS1010S: {
-          Lecture: [0],
-          Recitation: [1],
-        },
+      configs.forEach((config) => {
+        expect(serializeThenDeserialize(config)).toEqual(config);
       });
     });
 
-    test('no lessons', () => {
-      expect(
-        deserializeTimetable(
-          'CS2105&CS3217&CS1010S=LEC:(0)&ta=&hidden=',
-          mockGetModuleSemesterTimetable,
-        ).semTimetableConfig,
-      ).toEqual({
-        CS2105: {},
-        CS3217: {},
-        CS1010S: {
-          Lecture: [0],
-        },
-      });
-    });
-
-    test('should ignore invalid lesson indices', () => {
-      expect(
-        deserializeTimetable('CS1010S=LEC:(20)', mockGetModuleSemesterTimetable).semTimetableConfig,
-      ).toEqual({
-        CS1010S: {
-          Lecture: [],
-        },
-      });
-    });
-  });
-
-  test('should return empty array if v2 serialized', () => {
-    expect(parseTaModuleCodes('(CS1010S,CS3216)')).toEqual([]);
-  });
-
-  describe('deserialize v1 config', () => {
-    test('deserialize v1', () => {
-      expect(
-        deserializeTimetable(
-          'CS1010S=LEC:1,TUT:8&CS3216=LEC:1&ta=CS3216(LEC:1),CS1010S(LEC:1,TUT:2,TUT:3)&hidden=CS3216',
-          mockGetModuleSemesterTimetable,
-        ),
-      ).toEqual({
+    test('deserializing timetable with ta and hidden modules', () => {
+      expect(deserialize('CS1010S=LEC:(0)&CS3216=LEC:(0)&ta=CS1010S&hidden=CS3216')).toEqual({
         semTimetableConfig: {
           CS1010S: {
             Lecture: [0],
-            Tutorial: [21, 30],
           },
           CS3216: {
             Lecture: [0],
           },
         },
-        ta: ['CS3216', 'CS1010S'],
+        ta: ['CS1010S'],
         hidden: ['CS3216'],
       });
     });
+  });
 
-    test('should ignore invalid lesson type', () => {
-      expect(
-        deserializeTimetable(
-          'CS1010S=LEC:1&ta=CS1010S(TUT:2,INVALIDLESSONTYPE:1)',
-          mockGetModuleSemesterTimetable,
-        ),
-      ).toEqual({
-        semTimetableConfig: {
-          CS1010S: {
-            Tutorial: [21],
+  describe('deserializing v2 strings', () => {
+    describe('typical strings', () => {
+      test('with non-ta modules and ta modules', () => {
+        expect(
+          deserialize(
+            'CS1010S=LEC:(0);REC:(3);TUT:(30)' + '&CS4243=LAB:(1);LEC:(5)' + '&ta=CS4243',
+          ),
+        ).toStrictEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Lecture: [0],
+              Recitation: [3],
+              Tutorial: [30],
+            },
+            CS4243: {
+              Laboratory: [1],
+              Lecture: [5],
+            },
           },
-        },
-        ta: ['CS1010S'],
-        hidden: [],
+          ta: ['CS4243'],
+          hidden: [],
+        });
+      });
+      test('with non-ta modules and ta modules that are hidden', () => {
+        expect(
+          deserialize(
+            'CS1010S=LEC:(0);REC:(3);TUT:(30)' +
+              '&CS4243=LAB:(1);LEC:(5)' +
+              '&hidden=CS1010S,CS4243' +
+              '&ta=CS4243',
+          ),
+        ).toStrictEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Lecture: [0],
+              Recitation: [3],
+              Tutorial: [30],
+            },
+            CS4243: {
+              Laboratory: [1],
+              Lecture: [5],
+            },
+          },
+          ta: ['CS4243'],
+          hidden: ['CS1010S', 'CS4243'],
+        });
       });
     });
 
-    test('should ignore invalid classNo', () => {
-      expect(
-        deserializeTimetable('CS1010S=LEC:INVALIDCLASSNO', mockGetModuleSemesterTimetable),
-      ).toEqual({
-        semTimetableConfig: {
-          CS1010S: {
-            Lecture: [],
+    describe('deserializing edge cases', () => {
+      test('duplicate module code', () => {
+        expect(deserialize('CS1010S=LEC:(0)&CS1010S=REC:(1)')).toEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Lecture: [0],
+              Recitation: [1],
+            },
           },
-        },
-        ta: [],
-        hidden: [],
+          ta: [],
+          hidden: [],
+        });
+      });
+
+      test('no lessons', () => {
+        expect(deserialize('CS2105&CS3217&CS1010S=LEC:(0)&ta=&hidden=')).toEqual({
+          semTimetableConfig: {
+            CS2105: {},
+            CS3217: {},
+            CS1010S: {
+              Lecture: [0],
+            },
+          },
+          ta: [],
+          hidden: [],
+        });
+      });
+
+      test('should ignore invalid lesson indices', () => {
+        expect(deserialize('CS1010S=LEC:(20)')).toEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Lecture: [],
+            },
+          },
+          ta: [],
+          hidden: [],
+        });
+      });
+    });
+  });
+
+  describe('deserializing v1 strings', () => {
+    describe('typical strings', () => {
+      test('with non-ta modules and ta modules', () => {
+        expect(
+          deserialize(
+            'CS1010S=LEC:1,TUT:8&CS3216=LEC:1&ta=CS3216(LEC:1),CS1010S(LEC:1,TUT:2,TUT:3)&hidden=CS3216',
+          ),
+        ).toEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Lecture: [0],
+              Tutorial: [21, 30],
+            },
+            CS3216: {
+              Lecture: [0],
+            },
+          },
+          ta: ['CS3216', 'CS1010S'],
+          hidden: ['CS3216'],
+        });
       });
     });
 
-    test('use only last ta param', () => {
-      expect(
-        deserializeTimetable(
-          'CS1010S=LEC:1&ta=CS3216(LEC:1)&ta=CS1010S(TUT:2)',
-          mockGetModuleSemesterTimetable,
-        ),
-      ).toEqual({
-        semTimetableConfig: {
-          CS1010S: {
-            Tutorial: [21],
+    describe('deserializing edge cases', () => {
+      test('should ignore invalid lesson type', () => {
+        expect(deserialize('CS1010S=LEC:1&ta=CS1010S(TUT:2,INVALIDLESSONTYPE:1)')).toEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Tutorial: [21],
+            },
           },
-        },
-        ta: ['CS1010S'],
-        hidden: [],
+          ta: ['CS1010S'],
+          hidden: [],
+        });
       });
-    });
 
-    test('should ignore invalid ta lessons', () => {
-      expect(
-        deserializeTimetable('CS1010S=LEC:1&ta=CS1010S(LEC:2)', mockGetModuleSemesterTimetable),
-      ).toEqual({
-        semTimetableConfig: {
-          CS1010S: {
-            Lecture: [],
+      test('should ignore invalid classNo', () => {
+        expect(deserialize('CS1010S=LEC:INVALIDCLASSNO')).toEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Lecture: [],
+            },
           },
-        },
-        ta: ['CS1010S'],
-        hidden: [],
+          ta: [],
+          hidden: [],
+        });
       });
-    });
 
-    test('ta module config without lessons', () => {
-      expect(
-        deserializeTimetable('CS1010S=LEC:1,TUT:3&ta=CS1010S()', mockGetModuleSemesterTimetable),
-      ).toEqual({
-        semTimetableConfig: {
-          CS1010S: {},
-        },
-        ta: ['CS1010S'],
-        hidden: [],
-      });
-    });
-
-    test('ignore modules without semester data', () => {
-      expect(
-        deserializeTimetable(
-          'CS1010S=LEC:1,REC:1,TUT:3&ta=CS3217(LEC:1)',
-          mockGetModuleSemesterTimetable,
-        ),
-      ).toEqual({
-        semTimetableConfig: {
-          CS1010S: {
-            Lecture: [0],
-            Recitation: [1],
-            Tutorial: [30],
+      test('use only last ta param', () => {
+        expect(deserialize('CS1010S=LEC:1&ta=CS3216(LEC:1)&ta=CS1010S(TUT:2)')).toEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Tutorial: [21],
+            },
           },
-        },
-        ta: [],
-        hidden: [],
+          ta: ['CS1010S'],
+          hidden: [],
+        });
       });
-    });
 
-    test('should ignore invalid ta module config', () => {
-      expect(
-        deserializeTimetable(
-          'CS1010S=LEC:1,REC:1,TUT:3&ta=INVALID),CS1010S(LEC:1)',
-          mockGetModuleSemesterTimetable,
-        ),
-      ).toEqual({
-        semTimetableConfig: {
-          CS1010S: {
-            Lecture: [0],
+      test('should ignore invalid ta lessons', () => {
+        expect(deserialize('CS1010S=LEC:1&ta=CS1010S(LEC:2)')).toEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Lecture: [],
+            },
           },
-        },
-        ta: ['CS1010S'],
-        hidden: [],
+          ta: ['CS1010S'],
+          hidden: [],
+        });
+      });
+
+      test('ta module config without lessons', () => {
+        expect(deserialize('CS1010S=LEC:1,TUT:3&ta=CS1010S()')).toEqual({
+          semTimetableConfig: {
+            CS1010S: {},
+          },
+          ta: ['CS1010S'],
+          hidden: [],
+        });
+      });
+
+      test('ignore modules without semester data', () => {
+        expect(deserialize('CS1010S=LEC:1,REC:1,TUT:3&ta=CS3217(LEC:1)')).toEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Lecture: [0],
+              Recitation: [1],
+              Tutorial: [30],
+            },
+          },
+          ta: [],
+          hidden: [],
+        });
+      });
+
+      test('should ignore invalid ta module config', () => {
+        expect(deserialize('CS1010S=LEC:1,REC:1,TUT:3&ta=INVALID),CS1010S(LEC:1)')).toEqual({
+          semTimetableConfig: {
+            CS1010S: {
+              Lecture: [0],
+            },
+          },
+          ta: ['CS1010S'],
+          hidden: [],
+        });
       });
     });
 


### PR DESCRIPTION
Refactoring to make it easier to categorize and write tests for the v3 serialization/deserialization logic.

A change I made is to check the entire config, including the hidden and TA module list.