### PR TITLE
[codex] Polish random course button

### DIFF
--- a/website/src/views/modules/ModuleRandomButton.scss
+++ b/website/src/views/modules/ModuleRandomButton.scss
@@ -4,6 +4,34 @@
   composes: btn btn-secondary btn-svg from global;
   flex-grow: 1;
   margin-bottom: 2rem;
+  transition:
+    box-shadow $desktop-entering-duration $material-deceleration-curve,
+    transform $desktop-entering-duration $material-deceleration-curve;
+
+  :global(.svg) {
+    transition: transform $desktop-entering-duration $material-deceleration-curve;
+  }
+
+  &:hover,
+  &:focus {
+    box-shadow: 0 0.25rem 0.75rem rgba(#000, 0.18);
+    transform: translateY(-1px);
+
+    :global(.svg) {
+      transform: rotate(-12deg);
+    }
+  }
+
+  &:focus-visible {
+    box-shadow:
+      0 0.25rem 0.75rem rgba(#000, 0.18),
+      0 0 0 0.2rem rgba(theme-color(), 0.28);
+  }
+
+  &:active {
+    box-shadow: none;
+    transform: translateY(0);
+  }
 
   @include media-breakpoint-down(md) {
     margin: 0 1rem;


### PR DESCRIPTION
## Summary
- Adds a subtle hover/focus lift to the Random Course button in the course finder.
- Animates the shuffle icon slightly on hover/focus and adds a clearer focus-visible ring.

## Impact
This is a small visual polish change only; the button behavior is unchanged.

## Validation
- `pnpm --dir website lint:styles`
- `pnpm format:check -- website/src/views/modules/ModuleRandomButton.scss`
- Started the website dev server at `http://127.0.0.1:3000/courses` and verified the Random Course button is present with the compiled transition styles.
