### PR TITLE
Refactor the unrelated `getModuleSemester` function out of `lessonIndices`

### DIFF
--- a/website/src/utils/timetables/index.ts
+++ b/website/src/utils/timetables/index.ts
@@ -1,5 +1,15 @@
 import { AcadWeekInfo } from 'nusmoderator';
-import { flatMapDeep, groupBy, isEqual, map, mapValues, range, sample, values } from 'lodash-es';
+import {
+  flatMapDeep,
+  groupBy,
+  isEqual,
+  map,
+  mapValues,
+  pick,
+  range,
+  sample,
+  values,
+} from 'lodash-es';
 import { addDays, min as minDate, parseISO, startOfDay } from 'date-fns';
 
 import {
@@ -9,6 +19,7 @@ import {
   NumericWeeks,
   RawLesson,
   Semester,
+  Module,
 } from 'types/modules';
 
 import {
@@ -22,6 +33,7 @@ import {
 
 import { getTimeAsDate } from '../timify';
 import { deltas } from '../array';
+import { ModulesMap } from 'types/reducers';
 
 export function isValidSemester(semester: Semester): boolean {
   return semester >= 1 && semester <= 4;
@@ -183,6 +195,14 @@ export function getHoverLesson(lesson: InteractableLesson): HoverLesson {
   };
 }
 
+// Get information for all modules present in a semester timetable config
+export function getSemesterModules(
+  timetable: { [moduleCode: string]: unknown },
+  modules: ModulesMap,
+): Module[] {
+  return values(pick(modules, Object.keys(timetable)));
+}
+
 export { findExamClashes } from './exams';
 export { isInteractable, getInteractableLessons } from './interactabilityHydration';
 export { hydrateSemTimetableWithLessons } from './lessonHydration';
@@ -190,7 +210,6 @@ export {
   getClosestLessonConfig,
   getLessonIndices,
   getRecoveryLessonIndices,
-  getSemesterModules,
   makeLessonIndicesMap,
 } from './lessonIndices';
 export { LESSON_ABBREV_TYPE, LESSON_TYPE_ABBREV, getLessonIdentifier } from './lessonId';

--- a/website/src/utils/timetables/lessonIndices.ts
+++ b/website/src/utils/timetables/lessonIndices.ts
@@ -8,19 +8,15 @@ import {
   map,
   mapValues,
   maxBy,
-  pick,
   reduce,
-  values,
 } from 'lodash-es';
 import {
   ClassNo,
   LessonIndex,
   LessonIndicesMap,
   LessonType,
-  Module,
   RawLessonWithIndex,
 } from 'types/modules';
-import { ModulesMap } from 'types/reducers';
 import { ModuleLessonConfig } from 'types/timetables';
 
 /**
@@ -73,14 +69,6 @@ export const getLessonIndices = (
   lessonType: LessonType,
   classNo: ClassNo,
 ): LessonIndex[] => get(get(lessonIndicesMap, lessonType), classNo);
-
-// Get information for all modules present in a semester timetable config
-export function getSemesterModules(
-  timetable: { [moduleCode: string]: unknown },
-  modules: ModulesMap,
-): Module[] {
-  return values(pick(modules, Object.keys(timetable)));
-}
 
 /**
  * Based on what lessons are currently in the lesson config, find the classNo that most of the lessons belong to


### PR DESCRIPTION
Refactor the `getModuleSemester` function that is unrelated to `lessonIndices` into `utils/index`

<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context

<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->
I mistakenly included the `getSemesterModule` function in the `lessonIndices.ts` in #4389

## Implementation

<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->

## Other Information

<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
