### PR TITLE
Introduce `LessonId`s

### DIFF
--- a/export/src/data.ts
+++ b/export/src/data.ts
@@ -7,6 +7,7 @@ import type { Middleware } from 'koa';
 
 import config from './config';
 import type { ExportData, State } from './types';
+import { makeModuleLessonMap } from './makeModuleLessonMap';
 
 async function fetchModule(moduleCode: string) {
   const fileName = `${moduleCode}.json`;
@@ -37,7 +38,20 @@ async function fetchModule(moduleCode: string) {
 
 export async function getModules(moduleCodes: Array<string>) {
   const modules = await Promise.all(
-    moduleCodes.map((moduleCode) => fetchModule(moduleCode).catch(() => null)),
+    moduleCodes.map(async (moduleCode) => {
+      // Not in use currently, refer to https://github.com/nusmodifications/nusmods/discussions/4387
+      return await fetchModule(moduleCode)
+        .then((module) => {
+          return {
+            ...module,
+            semesterData: _.map(module.semesterData, (semesterData) => ({
+              ...semesterData,
+              lessonMap: makeModuleLessonMap(semesterData.timetable),
+            })),
+          };
+        })
+        .catch(() => null);
+    }),
   );
 
   return modules.filter(Boolean);

--- a/export/src/data.ts
+++ b/export/src/data.ts
@@ -38,9 +38,9 @@ async function fetchModule(moduleCode: string) {
 
 export async function getModules(moduleCodes: Array<string>) {
   const modules = await Promise.all(
-    moduleCodes.map(async (moduleCode) => {
+    moduleCodes.map(async (moduleCode) =>
       // Not in use currently, refer to https://github.com/nusmodifications/nusmods/discussions/4387
-      return await fetchModule(moduleCode)
+      fetchModule(moduleCode)
         .then((module) => {
           return {
             ...module,
@@ -50,8 +50,8 @@ export async function getModules(moduleCodes: Array<string>) {
             })),
           };
         })
-        .catch(() => null);
-    }),
+        .catch(() => null),
+    ),
   );
 
   return modules.filter(Boolean);

--- a/export/src/makeModuleLessonMap.ts
+++ b/export/src/makeModuleLessonMap.ts
@@ -1,16 +1,4 @@
-import {
-  fromPairs,
-  get,
-  groupBy,
-  invert,
-  isNaN,
-  isUndefined,
-  map,
-  mapValues,
-  omitBy,
-  some,
-  split,
-} from 'lodash';
+import { fromPairs, groupBy, invert, isUndefined, map, mapValues } from 'lodash';
 import { DayText, Lesson, ModuleLessonMap, RawLesson, WeekRange, Weeks } from './types';
 
 type lessonTypeAbbrev = { [lessonType: string]: string };
@@ -128,56 +116,11 @@ export const serializeLessonDetails = <T extends RawLesson>(lesson: T): string =
 /**
  * Group lessons by lesson types
  * @param lessons lessons to group
- * @returns map of `LessonId`s, not lessons
+ * @returns a {@link ModuleLessonMap|ModuleLessonMap} from the `RawLesson`s provided
  */
 export const makeModuleLessonMap = (lessons: Readonly<Array<RawLesson>>): ModuleLessonMap => {
   const lessonsByLessonType = groupBy(lessons, 'lessonType');
   return mapValues(lessonsByLessonType, (lessonsWithLessonType) =>
     fromPairs(map(lessonsWithLessonType, (lesson) => [serializeLessonDetails(lesson), lesson])),
   );
-};
-
-const deserializeWeekNumbers = (serializedWeekNumbers: string): Array<number> => {
-  const weeks = map(split(serializedWeekNumbers, WEEKS_SEP), (week) => Number.parseInt(week, 10));
-
-  if (some(weeks, isNaN)) {
-    throw 'Serialized weeks is malformed';
-  }
-
-  return weeks;
-};
-
-/**
- * Parses serialized weeks by first attempting to deserialize it as a week range\
- * if that fails, attempt to deserialize it as week numbers\
- * if that also fails, the string is malformed
- * @param serializedWeeks
- * @returns
- */
-export const parseWeeks = (serializedWeeks: string): Weeks => {
-  const parsedRegex =
-    /(?<start>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<end>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<weekInterval>[0-9])_?(?<weeks>(?:_*[0-9])*)/.exec(
-      serializedWeeks,
-    );
-  const regexGroup = parsedRegex?.groups;
-  if (!regexGroup) {
-    return deserializeWeekNumbers(serializedWeeks);
-  }
-
-  const start = get(regexGroup, 'start');
-  const end = get(regexGroup, 'end');
-  const weekIntervalString = get(regexGroup, 'weekInterval');
-
-  const weekInterval = Number.parseInt(weekIntervalString, 10);
-  const weeks = get(regexGroup, 'weeks', undefined);
-
-  return omitBy(
-    {
-      end,
-      start,
-      weekInterval: weekInterval === 0 ? undefined : weekInterval,
-      weeks: weeks ? deserializeWeekNumbers(weeks) : undefined,
-    },
-    isUndefined,
-  ) as WeekRange;
 };

--- a/export/src/makeModuleLessonMap.ts
+++ b/export/src/makeModuleLessonMap.ts
@@ -1,0 +1,125 @@
+import { fromPairs, groupBy, invert, isUndefined, map, mapValues } from 'lodash';
+
+type lessonTypeAbbrev = { [lessonType: string]: string };
+export const LESSON_TYPE_ABBREV: lessonTypeAbbrev = {
+  'Design Lecture': 'DLEC',
+  Laboratory: 'LAB',
+  Lecture: 'LEC',
+  'Packaged Laboratory': 'PLAB',
+  'Packaged Lecture': 'PLEC',
+  'Packaged Tutorial': 'PTUT',
+  Recitation: 'REC',
+  'Sectional Teaching': 'SEC',
+  'Seminar-Style Module Class': 'SEM',
+  Tutorial: 'TUT',
+  'Tutorial Type 2': 'TUT2',
+  'Tutorial Type 3': 'TUT3',
+  Workshop: 'WS',
+};
+
+// Reverse lookup map of LESSON_TYPE_ABBREV
+export const LESSON_ABBREV_TYPE = invert(LESSON_TYPE_ABBREV);
+
+/**
+ * Used for {@link Weeks|Weeks} serialization - these must be query string safe
+ * See: https://stackoverflow.com/a/31300627
+ */
+const LESSON_DETAILS_SEP = '|';
+const WEEKS_SEP = '_';
+
+export type DayOfWeek =
+  | 'Monday'
+  | 'Tuesday'
+  | 'Wednesday'
+  | 'Thursday'
+  | 'Friday'
+  | 'Saturday'
+  | 'Sunday';
+export const DAY_OF_WEEK_ABBREV: { [x in DayOfWeek]: string } = {
+  Monday: 'MON',
+  Tuesday: 'TUE',
+  Wednesday: 'WED',
+  Thursday: 'THU',
+  Friday: 'FRI',
+  Saturday: 'SAT',
+  Sunday: 'SUN',
+};
+const DAY_OF_WEEK_FULL = invert(DAY_OF_WEEK_ABBREV);
+
+/**
+ * Obtain a semi-unique key for a lesson
+ */
+export function getLessonIdentifier(lesson: any): string {
+  return `${lesson.moduleCode}-${LESSON_TYPE_ABBREV[lesson.lessonType]}-${lesson.classNo}`;
+}
+
+export const serializeWeekNumbers = (weeks: readonly number[]): string => {
+  return weeks.join(WEEKS_SEP);
+};
+
+/**
+ * Given a {@link WeekRange|WeekRange}
+ * ```ts
+ * {
+ *   start: "2025-01-13",
+ *   end: "2025-02-14",
+ *   weekInterval: 1,
+ *   weeks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+ * }
+ * ```
+ * will be serialized to `2025-01-13_2025-02-14_1_1_2_3_4_5_6_7_8_9_10_11_12_13`\
+ *
+ * If `weekInterval` is undefined, it is serialized as `0`, _despite the fact that a 1 week interval is assumed in the logic_\
+ * If weeks is an empty array, the serialized string would be `2025-01-13_2025-02-14_`\
+ * If weeks is undefined, the serialized string would be `2025-01-13_2025-02-14`, without the dangling `_`\
+ * to ensure that the string is a complete and unique representation of the WeekRange\
+ */
+export const serializeWeekRange = ({ start, end, weekInterval, weeks }: any) => {
+  const serializedStartEndInterval = [start, end, weekInterval ?? 0].join(WEEKS_SEP);
+  if (isUndefined(weeks)) return serializedStartEndInterval;
+  return `${serializedStartEndInterval}${WEEKS_SEP}${serializeWeekNumbers(weeks)}`;
+};
+
+const isWeekRange = (week: any) => !Array.isArray(week);
+
+/**
+ * Given a {@link RawLesson|RawLesson}
+ * ```ts
+ * {
+ *   classNo: 1,
+ *   day: "Wednesday",
+ *   startTime: "1000",
+ *   endTime: "1200",
+ *   lessonType: "Lecture",
+ *   venue: "LT26",
+ *   weeks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+ * }
+ * ```
+ * will be serialized to `1|WED|1000|1200|LT26|1_2_3_4_5_6_7_8_9_10_11_12_13`\
+ *
+ * Notably, _`lessonType` is excluded_ because timetable serialization groups lessons together
+ */
+export const serializeLessonDetails = (lesson: any): string => {
+  const { classNo, day, startTime, endTime, venue, weeks } = lesson;
+
+  const abbreviatedDayOfWeek = DAY_OF_WEEK_ABBREV[day as DayOfWeek];
+  const serializedWeeks = isWeekRange(weeks)
+    ? serializeWeekRange(weeks)
+    : serializeWeekNumbers(weeks);
+
+  return [classNo, abbreviatedDayOfWeek, startTime, endTime, venue, serializedWeeks].join(
+    LESSON_DETAILS_SEP,
+  );
+};
+
+/**
+ * Group lessons by lesson types
+ * @param lessons lessons to group
+ * @returns map of `LessonId`s, not lessons
+ */
+export const makeModuleLessonMap = (lessons: readonly any[]) => {
+  const lessonsByLessonType = groupBy(lessons, 'lessonType');
+  return mapValues(lessonsByLessonType, (lessonsWithLessonType) =>
+    fromPairs(map(lessonsWithLessonType, (lesson) => [serializeLessonDetails(lesson), lesson])),
+  );
+};

--- a/export/src/makeModuleLessonMap.ts
+++ b/export/src/makeModuleLessonMap.ts
@@ -1,4 +1,4 @@
-import { fromPairs, groupBy, invert, isUndefined, map, mapValues } from 'lodash';
+import { fromPairs, groupBy, invert, isEmpty, isUndefined, map, mapValues } from 'lodash';
 import { DayText, Lesson, ModuleLessonMap, RawLesson, WeekRange, Weeks } from './types';
 
 type lessonTypeAbbrev = { [lessonType: string]: string };
@@ -49,6 +49,10 @@ export function getLessonIdentifier(lesson: Lesson): string {
 }
 
 export const serializeWeekNumbers = (weeks: Readonly<Array<number>>): string => {
+  if (isEmpty(weeks)) {
+    return '_';
+  }
+
   return weeks.join(WEEKS_SEP);
 };
 

--- a/export/src/makeModuleLessonMap.ts
+++ b/export/src/makeModuleLessonMap.ts
@@ -69,8 +69,8 @@ export const serializeWeekNumbers = (weeks: Readonly<Array<number>>): string => 
  * will be serialized to `2025-01-13_2025-02-14_1_1_2_3_4_5_6_7_8_9_10_11_12_13`\
  *
  * If `weekInterval` is undefined, it is serialized as `0`, _despite the fact that a 1 week interval is assumed in the logic_\
- * If weeks is an empty array, the serialized string would be `2025-01-13_2025-02-14_`\
- * If weeks is undefined, the serialized string would be `2025-01-13_2025-02-14`, without the dangling `_`\
+ * If `weeks` is an empty array, the serialized string would be `2025-01-13_2025-02-14_`\
+ * If `weeks` is undefined, the serialized string would be `2025-01-13_2025-02-14`, without the dangling `_`\
  * to ensure that the string is a complete and unique representation of the WeekRange\
  */
 export const serializeWeekRange = ({ end, start, weekInterval, weeks }: WeekRange) => {

--- a/export/src/makeModuleLessonMap.ts
+++ b/export/src/makeModuleLessonMap.ts
@@ -1,4 +1,17 @@
-import { fromPairs, groupBy, invert, isUndefined, map, mapValues } from 'lodash';
+import {
+  fromPairs,
+  get,
+  groupBy,
+  invert,
+  isNaN,
+  isUndefined,
+  map,
+  mapValues,
+  omitBy,
+  some,
+  split,
+} from 'lodash';
+import { DayText, Lesson, ModuleLessonMap, RawLesson, WeekRange, Weeks } from './types';
 
 type lessonTypeAbbrev = { [lessonType: string]: string };
 export const LESSON_TYPE_ABBREV: lessonTypeAbbrev = {
@@ -27,15 +40,9 @@ export const LESSON_ABBREV_TYPE = invert(LESSON_TYPE_ABBREV);
 const LESSON_DETAILS_SEP = '|';
 const WEEKS_SEP = '_';
 
-export type DayOfWeek =
-  | 'Monday'
-  | 'Tuesday'
-  | 'Wednesday'
-  | 'Thursday'
-  | 'Friday'
-  | 'Saturday'
-  | 'Sunday';
-export const DAY_OF_WEEK_ABBREV: { [x in DayOfWeek]: string } = {
+// Ignore the sort-objects rule because sorting by order of days of week is more logical than sorting by alphabetical order
+/* eslint-disable @perfectionist/sort-objects */
+export const DAY_OF_WEEK_ABBREV: Record<DayText, string> = {
   Monday: 'MON',
   Tuesday: 'TUE',
   Wednesday: 'WED',
@@ -44,16 +51,16 @@ export const DAY_OF_WEEK_ABBREV: { [x in DayOfWeek]: string } = {
   Saturday: 'SAT',
   Sunday: 'SUN',
 };
-const DAY_OF_WEEK_FULL = invert(DAY_OF_WEEK_ABBREV);
+/* eslint-enable @perfectionist/sort-objects */
 
 /**
  * Obtain a semi-unique key for a lesson
  */
-export function getLessonIdentifier(lesson: any): string {
+export function getLessonIdentifier(lesson: Lesson): string {
   return `${lesson.moduleCode}-${LESSON_TYPE_ABBREV[lesson.lessonType]}-${lesson.classNo}`;
 }
 
-export const serializeWeekNumbers = (weeks: readonly number[]): string => {
+export const serializeWeekNumbers = (weeks: Readonly<Array<number>>): string => {
   return weeks.join(WEEKS_SEP);
 };
 
@@ -74,13 +81,19 @@ export const serializeWeekNumbers = (weeks: readonly number[]): string => {
  * If weeks is undefined, the serialized string would be `2025-01-13_2025-02-14`, without the dangling `_`\
  * to ensure that the string is a complete and unique representation of the WeekRange\
  */
-export const serializeWeekRange = ({ start, end, weekInterval, weeks }: any) => {
+export const serializeWeekRange = ({ end, start, weekInterval, weeks }: WeekRange) => {
   const serializedStartEndInterval = [start, end, weekInterval ?? 0].join(WEEKS_SEP);
-  if (isUndefined(weeks)) return serializedStartEndInterval;
+  if (isUndefined(weeks)) {
+    return serializedStartEndInterval;
+  }
+
   return `${serializedStartEndInterval}${WEEKS_SEP}${serializeWeekNumbers(weeks)}`;
 };
 
-const isWeekRange = (week: any) => !Array.isArray(week);
+/**
+ * Typesafe helper functions for consuming Weeks
+ */
+export const isWeekRange = (week: Weeks): week is WeekRange => !Array.isArray(week);
 
 /**
  * Given a {@link RawLesson|RawLesson}
@@ -99,10 +112,10 @@ const isWeekRange = (week: any) => !Array.isArray(week);
  *
  * Notably, _`lessonType` is excluded_ because timetable serialization groups lessons together
  */
-export const serializeLessonDetails = (lesson: any): string => {
-  const { classNo, day, startTime, endTime, venue, weeks } = lesson;
+export const serializeLessonDetails = <T extends RawLesson>(lesson: T): string => {
+  const { classNo, day, endTime, startTime, venue, weeks } = lesson;
 
-  const abbreviatedDayOfWeek = DAY_OF_WEEK_ABBREV[day as DayOfWeek];
+  const abbreviatedDayOfWeek = DAY_OF_WEEK_ABBREV[day as DayText];
   const serializedWeeks = isWeekRange(weeks)
     ? serializeWeekRange(weeks)
     : serializeWeekNumbers(weeks);
@@ -117,9 +130,54 @@ export const serializeLessonDetails = (lesson: any): string => {
  * @param lessons lessons to group
  * @returns map of `LessonId`s, not lessons
  */
-export const makeModuleLessonMap = (lessons: readonly any[]) => {
+export const makeModuleLessonMap = (lessons: Readonly<Array<RawLesson>>): ModuleLessonMap => {
   const lessonsByLessonType = groupBy(lessons, 'lessonType');
   return mapValues(lessonsByLessonType, (lessonsWithLessonType) =>
     fromPairs(map(lessonsWithLessonType, (lesson) => [serializeLessonDetails(lesson), lesson])),
   );
+};
+
+const deserializeWeekNumbers = (serializedWeekNumbers: string): Array<number> => {
+  const weeks = map(split(serializedWeekNumbers, WEEKS_SEP), (week) => Number.parseInt(week, 10));
+
+  if (some(weeks, isNaN)) {
+    throw 'Serialized weeks is malformed';
+  }
+
+  return weeks;
+};
+
+/**
+ * Parses serialized weeks by first attempting to deserialize it as a week range\
+ * if that fails, attempt to deserialize it as week numbers\
+ * if that also fails, the string is malformed
+ * @param serializedWeeks
+ * @returns
+ */
+export const parseWeeks = (serializedWeeks: string): Weeks => {
+  const parsedRegex =
+    /(?<start>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<end>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<weekInterval>[0-9])_?(?<weeks>(?:_*[0-9])*)/.exec(
+      serializedWeeks,
+    );
+  const regexGroup = parsedRegex?.groups;
+  if (!regexGroup) {
+    return deserializeWeekNumbers(serializedWeeks);
+  }
+
+  const start = get(regexGroup, 'start');
+  const end = get(regexGroup, 'end');
+  const weekIntervalString = get(regexGroup, 'weekInterval');
+
+  const weekInterval = Number.parseInt(weekIntervalString, 10);
+  const weeks = get(regexGroup, 'weeks', undefined);
+
+  return omitBy(
+    {
+      end,
+      start,
+      weekInterval: weekInterval === 0 ? undefined : weekInterval,
+      weeks: weeks ? deserializeWeekNumbers(weeks) : undefined,
+    },
+    isUndefined,
+  ) as WeekRange;
 };

--- a/export/src/types.ts
+++ b/export/src/types.ts
@@ -14,7 +14,35 @@ export type ColorScheme = 'LIGHT_COLOR_SCHEME' | 'DARK_COLOR_SCHEME';
 export type Semester = number;
 export type ClassNo = string; // E.g. "1", "A"
 export type LessonType = string; // E.g. "Lecture", "Tutorial"
+export type DayText =
+  | 'Monday'
+  | 'Tuesday'
+  | 'Wednesday'
+  | 'Thursday'
+  | 'Friday'
+  | 'Saturday'
+  | 'Sunday';
+type StartTime = string; // E.g. "1000"
+type EndTime = string; // E.g. "1200"
+type Venue = string; // E.g. "LT26"
+type LessonId = string; // E.g. "1|WED|1000|1200|LT26|1_2_3_4_5_6_7_8_9_10_11_12_13"
+
+type NumericWeeks = Readonly<Array<number>>;
+export type WeekRange = {
+  // The start and end dates
+  end: string;
+  start: string;
+  // Number of weeks between each lesson. If not specified one week is assumed
+  // ie. there are lessons every week
+  weekInterval?: number;
+  // Week intervals for modules with uneven spacing between lessons
+  weeks?: Array<number>;
+};
+export type Weeks = NumericWeeks | WeekRange;
+
 export type ModuleCode = string; // E.g. "CS3216"
+type ModuleTitle = string; // E.g. "Software Product Engineering for Digital Markets"
+
 export type SemTimetableConfig = {
   [moduleCode: ModuleCode]: ModuleLessonConfig;
 };
@@ -42,3 +70,32 @@ export interface State {
   data: ExportData;
   page: Page;
 }
+
+// RawLesson is a lesson time slot obtained from the API.
+// Lessons do not implement a modifiable interface.
+// They have to be injected in before using in the timetable.
+// Usually ModuleCode and ModuleTitle has to be injected in before using in the timetable.
+export type RawLesson = Readonly<{
+  classNo: ClassNo;
+  day: DayText;
+  endTime: EndTime;
+  lessonType: LessonType;
+  startTime: StartTime;
+  venue: Venue;
+  weeks: Weeks;
+}>;
+
+//  ModuleLessonConfigWithLessons is a mapping of lessonType to an array of Lessons for a module.
+export type Lesson = RawLesson & {
+  moduleCode: ModuleCode;
+  title: ModuleTitle;
+};
+
+/**
+ * Mapping of lessons to their respective lesson ID and lesson type\
+ */
+export type ModuleLessonMap = {
+  [lessonType: LessonType]: {
+    [lessonId: LessonId]: RawLesson;
+  };
+};

--- a/website/src/__mocks__/modules/index.ts
+++ b/website/src/__mocks__/modules/index.ts
@@ -1,5 +1,7 @@
 import type { Module } from 'types/modules';
 
+import { map } from 'lodash-es';
+import { makeModuleLessonMap } from 'utils/timetables/lessonId';
 import ACC2002_JSON from './ACC2002.json';
 import BFS1001_JSON from './BFS1001.json';
 import CP3880_JSON from './CP3880.json';
@@ -12,20 +14,29 @@ import PC1222_JSON from './PC1222.json';
 import GER1000_JSON from './GER1000.json';
 import MA151_JSON from './MA1521.json';
 
+const mockReducerTransform = (module: any): Module => ({
+  ...module,
+  semesterData: map(module.semesterData, (semesterData) => ({
+    ...semesterData,
+    lessonMap: makeModuleLessonMap(semesterData.timetable),
+  })),
+  timestamp: 1572843950000,
+});
+
 // Have to cast these as Module explicitly, otherwise TS will try to
 // incorrectly infer the shape from the JSON - specifically Weeks will
 // not be cast correctly
-export const ACC2002: Module = { ...ACC2002_JSON, timestamp: 1572843950000 };
-export const BFS1001: Module = { ...BFS1001_JSON, timestamp: 1572843950000 };
-export const CP3880: Module = { ...CP3880_JSON, timestamp: 1572843950000 };
-export const CS1010A: Module = { ...CS1010A_JSON, timestamp: 1572843950000 };
-export const CS1010S: Module = { ...CS1010S_JSON, timestamp: 1572843950000 };
-export const CS3216: Module = { ...CS3216_JSON, timestamp: 1572843950000 };
-export const CS4243: Module = { ...CS4243_JSON, timestamp: 1572843950000 };
-export const GES1021: Module = { ...GES1021_JSON, timestamp: 1572843950000 };
-export const MA1521: Module = { ...MA151_JSON, timestamp: 1572843950000 };
-export const PC1222: Module = { ...PC1222_JSON, timestamp: 1572843950000 };
-export const GER1000: Module = { ...GER1000_JSON, timestamp: 1572843950000 };
+export const ACC2002 = mockReducerTransform(ACC2002_JSON);
+export const BFS1001 = mockReducerTransform(BFS1001_JSON);
+export const CP3880 = mockReducerTransform(CP3880_JSON);
+export const CS1010A = mockReducerTransform(CS1010A_JSON);
+export const CS1010S = mockReducerTransform(CS1010S_JSON);
+export const CS3216 = mockReducerTransform(CS3216_JSON);
+export const CS4243 = mockReducerTransform(CS4243_JSON);
+export const GES1021 = mockReducerTransform(GES1021_JSON);
+export const MA1521 = mockReducerTransform(MA151_JSON);
+export const PC1222 = mockReducerTransform(PC1222_JSON);
+export const GER1000 = mockReducerTransform(GER1000_JSON);
 
 const modules: Module[] = [ACC2002, BFS1001, CS1010S, CS3216, GES1021, PC1222, CS1010A];
 export default modules;

--- a/website/src/reducers/moduleBank.ts
+++ b/website/src/reducers/moduleBank.ts
@@ -15,6 +15,7 @@ import {
   SET_EXPORTED_DATA,
 } from 'actions/constants';
 import { SUCCESS_KEY } from 'middlewares/requests-middleware';
+import { makeModuleLessonMap } from 'utils/timetables/lessonId';
 
 const defaultModuleBankState: ModuleBank = {
   moduleList: [], // List of basic modules data (module code, name, semester)
@@ -58,6 +59,8 @@ function moduleBank(state: ModuleBank = defaultModuleBankState, action: Actions)
                 ...lesson,
                 lessonIndex,
               })),
+              // Not in use currently, refer to https://github.com/nusmodifications/nusmods/discussions/4387
+              lessonMap: makeModuleLessonMap(semesterData.timetable),
             })),
           },
         },

--- a/website/src/types/modules.ts
+++ b/website/src/types/modules.ts
@@ -26,6 +26,11 @@ export type WeekRange = {
   weeks?: number[];
 };
 export type LessonIndex = number;
+/**
+ * `LessonId`s identify a singular lesson from a list of lessons of a `LessonType`.
+ * `LessonType` is excluded from the `LessonId` because lessons of different `LessonType`s are serialized separately in sharing links.
+ */
+export type LessonId = string;
 
 // Recursive tree of module codes and boolean operators for the prereq tree
 export type PrereqTree =
@@ -147,10 +152,20 @@ export type LessonIndicesMap = {
   };
 };
 
+/**
+ * Mapping of lessons to their respective lesson ID and lesson type\
+ */
+export type ModuleLessonMap<T extends RawLesson> = {
+  [lessonType: LessonType]: {
+    [lessonId: LessonId]: T;
+  };
+};
+
 // Semester-specific information of a module.
 export type SemesterData = {
   semester: Semester;
   timetable: readonly RawLessonWithIndex[];
+  readonly lessonMap: ModuleLessonMap<RawLesson>;
 
   // Exam
   examDate?: string;

--- a/website/src/utils/modules.test.ts
+++ b/website/src/utils/modules.test.ts
@@ -43,6 +43,20 @@ test('getModuleSemesterData should return semester data if semester is present',
         lessonIndex: 0,
       },
     ],
+    lessonMap: {
+      Lecture: {
+        '1|MON|1830|2030|VCRm|1_2_3_4_5_6_7_8_9_10_11_12_13': {
+          classNo: '1',
+          lessonType: 'Lecture',
+          weeks: EVERY_WEEK,
+          day: 'Monday',
+          startTime: '1830',
+          endTime: '2030',
+          venue: 'VCRm',
+          lessonIndex: 0,
+        },
+      },
+    },
   };
   expect(actual).toEqual(expected);
 });
@@ -89,6 +103,7 @@ describe(getFirstAvailableSemester, () => {
     return {
       semester,
       timetable: [],
+      lessonMap: {},
     };
   }
 

--- a/website/src/utils/modules.ts
+++ b/website/src/utils/modules.ts
@@ -3,6 +3,8 @@ import { format } from 'date-fns';
 import type {
   Module,
   ModuleCode,
+  ModuleLessonMap,
+  RawLesson,
   RawLessonWithIndex,
   Semester,
   SemesterData,
@@ -34,6 +36,19 @@ export function getModuleTimetable(
   semester: Semester,
 ): readonly RawLessonWithIndex[] {
   return get(getModuleSemesterData(module, semester), 'timetable', []);
+}
+
+/**
+ * Returns a map of lessons to lessonType of a module for the corresponding semester.
+ * @param module
+ * @param semester
+ * @returns the lesson map generated when module data was downloaded
+ */
+export function getModuleLessonMap(
+  module: Module,
+  semester: Semester,
+): Readonly<ModuleLessonMap<RawLesson>> {
+  return get(getModuleSemesterData(module, semester), 'lessonMap', {});
 }
 
 /**

--- a/website/src/utils/timetables/lessonId.test.ts
+++ b/website/src/utils/timetables/lessonId.test.ts
@@ -1,6 +1,7 @@
-import { each } from 'lodash-es';
+import { each, get } from 'lodash-es';
 import {
   deserializeLessonDetails,
+  getRecoverySerializedLessonDetails,
   makeModuleLessonMap,
   parseWeeks,
   serializeLessonDetails,
@@ -8,8 +9,8 @@ import {
   serializeWeekRange,
 } from './lessonId';
 import { ModuleLessonMap, RawLesson, WeekRange } from 'types/modules';
-import { CS1010S } from '__mocks__/modules';
-import { getModuleTimetable } from 'utils/modules';
+import { CS1010S, GES1021 } from '__mocks__/modules';
+import { getModuleLessonMap, getModuleTimetable } from 'utils/modules';
 
 const semester = 1;
 const sampleModuleTimetable = getModuleTimetable(CS1010S, semester);
@@ -203,5 +204,41 @@ describe('deserializeLessonDetails', () => {
         expect(() => deserializeLessonDetails(lessonId)).toThrow('Serialized weeks is malformed');
       });
     });
+  });
+});
+
+describe('getRecoverySerializedLessonDetails', () => {
+  test('return corresponding lesson ids if config contains valid class no', () => {
+    const lessonMap = getModuleLessonMap(GES1021, 1);
+
+    expect(getRecoverySerializedLessonDetails(get(lessonMap, 'Lecture'), ['SL1'])).toStrictEqual([
+      'SL1|MON|1600|1800|LT27|1_2_3_4_5_6_7_8_9_10_11_12_13',
+      'SL1|WED|1600|1800|LT27|1_2_3_4_5_6_7_8_9_10_11_12_13',
+    ]);
+  });
+
+  const lessonMap = getModuleLessonMap(CS1010S, 1);
+
+  test('return first lessonId if config is empty', () => {
+    expect(getRecoverySerializedLessonDetails(get(lessonMap, 'Tutorial'), [])).toStrictEqual([
+      '1|MON|0900|1000|COM1-0203|3_4_5_6_7_8_9_10_11_12_13',
+    ]);
+  });
+
+  test('return valid lessonIds if any are present', () => {
+    expect(
+      getRecoverySerializedLessonDetails(get(lessonMap, 'Tutorial'), [
+        '2|MON|1000|1100|COM1-0217|3_4_5_6_7_8_9_10_11_12_13',
+        '3|WED|1000|1200|LT26|1_2_3_4_5_6_7_8_9_10_11_12_13',
+      ]),
+    ).toStrictEqual(['2|MON|1000|1100|COM1-0217|3_4_5_6_7_8_9_10_11_12_13']);
+  });
+
+  test('return first lessonId if no classNo or lessonId is valid', () => {
+    expect(
+      getRecoverySerializedLessonDetails(get(lessonMap, 'Tutorial'), [
+        '3|WED|1000|1200|LT26|1_2_3_4_5_6_7_8_9_10_11_12_13',
+      ]),
+    ).toStrictEqual(['1|MON|0900|1000|COM1-0203|3_4_5_6_7_8_9_10_11_12_13']);
   });
 });

--- a/website/src/utils/timetables/lessonId.test.ts
+++ b/website/src/utils/timetables/lessonId.test.ts
@@ -35,7 +35,7 @@ describe('serialize/parse weeks', () => {
 
     each(weekRanges, (weekRange) => {
       const deserializedWeekRange = parseWeeks(serializeWeekRange(weekRange));
-      expect(deserializedWeekRange).toStrictEqual(weekRange);
+      expect(deserializedWeekRange).resolves.toStrictEqual(weekRange);
     });
   });
 
@@ -43,7 +43,7 @@ describe('serialize/parse weeks', () => {
     const weekNumbers = [2, 3, 5, 7, 11, 13];
 
     const deserializedWeekRange = parseWeeks(serializeWeekNumbers(weekNumbers));
-    expect(deserializedWeekRange).toStrictEqual(weekNumbers);
+    expect(deserializedWeekRange).resolves.toStrictEqual(weekNumbers);
   });
 });
 

--- a/website/src/utils/timetables/lessonId.test.ts
+++ b/website/src/utils/timetables/lessonId.test.ts
@@ -1,7 +1,9 @@
 import { each } from 'lodash-es';
 import {
+  deserializeLessonDetails,
   makeModuleLessonMap,
   parseWeeks,
+  serializeLessonDetails,
   serializeWeekNumbers,
   serializeWeekRange,
 } from './lessonId';
@@ -70,5 +72,98 @@ describe('makeModuleLessonMap', () => {
     };
 
     expect(makeModuleLessonMap(lessons)).toStrictEqual(expectedLessonMap);
+  });
+});
+
+describe('deserializeLessonDetails', () => {
+  const lesson = {
+    classNo: '1',
+    weeks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+    day: 'Monday',
+    startTime: '1830',
+    endTime: '2030',
+    venue: 'VCRm',
+  };
+
+  describe('deserialized lessonId should be identical to lesson details that was serialized', () => {
+    test('lesson with NumericWeeks', () => {
+      const serializedLessonDetails = serializeLessonDetails(lesson);
+
+      expect(serializedLessonDetails).toBe('1|MON|1830|2030|VCRm|1_2_3_4_5_6_7_8_9_10_11_12_13');
+      expect(deserializeLessonDetails(serializedLessonDetails)).resolves.toStrictEqual(lesson);
+    });
+
+    test('lesson with WeekRange with both weekInterval and weeks', () => {
+      const lessonWithWeekRange = {
+        ...lesson,
+        weeks: {
+          start: '2026-06-18',
+          end: '2026-05-21',
+          weekInterval: 2,
+          weeks: [1, 3, 5, 7, 9, 11, 13],
+        },
+      };
+      const serializedLessonDetails = serializeLessonDetails(lessonWithWeekRange);
+
+      expect(serializedLessonDetails).toBe(
+        '1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_2_1_3_5_7_9_11_13',
+      );
+      expect(deserializeLessonDetails(serializedLessonDetails)).resolves.toStrictEqual(
+        lessonWithWeekRange,
+      );
+    });
+
+    test('lesson with WeekRange with no week interval', () => {
+      const lessonWithWeekRange = {
+        ...lesson,
+        weeks: {
+          start: '2026-06-18',
+          end: '2026-05-21',
+          weeks: [1, 3, 5, 7, 9, 11, 13],
+        },
+      };
+      const serializedLessonDetails = serializeLessonDetails(lessonWithWeekRange);
+
+      expect(serializedLessonDetails).toBe(
+        '1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_0_1_3_5_7_9_11_13',
+      );
+      expect(deserializeLessonDetails(serializedLessonDetails)).resolves.toStrictEqual(
+        lessonWithWeekRange,
+      );
+    });
+
+    test('lesson with WeekRange with empty week numbers list', () => {
+      const lessonWithWeekRange = {
+        ...lesson,
+        weeks: {
+          start: '2026-06-18',
+          end: '2026-05-21',
+          weeks: [],
+        },
+      };
+      const serializedLessonDetails = serializeLessonDetails(lessonWithWeekRange);
+
+      expect(serializedLessonDetails).toBe('1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_0__');
+      expect(deserializeLessonDetails(serializedLessonDetails)).resolves.toStrictEqual(
+        lessonWithWeekRange,
+      );
+    });
+
+    test('lesson with WeekRange with no week numbers list defined', () => {
+      const lessonWithWeekRange = {
+        ...lesson,
+        weeks: {
+          start: '2026-06-18',
+          end: '2026-05-21',
+          weekInterval: 2,
+        },
+      };
+      const serializedLessonDetails = serializeLessonDetails(lessonWithWeekRange);
+
+      expect(serializedLessonDetails).toBe('1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_2');
+      expect(deserializeLessonDetails(serializedLessonDetails)).resolves.toStrictEqual(
+        lessonWithWeekRange,
+      );
+    });
   });
 });

--- a/website/src/utils/timetables/lessonId.test.ts
+++ b/website/src/utils/timetables/lessonId.test.ts
@@ -1,0 +1,74 @@
+import { each } from 'lodash-es';
+import {
+  makeModuleLessonMap,
+  parseWeeks,
+  serializeWeekNumbers,
+  serializeWeekRange,
+} from './lessonId';
+import { ModuleLessonMap, RawLesson, WeekRange } from 'types/modules';
+import { CS1010S } from '__mocks__/modules';
+import { getModuleTimetable } from 'utils/modules';
+
+const semester = 1;
+const sampleModuleTimetable = getModuleTimetable(CS1010S, semester);
+
+describe('serialize/parse weeks', () => {
+  test('serialized weekRange should be deserialized to the same weekRange', () => {
+    const weekRanges: WeekRange[] = [
+      {
+        start: '2026-01-13',
+        end: '2026-02-14',
+        weekInterval: 1,
+      },
+      {
+        start: '2026-01-13',
+        end: '2026-02-14',
+        weeks: [2, 3, 5, 7, 11, 13],
+      },
+      {
+        start: '2026-01-13',
+        end: '2026-02-14',
+        weekInterval: 1,
+        weeks: [2, 3, 5, 7, 11, 13],
+      },
+    ];
+
+    each(weekRanges, (weekRange) => {
+      const deserializedWeekRange = parseWeeks(serializeWeekRange(weekRange));
+      expect(deserializedWeekRange).toStrictEqual(weekRange);
+    });
+  });
+
+  test('serialized week numbers should be deserialized to the same weekRange', () => {
+    const weekNumbers = [2, 3, 5, 7, 11, 13];
+
+    const deserializedWeekRange = parseWeeks(serializeWeekNumbers(weekNumbers));
+    expect(deserializedWeekRange).toStrictEqual(weekNumbers);
+  });
+});
+
+describe('makeModuleLessonMap', () => {
+  test('should make lesson map from array of lessons', () => {
+    const lectureLessons = [sampleModuleTimetable[0]];
+    const recitationLessons = [sampleModuleTimetable[1], sampleModuleTimetable[2]];
+    const tutorialLessons = [sampleModuleTimetable[11], sampleModuleTimetable[12]];
+
+    const lessons: RawLesson[] = [...lectureLessons, ...recitationLessons, ...tutorialLessons];
+
+    const expectedLessonMap: ModuleLessonMap<RawLesson> = {
+      Lecture: {
+        '1|WED|1000|1200|LT26|1_2_3_4_5_6_7_8_9_10_11_12_13': sampleModuleTimetable[0],
+      },
+      Recitation: {
+        '1|THU|1200|1300|S14-0619|1_2_3_4_5_6_7_8_9_10_11_12_13': sampleModuleTimetable[1],
+        '10|THU|1200|1300|RMI-SR1|1_2_3_4_5_6_7_8_9_10_11_12_13': sampleModuleTimetable[2],
+      },
+      Tutorial: {
+        '1|MON|0900|1000|COM1-0203|3_4_5_6_7_8_9_10_11_12_13': sampleModuleTimetable[11],
+        '10|TUE|0900|1000|COM1-0209|3_4_5_6_7_8_9_10_11_12_13': sampleModuleTimetable[12],
+      },
+    };
+
+    expect(makeModuleLessonMap(lessons)).toStrictEqual(expectedLessonMap);
+  });
+});

--- a/website/src/utils/timetables/lessonId.test.ts
+++ b/website/src/utils/timetables/lessonId.test.ts
@@ -37,7 +37,7 @@ describe('serialize/parse weeks', () => {
 
     each(weekRanges, (weekRange) => {
       const deserializedWeekRange = parseWeeks(serializeWeekRange(weekRange));
-      expect(deserializedWeekRange).resolves.toStrictEqual(weekRange);
+      expect(deserializedWeekRange).toStrictEqual(weekRange);
     });
   });
 
@@ -45,7 +45,7 @@ describe('serialize/parse weeks', () => {
     const weekNumbers = [2, 3, 5, 7, 11, 13];
 
     const deserializedWeekRange = parseWeeks(serializeWeekNumbers(weekNumbers));
-    expect(deserializedWeekRange).resolves.toStrictEqual(weekNumbers);
+    expect(deserializedWeekRange).toStrictEqual(weekNumbers);
   });
 });
 
@@ -90,7 +90,7 @@ describe('deserializeLessonDetails', () => {
       const serializedLessonDetails = serializeLessonDetails(lesson);
 
       expect(serializedLessonDetails).toBe('1|MON|1830|2030|VCRm|1_2_3_4_5_6_7_8_9_10_11_12_13');
-      expect(deserializeLessonDetails(serializedLessonDetails)).resolves.toStrictEqual(lesson);
+      expect(deserializeLessonDetails(serializedLessonDetails)).toStrictEqual(lesson);
     });
 
     test('lesson with WeekRange with both weekInterval and weeks', () => {
@@ -108,9 +108,21 @@ describe('deserializeLessonDetails', () => {
       expect(serializedLessonDetails).toBe(
         '1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_2_1_3_5_7_9_11_13',
       );
-      expect(deserializeLessonDetails(serializedLessonDetails)).resolves.toStrictEqual(
-        lessonWithWeekRange,
-      );
+      expect(deserializeLessonDetails(serializedLessonDetails)).toStrictEqual(lessonWithWeekRange);
+    });
+
+    test('lesson with WeekRange with neither weekInterval nor weeks', () => {
+      const lessonWithWeekRange = {
+        ...lesson,
+        weeks: {
+          start: '2026-06-18',
+          end: '2026-05-21',
+        },
+      };
+      const serializedLessonDetails = serializeLessonDetails(lessonWithWeekRange);
+
+      expect(serializedLessonDetails).toBe('1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_0');
+      expect(deserializeLessonDetails(serializedLessonDetails)).toStrictEqual(lessonWithWeekRange);
     });
 
     test('lesson with WeekRange with no week interval', () => {
@@ -127,9 +139,7 @@ describe('deserializeLessonDetails', () => {
       expect(serializedLessonDetails).toBe(
         '1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_0_1_3_5_7_9_11_13',
       );
-      expect(deserializeLessonDetails(serializedLessonDetails)).resolves.toStrictEqual(
-        lessonWithWeekRange,
-      );
+      expect(deserializeLessonDetails(serializedLessonDetails)).toStrictEqual(lessonWithWeekRange);
     });
 
     test('lesson with WeekRange with empty week numbers list', () => {
@@ -144,9 +154,7 @@ describe('deserializeLessonDetails', () => {
       const serializedLessonDetails = serializeLessonDetails(lessonWithWeekRange);
 
       expect(serializedLessonDetails).toBe('1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_0__');
-      expect(deserializeLessonDetails(serializedLessonDetails)).resolves.toStrictEqual(
-        lessonWithWeekRange,
-      );
+      expect(deserializeLessonDetails(serializedLessonDetails)).toStrictEqual(lessonWithWeekRange);
     });
 
     test('lesson with WeekRange with no week numbers list defined', () => {
@@ -155,15 +163,45 @@ describe('deserializeLessonDetails', () => {
         weeks: {
           start: '2026-06-18',
           end: '2026-05-21',
-          weekInterval: 2,
+          weekInterval: 10,
         },
       };
       const serializedLessonDetails = serializeLessonDetails(lessonWithWeekRange);
 
-      expect(serializedLessonDetails).toBe('1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_2');
-      expect(deserializeLessonDetails(serializedLessonDetails)).resolves.toStrictEqual(
-        lessonWithWeekRange,
-      );
+      expect(serializedLessonDetails).toBe('1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_10');
+      expect(deserializeLessonDetails(serializedLessonDetails)).toStrictEqual(lessonWithWeekRange);
+    });
+  });
+
+  describe('reject malformed strings', () => {
+    test('reject malformed lesson id', () => {
+      const malformedLessonIds = [
+        '1|ABC|1830|2030|VCRm|1_2_3_4_5_6_7_8_9_10_11_12_13',
+        '1|MON|TEXT|2030|VCRm|1_2_3_4_5_6_7_8_9_10_11_12_13',
+        '1|MON|1830|TEXT|VCRm|1_2_3_4_5_6_7_8_9_10_11_12_13',
+        '1|MON|1830|2030|VCRm|',
+        '1|MON|1830|2030|VCRm|1_2_3_4_5_6_7_8_9_10_11_12_13|EXTRA',
+      ];
+
+      each(malformedLessonIds, (lessonId) => {
+        expect(() => deserializeLessonDetails(lessonId)).toThrow('Lesson ID is malformed');
+      });
+    });
+
+    test('reject malformed serialized weeks', () => {
+      const lessonIdsWithMalformedSerializedWeeks = [
+        '1|MON|1830|2030|VCRm|1_2_3_4_5_6_7_8_9_10_11_12_13_',
+        '1|MON|1830|2030|VCRm|1_2_3_4_5_6_7_8_9_10_11_12__13',
+        '1|MON|1830|2030|VCRm|-_2026-06-18_2026-05-21_2_1_3_5_7_9_11_13',
+        '1|MON|1830|2030|VCRm|2026-06-18_2026-05-21__1_3_5_7_9_11_13',
+        '1|MON|1830|2030|VCRm|2026-06-18_2026-05-21_2_1_3_5_7_9_11_13_-',
+        '1|MON|1830|2030|VCRm|2026-06-18__2_1_3_5_7_9_11_13',
+        '1|MON|1830|2030|VCRm|2026-06-18_2_1_3_5_7_9_11_13',
+      ];
+
+      each(lessonIdsWithMalformedSerializedWeeks, (lessonId) => {
+        expect(() => deserializeLessonDetails(lessonId)).toThrow('Serialized weeks is malformed');
+      });
     });
   });
 });

--- a/website/src/utils/timetables/lessonId.ts
+++ b/website/src/utils/timetables/lessonId.ts
@@ -4,6 +4,7 @@ import {
   get,
   groupBy,
   invert,
+  isEmpty,
   isNaN,
   isUndefined,
   keys,
@@ -85,6 +86,10 @@ export function getLessonIdentifier(lesson: Lesson): string {
 }
 
 export const serializeWeekNumbers = (weeks: readonly number[]): string => {
+  if (isEmpty(weeks)) {
+    return '_';
+  }
+
   return weeks.join(WEEKS_SEP);
 };
 
@@ -128,7 +133,9 @@ export const serializeWeekRange = ({ start, end, weekInterval, weeks }: WeekRang
  *
  * Notably, _`lessonType` is excluded_ because timetable serialization groups lessons together
  */
-export const serializeLessonDetails = <T extends RawLesson>(lesson: T): string => {
+export const serializeLessonDetails = <T extends Omit<RawLesson, 'lessonType'>>(
+  lesson: T,
+): string => {
   const { classNo, day, startTime, endTime, venue, weeks } = lesson;
 
   const abbreviatedDayOfWeek = DAY_OF_WEEK_ABBREV[day as DayOfWeek];
@@ -154,6 +161,8 @@ export const makeModuleLessonMap = (lessons: readonly RawLesson[]): ModuleLesson
 };
 
 const deserializeWeekNumbers = async (serializedWeekNumbers: string): Promise<number[]> => {
+  if (serializedWeekNumbers === '_') return [];
+
   const weeks = map(split(serializedWeekNumbers, WEEKS_SEP), (week) => parseInt(week, 10));
 
   if (some(weeks, isNaN)) {
@@ -172,7 +181,7 @@ const deserializeWeekNumbers = async (serializedWeekNumbers: string): Promise<nu
  */
 export const parseWeeks = async (serializedWeeks: string): Promise<Weeks> => {
   const parsedRegex =
-    /(?<start>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<end>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<weekInterval>[0-9])_?(?<weeks>(?:_*[0-9])*)/.exec(
+    /(?<start>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<end>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<weekInterval>[0-9])_?(?<weeks>(?:_*[0-9]*)*)/.exec(
       serializedWeeks,
     );
   const regexGroup = parsedRegex?.groups;

--- a/website/src/utils/timetables/lessonId.ts
+++ b/website/src/utils/timetables/lessonId.ts
@@ -1,6 +1,33 @@
-import { invert } from 'lodash-es';
+import {
+  first,
+  fromPairs,
+  get,
+  groupBy,
+  invert,
+  isNaN,
+  isUndefined,
+  keys,
+  map,
+  mapValues,
+  maxBy,
+  omitBy,
+  pick,
+  pickBy,
+  size,
+  some,
+  split,
+  toPairs,
+} from 'lodash-es';
 
-import { LessonType } from 'types/modules';
+import {
+  isWeekRange,
+  LessonId,
+  LessonType,
+  ModuleLessonMap,
+  RawLesson,
+  WeekRange,
+  Weeks,
+} from 'types/modules';
 
 import { Lesson } from 'types/timetables';
 
@@ -25,8 +52,243 @@ export const LESSON_TYPE_ABBREV: lessonTypeAbbrev = {
 export const LESSON_ABBREV_TYPE: { [key: string]: LessonType } = invert(LESSON_TYPE_ABBREV);
 
 /**
+ * Used for {@link Weeks|Weeks} serialization - these must be query string safe
+ * See: https://stackoverflow.com/a/31300627
+ */
+const LESSON_DETAILS_SEP = '|';
+const WEEKS_SEP = '_';
+
+export type DayOfWeek =
+  | 'Monday'
+  | 'Tuesday'
+  | 'Wednesday'
+  | 'Thursday'
+  | 'Friday'
+  | 'Saturday'
+  | 'Sunday';
+export const DAY_OF_WEEK_ABBREV: { [x in DayOfWeek]: string } = {
+  Monday: 'MON',
+  Tuesday: 'TUE',
+  Wednesday: 'WED',
+  Thursday: 'THU',
+  Friday: 'FRI',
+  Saturday: 'SAT',
+  Sunday: 'SUN',
+};
+const DAY_OF_WEEK_FULL = invert(DAY_OF_WEEK_ABBREV);
+
+/**
  * Obtain a semi-unique key for a lesson
  */
 export function getLessonIdentifier(lesson: Lesson): string {
   return `${lesson.moduleCode}-${LESSON_TYPE_ABBREV[lesson.lessonType]}-${lesson.classNo}`;
+}
+
+export const serializeWeekNumbers = (weeks: readonly number[]): string => {
+  return weeks.join(WEEKS_SEP);
+};
+
+/**
+ * Given a {@link WeekRange|WeekRange}
+ * ```ts
+ * {
+ *   start: "2025-01-13",
+ *   end: "2025-02-14",
+ *   weekInterval: 1,
+ *   weeks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+ * }
+ * ```
+ * will be serialized to `2025-01-13_2025-02-14_1_1_2_3_4_5_6_7_8_9_10_11_12_13`\
+ *
+ * If `weekInterval` is undefined, it is serialized as `0`, _despite the fact that a 1 week interval is assumed in the logic_\
+ * If weeks is an empty array, the serialized string would be `2025-01-13_2025-02-14_`\
+ * If weeks is undefined, the serialized string would be `2025-01-13_2025-02-14`, without the dangling `_`\
+ * to ensure that the string is a complete and unique representation of the WeekRange\
+ */
+export const serializeWeekRange = ({ start, end, weekInterval, weeks }: WeekRange) => {
+  const serializedStartEndInterval = [start, end, weekInterval ?? 0].join(WEEKS_SEP);
+  if (isUndefined(weeks)) return serializedStartEndInterval;
+  return `${serializedStartEndInterval}${WEEKS_SEP}${serializeWeekNumbers(weeks)}`;
+};
+
+/**
+ * Given a {@link RawLesson|RawLesson}
+ * ```ts
+ * {
+ *   classNo: 1,
+ *   day: "Wednesday",
+ *   startTime: "1000",
+ *   endTime: "1200",
+ *   lessonType: "Lecture",
+ *   venue: "LT26",
+ *   weeks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+ * }
+ * ```
+ * will be serialized to `1|WED|1000|1200|LT26|1_2_3_4_5_6_7_8_9_10_11_12_13`\
+ *
+ * Notably, _`lessonType` is excluded_ because timetable serialization groups lessons together
+ */
+export const serializeLessonDetails = <T extends RawLesson>(lesson: T): string => {
+  const { classNo, day, startTime, endTime, venue, weeks } = lesson;
+
+  const abbreviatedDayOfWeek = DAY_OF_WEEK_ABBREV[day as DayOfWeek];
+  const serializedWeeks = isWeekRange(weeks)
+    ? serializeWeekRange(weeks)
+    : serializeWeekNumbers(weeks);
+
+  return [classNo, abbreviatedDayOfWeek, startTime, endTime, venue, serializedWeeks].join(
+    LESSON_DETAILS_SEP,
+  );
+};
+
+/**
+ * Group lessons by lesson types
+ * @param lessons lessons to group
+ * @returns map of `LessonId`s, not lessons
+ */
+export const makeModuleLessonMap = (lessons: readonly RawLesson[]): ModuleLessonMap<RawLesson> => {
+  const lessonsByLessonType = groupBy(lessons, 'lessonType');
+  return mapValues(lessonsByLessonType, (lessonsWithLessonType) =>
+    fromPairs(map(lessonsWithLessonType, (lesson) => [serializeLessonDetails(lesson), lesson])),
+  );
+};
+
+const deserializeWeekNumbers = (serializedWeekNumbers: string): number[] => {
+  const weeks = map(split(serializedWeekNumbers, WEEKS_SEP), (week) => parseInt(week, 10));
+
+  if (some(weeks, isNaN)) {
+    throw 'Serialized weeks is malformed';
+  }
+
+  return weeks;
+};
+
+/**
+ * Parses serialized weeks by first attempting to deserialize it as a week range\
+ * if that fails, attempt to deserialize it as week numbers\
+ * if that also fails, the string is malformed
+ * @param serializedWeeks
+ * @returns
+ */
+export const parseWeeks = (serializedWeeks: string): Weeks => {
+  const parsedRegex =
+    /(?<start>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<end>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<weekInterval>[0-9])_?(?<weeks>(?:_*[0-9])*)/.exec(
+      serializedWeeks,
+    );
+  const regexGroup = parsedRegex?.groups;
+  if (!regexGroup) {
+    return deserializeWeekNumbers(serializedWeeks);
+  }
+
+  const start = get(regexGroup, 'start');
+  const end = get(regexGroup, 'end');
+  const weekIntervalString = get(regexGroup, 'weekInterval');
+
+  const weekInterval = parseInt(weekIntervalString, 10);
+  const weeks = get(regexGroup, 'weeks', undefined);
+
+  return omitBy(
+    {
+      start,
+      end,
+      weekInterval: weekInterval === 0 ? undefined : weekInterval,
+      weeks: weeks ? deserializeWeekNumbers(weeks) : undefined,
+    },
+    isUndefined,
+  ) as WeekRange;
+};
+
+/**
+ * Refer to {@link serializeLessonDetails|serializeLessonDetails}
+ */
+export const deserializeLessonDetails = async (
+  lessonId: string,
+): Promise<Omit<RawLesson, 'lessonType'>> => {
+  const parsedRegex =
+    /(?<classNo>.*)\|(?<abbreviatedDayOfWeek>.*)\|(?<startTime>.*)\|(?<endTime>.*)\|(?<venue>.*)\|(?<serializedWeeks>.*)/.exec(
+      lessonId,
+    );
+
+  const regexGroup = parsedRegex?.groups;
+  if (!regexGroup) {
+    throw 'Lesson ID is malformed';
+  }
+
+  const classNo = get(regexGroup, 'classNo');
+  const abbreviatedDayOfWeek = get(regexGroup, 'abbreviatedDayOfWeek');
+  const startTime = get(regexGroup, 'startTime');
+  const endTime = get(regexGroup, 'endTime');
+  const venue = get(regexGroup, 'venue');
+  const serializedWeeks = get(regexGroup, 'serializedWeeks');
+
+  const day = get(DAY_OF_WEEK_FULL, abbreviatedDayOfWeek);
+  const weeks = parseWeeks(serializedWeeks);
+
+  return {
+    classNo,
+    day,
+    startTime,
+    endTime,
+    venue,
+    weeks,
+  };
+};
+
+/**
+ * Used to recover from the config of a lesson type of a non-TA module with invalid lessons
+ * @param lessonsWithLessonType lessons with the same lesson type to generate a valid lesson config from
+ * @returns a `ClassNo`. The current implementation generates a config containing the first `ClassNo`
+ */
+export function getRecoveryClassNo(lessonsWithLessonType: Record<LessonId, RawLesson>): LessonId[] {
+  const firstClass = first(map(lessonsWithLessonType));
+  if (!firstClass) {
+    return [];
+  }
+  return [firstClass.classNo];
+}
+
+/**
+ * Used to recover from the config of a lesson type of a TA module with invalid lessons
+ * @param lessonsWithLessonType lessons with the same lesson type to generate a valid lesson config from
+ * @returns a `LessonId`. The current implementation generates a config containing the first `LessonId`
+ */
+export function getRecoverySerializedLessonDetails(
+  lessonsWithLessonType: Record<LessonId, RawLesson>,
+  configLessonTypeLessonIds: LessonId[],
+): LessonId[] {
+  const configLessonTypeLessonIdsSet = new Set(configLessonTypeLessonIds);
+  const recoveryLessons = pickBy(lessonsWithLessonType, (lesson) =>
+    configLessonTypeLessonIdsSet.has(lesson.classNo),
+  );
+  if (size(recoveryLessons) > 0) return keys(recoveryLessons);
+
+  const firstLessonId = first(keys(lessonsWithLessonType));
+  if (!firstLessonId) {
+    return [];
+  }
+  return [firstLessonId];
+}
+
+/**
+ * Find the `ClassNo` that is shared by the most TA lessons
+ * Used for converting a TA module config to a non-TA module lesson config
+ * @param lessonTypeLessons all lessons of the `LessonType`
+ * @param configLessonTypeLessonIds `LessonId`s of a lesson type in a TA module lesson config
+ * @returns
+ */
+export function getClosestClassNo(
+  lessonTypeLessons: Record<LessonId, RawLesson>,
+  configLessonTypeLessonIds: LessonId[],
+) {
+  const configLessonsByClassNo = groupBy(
+    pick(lessonTypeLessons, configLessonTypeLessonIds),
+    'classNo',
+  );
+  const closestLessons = maxBy(
+    toPairs(configLessonsByClassNo),
+    ([, lessonsWithClassNo]) => lessonsWithClassNo.length,
+  );
+
+  if (!closestLessons) return null;
+  return closestLessons[0];
 }

--- a/website/src/utils/timetables/lessonId.ts
+++ b/website/src/utils/timetables/lessonId.ts
@@ -3,6 +3,7 @@ import {
   fromPairs,
   get,
   groupBy,
+  intersection,
   invert,
   isEmpty,
   isNaN,
@@ -275,11 +276,13 @@ export function getRecoverySerializedLessonDetails(
   lessonsWithLessonType: Record<LessonId, RawLesson>,
   configLessonTypeLessonIds: LessonId[],
 ): LessonId[] {
+  const lessonsWithValidLessonIds = intersection(
+    keys(lessonsWithLessonType),
+    configLessonTypeLessonIds,
+  );
+  if (!isEmpty(lessonsWithValidLessonIds)) return lessonsWithValidLessonIds;
+
   const configLessonTypeLessonIdsSet = new Set(configLessonTypeLessonIds);
-
-  const lessonsWithValidLessonIds = pick(lessonsWithLessonType, configLessonTypeLessonIds);
-  if (size(lessonsWithValidLessonIds) > 0) return keys(lessonsWithValidLessonIds);
-
   const lessonsWithClassNo = pickBy(lessonsWithLessonType, (lesson) =>
     configLessonTypeLessonIdsSet.has(lesson.classNo),
   );

--- a/website/src/utils/timetables/lessonId.ts
+++ b/website/src/utils/timetables/lessonId.ts
@@ -144,7 +144,7 @@ export const serializeLessonDetails = <T extends RawLesson>(lesson: T): string =
 /**
  * Group lessons by lesson types
  * @param lessons lessons to group
- * @returns map of `LessonId`s, not lessons
+ * @returns a {@link ModuleLessonMap|ModuleLessonMap} from the `RawLesson`s provided
  */
 export const makeModuleLessonMap = (lessons: readonly RawLesson[]): ModuleLessonMap<RawLesson> => {
   const lessonsByLessonType = groupBy(lessons, 'lessonType');
@@ -153,11 +153,11 @@ export const makeModuleLessonMap = (lessons: readonly RawLesson[]): ModuleLesson
   );
 };
 
-const deserializeWeekNumbers = (serializedWeekNumbers: string): number[] => {
+const deserializeWeekNumbers = async (serializedWeekNumbers: string): Promise<number[]> => {
   const weeks = map(split(serializedWeekNumbers, WEEKS_SEP), (week) => parseInt(week, 10));
 
   if (some(weeks, isNaN)) {
-    throw 'Serialized weeks is malformed';
+    throw new Error('Serialized weeks is malformed');
   }
 
   return weeks;
@@ -170,7 +170,7 @@ const deserializeWeekNumbers = (serializedWeekNumbers: string): number[] => {
  * @param serializedWeeks
  * @returns
  */
-export const parseWeeks = (serializedWeeks: string): Weeks => {
+export const parseWeeks = async (serializedWeeks: string): Promise<Weeks> => {
   const parsedRegex =
     /(?<start>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<end>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<weekInterval>[0-9])_?(?<weeks>(?:_*[0-9])*)/.exec(
       serializedWeeks,
@@ -192,7 +192,7 @@ export const parseWeeks = (serializedWeeks: string): Weeks => {
       start,
       end,
       weekInterval: weekInterval === 0 ? undefined : weekInterval,
-      weeks: weeks ? deserializeWeekNumbers(weeks) : undefined,
+      weeks: weeks ? await deserializeWeekNumbers(weeks) : undefined,
     },
     isUndefined,
   ) as WeekRange;
@@ -211,7 +211,7 @@ export const deserializeLessonDetails = async (
 
   const regexGroup = parsedRegex?.groups;
   if (!regexGroup) {
-    throw 'Lesson ID is malformed';
+    return Promise.reject('Lesson ID is malformed');
   }
 
   const classNo = get(regexGroup, 'classNo');
@@ -222,7 +222,7 @@ export const deserializeLessonDetails = async (
   const serializedWeeks = get(regexGroup, 'serializedWeeks');
 
   const day = get(DAY_OF_WEEK_FULL, abbreviatedDayOfWeek);
-  const weeks = parseWeeks(serializedWeeks);
+  const weeks = await parseWeeks(serializedWeeks);
 
   return {
     classNo,

--- a/website/src/utils/timetables/lessonId.ts
+++ b/website/src/utils/timetables/lessonId.ts
@@ -211,7 +211,7 @@ export const deserializeLessonDetails = async (
 
   const regexGroup = parsedRegex?.groups;
   if (!regexGroup) {
-    return Promise.reject('Lesson ID is malformed');
+    throw new Error('Lesson ID is malformed');
   }
 
   const classNo = get(regexGroup, 'classNo');

--- a/website/src/utils/timetables/lessonId.ts
+++ b/website/src/utils/timetables/lessonId.ts
@@ -264,19 +264,26 @@ export function getRecoveryClassNo(
 }
 
 /**
- * Used to recover from the config of a lesson type of a TA module with invalid lessons
+ * Used to recover from the config of a lesson type of a TA module with invalid lesson config\
+ * If any of the `LessonId`s are valid, they are returned\
+ * If none of the `LessonId`s are valid, check they are valid `ClassNo`s, if so, return the corresponding `LessonId`s\
+ * Otherwise return a config containing the first `LessonId`
  * @param lessonsWithLessonType lessons with the same lesson type to generate a valid lesson config from
- * @returns a `LessonId`. The current implementation generates a config containing the first `LessonId`
+ * @returns config of `LessonId`s
  */
 export function getRecoverySerializedLessonDetails(
   lessonsWithLessonType: Record<LessonId, RawLesson>,
   configLessonTypeLessonIds: LessonId[],
 ): LessonId[] {
   const configLessonTypeLessonIdsSet = new Set(configLessonTypeLessonIds);
-  const recoveryLessons = pickBy(lessonsWithLessonType, (lesson) =>
+
+  const lessonsWithValidLessonIds = pick(lessonsWithLessonType, configLessonTypeLessonIds);
+  if (size(lessonsWithValidLessonIds) > 0) return keys(lessonsWithValidLessonIds);
+
+  const lessonsWithClassNo = pickBy(lessonsWithLessonType, (lesson) =>
     configLessonTypeLessonIdsSet.has(lesson.classNo),
   );
-  if (size(recoveryLessons) > 0) return keys(recoveryLessons);
+  if (size(lessonsWithClassNo) > 0) return keys(lessonsWithClassNo);
 
   const firstLessonId = first(keys(lessonsWithLessonType));
   if (!firstLessonId) {

--- a/website/src/utils/timetables/lessonId.ts
+++ b/website/src/utils/timetables/lessonId.ts
@@ -21,6 +21,7 @@ import {
 } from 'lodash-es';
 
 import {
+  ClassNo,
   isWeekRange,
   LessonId,
   LessonType,
@@ -160,7 +161,7 @@ export const makeModuleLessonMap = (lessons: readonly RawLesson[]): ModuleLesson
   );
 };
 
-const deserializeWeekNumbers = async (serializedWeekNumbers: string): Promise<number[]> => {
+const deserializeWeekNumbers = (serializedWeekNumbers: string): number[] => {
   if (serializedWeekNumbers === '_') return [];
 
   const weeks = map(split(serializedWeekNumbers, WEEKS_SEP), (week) => parseInt(week, 10));
@@ -173,20 +174,25 @@ const deserializeWeekNumbers = async (serializedWeekNumbers: string): Promise<nu
 };
 
 /**
- * Parses serialized weeks by first attempting to deserialize it as a week range\
- * if that fails, attempt to deserialize it as week numbers\
- * if that also fails, the string is malformed
+ * Checks if serialized week string is serialized week numbers
+ * If it is, attempt to deserialize it as week numbers\
+ * Otherwise, deserialize it as a `WeekRange`. If that fails, the string is malformed
  * @param serializedWeeks
  * @returns
  */
-export const parseWeeks = async (serializedWeeks: string): Promise<Weeks> => {
+export const parseWeeks = (serializedWeeks: string): Weeks => {
+  const isSerializedWeekNumbers = /^(?:_*[0-9]*)*$/.test(serializedWeeks);
+  if (isSerializedWeekNumbers) {
+    return deserializeWeekNumbers(serializedWeeks);
+  }
+
   const parsedRegex =
-    /(?<start>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<end>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<weekInterval>[0-9])_?(?<weeks>(?:_*[0-9]*)*)/.exec(
+    /^(?<start>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<end>[0-9]{4}-[0-9]{2}-[0-9]{2})_(?<weekInterval>[0-9]+)_?(?<weeks>(?:_*[0-9]*)*)$/.exec(
       serializedWeeks,
     );
   const regexGroup = parsedRegex?.groups;
   if (!regexGroup) {
-    return deserializeWeekNumbers(serializedWeeks);
+    throw new Error('Serialized weeks is malformed');
   }
 
   const start = get(regexGroup, 'start');
@@ -201,7 +207,7 @@ export const parseWeeks = async (serializedWeeks: string): Promise<Weeks> => {
       start,
       end,
       weekInterval: weekInterval === 0 ? undefined : weekInterval,
-      weeks: weeks ? await deserializeWeekNumbers(weeks) : undefined,
+      weeks: weeks ? deserializeWeekNumbers(weeks) : undefined,
     },
     isUndefined,
   ) as WeekRange;
@@ -210,11 +216,9 @@ export const parseWeeks = async (serializedWeeks: string): Promise<Weeks> => {
 /**
  * Refer to {@link serializeLessonDetails|serializeLessonDetails}
  */
-export const deserializeLessonDetails = async (
-  lessonId: string,
-): Promise<Omit<RawLesson, 'lessonType'>> => {
+export const deserializeLessonDetails = (lessonId: string): Omit<RawLesson, 'lessonType'> => {
   const parsedRegex =
-    /(?<classNo>.*)\|(?<abbreviatedDayOfWeek>.*)\|(?<startTime>.*)\|(?<endTime>.*)\|(?<venue>.*)\|(?<serializedWeeks>.*)/.exec(
+    /^(?<classNo>.*)\|(?<abbreviatedDayOfWeek>(MON|TUE|WED|THU|FRI|SAT|SUN))\|(?<startTime>[0-9]{4})\|(?<endTime>[0-9]{4})\|(?<venue>.*)\|(?<serializedWeeks>[0-9_-]+)$/.exec(
       lessonId,
     );
 
@@ -231,7 +235,7 @@ export const deserializeLessonDetails = async (
   const serializedWeeks = get(regexGroup, 'serializedWeeks');
 
   const day = get(DAY_OF_WEEK_FULL, abbreviatedDayOfWeek);
-  const weeks = await parseWeeks(serializedWeeks);
+  const weeks = parseWeeks(serializedWeeks);
 
   return {
     classNo,
@@ -246,14 +250,17 @@ export const deserializeLessonDetails = async (
 /**
  * Used to recover from the config of a lesson type of a non-TA module with invalid lessons
  * @param lessonsWithLessonType lessons with the same lesson type to generate a valid lesson config from
- * @returns a `ClassNo`. The current implementation generates a config containing the first `ClassNo`
+ * @returns a `ClassNo` or `null` if record of lessons provided is empty
+ * The current implementation returns the first `ClassNo`
  */
-export function getRecoveryClassNo(lessonsWithLessonType: Record<LessonId, RawLesson>): LessonId[] {
+export function getRecoveryClassNo(
+  lessonsWithLessonType: Record<LessonId, RawLesson>,
+): ClassNo | null {
   const firstClass = first(map(lessonsWithLessonType));
   if (!firstClass) {
-    return [];
+    return null;
   }
-  return [firstClass.classNo];
+  return firstClass.classNo;
 }
 
 /**


### PR DESCRIPTION
- Generate `ModuleLessonMap` after module data is fetched, which stores a map of `RawLesson` to their `LessonId` so that serializeLessonDetails only needs to be called once.
- Generate `ModuleLessonMap` for sample modules as well.
- Generate `ModuleLessonMap` in the export service so lessons can be rendered.
- Currently these are inactive, and would only be used in a future PR.

<!--
Thank you for contributing to NUSMods!
The template below was made to help both you and the reviewers understand
your changes. Please fill it up to the best of your ability.
(These are comments, they won't be shown in the "preview")
-->

## Context
This is part of the changes meant to fix #4283 
Please refer to #4387 for additional info

<!-- Please link to a Github issue (type `#` to autocomplete issue) -->
<!-- Or provide a brief explanation about the problem -->

## Implementation
Other than adding the types, it also generates the `ModuleLessonMap` when modules are downloaded. This memoizes the `LessonId` so that they do not have to be generated every time they are used. This also applies to the export service. This also includes a couple of helper functions for serializing and deserializing `LessonId`s.
<!-- Explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
`LessonId`s are serialization of all a lesson details, except its module info and lesson type, please refer to https://github.com/nusmodifications/nusmods/pull/4292#issuecomment-3788288704 for why this was chosen. 
```ts
        {
          "classNo": "22",
          "lessonType": "Tutorial", // not serialized
          "weeks": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
          "day": "Wednesday",
          "startTime": "0900",
          "endTime": "1000",
          "venue": "S16-0518"
        },
```
would serialize to
`22|TUE|0900|1000|S16-0518|2_3_4_5_6_7_8_9_10_11_12_13`.

Serialization and deserialization can be quite expensive. So we calculate and store a map of the `LessonType` to `LessonId`s to lessons in `SemesterData`.
```ts
// Semester-specific information of a module.
export type SemesterData = {
  // ...
  readonly lessonMap: LessonMap<RawLesson>;
};
```

## Other Information
Currently these changes are inactive, they will be used in the a future PR. The delta to switch over to use `LessonId`s is already large enough as is.
<!--
This section is optional, it's for stuff like:
- Any questions you may have
- Any assistance you need
- Any tasks that are incomplete
- Letting us know that you're new to this (so we know how much to help out)
- Random gifs and emojis
-->
