### PR TITLE
fix: preserve planner course search input on blur

### DIFF
--- a/website/src/views/planner/PlannerModuleSelect.tsx
+++ b/website/src/views/planner/PlannerModuleSelect.tsx
@@ -1,6 +1,6 @@
 import { HTMLProps, useEffect, useMemo, useRef } from 'react';
 import { connect } from 'react-redux';
-import Downshift from 'downshift';
+import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
 import classnames from 'classnames';
 
 import { State } from 'types/state';
@@ -37,6 +37,20 @@ const MAX_MODULES = 50;
 function filterModules(term: string, modules: ModuleCondensed[]): ModuleCondensed[] {
   const predicate = createSearchPredicate(term);
   return takeUntil<ModuleCondensed>(modules, MAX_MODULES, predicate);
+}
+
+// By default Downshift resets the input value to the empty string whenever the
+// textarea is blurred (e.g. switching browser tabs or alt-tabbing away from the
+// window). Keep whatever the user has typed so their in-progress search isn't
+// lost, while still letting the menu close.
+function stateReducer(
+  state: DownshiftState<ModuleCode>,
+  changes: StateChangeOptions<ModuleCode>,
+): Partial<StateChangeOptions<ModuleCode>> {
+  if (changes.type === Downshift.stateChangeTypes.blurInput) {
+    return { ...changes, inputValue: state.inputValue };
+  }
+  return changes;
 }
 
 /**
@@ -88,6 +102,7 @@ export function PlannerModuleSelectComponent({
     <Downshift
       onChange={onSelect}
       onOuterClick={onBlur}
+      stateReducer={stateReducer}
       initialInputValue={defaultValue}
       initialIsOpen={false}
       initialHighlightedIndex={0}


### PR DESCRIPTION
## Problem

When adding a course in the Planner, typing a search query and then switching browser tabs or alt-tabbing away from the window clears the search field. On returning, the input is empty and you have to start typing again.

## Cause

The course search uses Downshift (`<Downshift>` render-prop component, v6.1.12) in `PlannerModuleSelect`. Downshift's default behaviour is to **reset the input value on blur** — it sets `inputValue` back to `itemToString(selectedItem)`, which is `''` when nothing has been selected yet. A window/tab switch fires a `blur` on the focused `<textarea>`, so the typed text gets wiped.

This is a long-standing, intentional Downshift behaviour, reported many times upstream:
- [downshift-js/downshift#574](https://github.com/downshift-js/downshift/issues/574) — empty input on blur when nothing is selected
- [downshift-js/downshift#598](https://github.com/downshift-js/downshift/issues/598) — blur fires a change to an empty value
- [downshift-js/downshift#289](https://github.com/downshift-js/downshift/issues/289) — value cleared when tabbing out

The community-recommended fix is a `stateReducer` keyed on `blurInput`. (The newer `useCombobox` hook doesn't reset on blur — see [#1011](https://github.com/downshift-js/downshift/issues/1011) — but migrating to it is out of scope here.)

## Fix

Add a `stateReducer` to the Downshift instance that, on the `blurInput` change, preserves the typed `inputValue` while still letting the dropdown menu close:

```ts
function stateReducer(state, changes) {
  if (changes.type === Downshift.stateChangeTypes.blurInput) {
    return { ...changes, inputValue: state.inputValue };
  }
  return changes;
}
```

This is shared by both call sites:

- `AddModule` (the reported case): no `onBlur`, so the form stays open and the search text now survives a tab/window switch.
- `PlannerModule` (placeholder editing): passes `onBlur` to cancel on outside-click, which only fires when the menu is closed and unmounts the input anyway — so behaviour there is unchanged.

## Testing

- Manual: Planner → Add Courses → type CS10 → alt-tab away and back (or switch browser tabs) → the text is retained.