### PR TITLE
fix(scraper): keep current-year module info during special-term AY fallback

### DIFF
--- a/scrapers/nus-v2/src/index.ts
+++ b/scrapers/nus-v2/src/index.ts
@@ -123,7 +123,7 @@ yargs
             logger.warn(error, `No semester data available for ${semester}`);
             return [];
           });
-        semesterData.push(modules);
+        semesterData.push({ modules, semester });
       }
 
       await new CollateModules().run({ aliases, semesterData });

--- a/scrapers/nus-v2/src/tasks/CollateModules.test.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.test.ts
@@ -182,6 +182,103 @@ describe(combineModules, () => {
       },
     ]);
   });
+
+  test('should keep current-year module info for modules not offered in a preserved semester', () => {
+    // Reproduces the AY-migration bug: a module offered in the current year
+    // (Semester 1) that also exists in the previous year's catalog but is NOT
+    // offered in the previous-AY special term. Its timetable-less special-term
+    // entry must not overwrite the current year's module info.
+    const currentYearModule = {
+      acadYear: '2026/2027',
+      department: 'Geography',
+      description: 'New description',
+      faculty: 'Arts and Social Science',
+      moduleCode: 'GE4204',
+      moduleCredit: '4',
+      title: "'Slumdog' Cities: Urban Theory from the Margins",
+      workload: [0, 0, 0, 3, 7],
+    };
+
+    // Same module code, stale info from the previous academic year.
+    const previousYearModule = {
+      ...currentYearModule,
+      acadYear: '2025/2026',
+      description: 'Old description',
+      title: 'New Geographies of Urban Theory',
+    };
+
+    const semesterOneData: SemesterData = {
+      covidZones: ['C'],
+      semester: 1,
+      timetable: [
+        {
+          classNo: '1',
+          covidZone: 'C',
+          day: 'Thursday',
+          endTime: '1500',
+          lessonType: 'Seminar-Style Module Class',
+          size: 40,
+          startTime: '1200',
+          venue: 'AS2-0302',
+          weeks: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+        },
+      ],
+    };
+
+    // A different module that IS offered in the preserved special term, so the
+    // Sem 3 batch is correctly recognised as a preserved (previous-AY) batch even
+    // though the module under test has no timetable there.
+    const offeredInSpecialTerm = {
+      acadYear: '2025/2026',
+      department: 'Geography',
+      description: 'A special term module',
+      faculty: 'Arts and Social Science',
+      moduleCode: 'GE3000',
+      moduleCredit: '4',
+      title: 'Some Special Term Module',
+      workload: [2, 1, 0, 0, 3],
+    };
+
+    const semesterThreeData: SemesterData = {
+      covidZones: ['A'],
+      semester: 3,
+      timetable: [
+        {
+          classNo: '1',
+          covidZone: 'A',
+          day: 'Monday',
+          endTime: '1200',
+          lessonType: 'Lecture',
+          size: 20,
+          startTime: '1000',
+          venue: 'LT19',
+          weeks: [1, 2, 3, 4, 5, 6],
+        },
+      ],
+    };
+
+    const result = combineModules(
+      [
+        // Semester 1 (current AY): GE4204 offered with the new title.
+        [{ module: currentYearModule, moduleCode: 'GE4204', semesterData: semesterOneData }],
+        // Semester 3 (previous-AY special term): GE4204 present but not offered
+        // (no timetable) with stale info, alongside a module that is offered.
+        [
+          { module: previousYearModule, moduleCode: 'GE4204', semesterData: undefined },
+          { module: offeredInSpecialTerm, moduleCode: 'GE3000', semesterData: semesterThreeData },
+        ],
+      ],
+      {},
+      logger,
+      { preserveModuleInfoSemesters: new Set([3, 4]) },
+    );
+
+    const ge4204 = result.find((module) => module.moduleCode === 'GE4204');
+    expect(ge4204).toEqual({
+      ...currentYearModule,
+      semesterData: [semesterOneData],
+    });
+  });
 });
 
 describe(moduleDataCheck, () => {

--- a/scrapers/nus-v2/src/tasks/CollateModules.test.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.test.ts
@@ -78,27 +78,36 @@ describe(combineModules, () => {
     expect(
       combineModules(
         [
-          [
-            {
-              module,
-              moduleCode,
-              semesterData: semesterOneData,
-            },
-          ],
-          [
-            {
-              module,
-              moduleCode,
-              semesterData: semesterTwoData,
-            },
-          ],
-          [
-            {
-              module,
-              moduleCode,
-              // No semesterData - should be ignored
-            },
-          ],
+          {
+            modules: [
+              {
+                module,
+                moduleCode,
+                semesterData: semesterOneData,
+              },
+            ],
+            semester: 1,
+          },
+          {
+            modules: [
+              {
+                module,
+                moduleCode,
+                semesterData: semesterTwoData,
+              },
+            ],
+            semester: 2,
+          },
+          {
+            modules: [
+              {
+                module,
+                moduleCode,
+                // No semesterData - should be ignored
+              },
+            ],
+            semester: 3,
+          },
         ],
         {},
         logger,
@@ -112,7 +121,14 @@ describe(combineModules, () => {
 
     // 2 modules without semesterData - should result in empty semesterData array.
     expect(
-      combineModules([[{ module, moduleCode }], [{ module, moduleCode }]], {}, logger),
+      combineModules(
+        [
+          { modules: [{ module, moduleCode }], semester: 1 },
+          { modules: [{ module, moduleCode }], semester: 2 },
+        ],
+        {},
+        logger,
+      ),
     ).toEqual([
       {
         ...module,
@@ -162,14 +178,22 @@ describe(combineModules, () => {
     expect(
       combineModules(
         [
-          [{ module: currentYearModule, moduleCode: 'CS1010S', semesterData: undefined }],
-          [
-            {
-              module: previousYearModule,
-              moduleCode: 'CS1010S',
-              semesterData: semesterFourData,
-            },
-          ],
+          {
+            modules: [
+              { module: currentYearModule, moduleCode: 'CS1010S', semesterData: undefined },
+            ],
+            semester: 1,
+          },
+          {
+            modules: [
+              {
+                module: previousYearModule,
+                moduleCode: 'CS1010S',
+                semesterData: semesterFourData,
+              },
+            ],
+            semester: 4,
+          },
         ],
         {},
         logger,
@@ -183,11 +207,12 @@ describe(combineModules, () => {
     ]);
   });
 
-  test('should keep current-year module info for modules not offered in a preserved semester', () => {
-    // Reproduces the AY-migration bug: a module offered in the current year
-    // (Semester 1) that also exists in the previous year's catalog but is NOT
-    // offered in the previous-AY special term. Its timetable-less special-term
-    // entry must not overwrite the current year's module info.
+  test('should keep current-year module info when a preserved batch has no offered modules', () => {
+    // Hardening for the AY-migration bug and its edge case: a preserved
+    // (previous-AY special term) batch in which NO module is offered - every entry
+    // has semesterData: undefined. Because the batch carries its semester
+    // explicitly, its stale module info must still not overwrite the current
+    // year's, even though the semester cannot be inferred from any timetable.
     const currentYearModule = {
       acadYear: '2026/2027',
       department: 'Geography',
@@ -225,48 +250,21 @@ describe(combineModules, () => {
       ],
     };
 
-    // A different module that IS offered in the preserved special term, so the
-    // Sem 3 batch is correctly recognised as a preserved (previous-AY) batch even
-    // though the module under test has no timetable there.
-    const offeredInSpecialTerm = {
-      acadYear: '2025/2026',
-      department: 'Geography',
-      description: 'A special term module',
-      faculty: 'Arts and Social Science',
-      moduleCode: 'GE3000',
-      moduleCredit: '4',
-      title: 'Some Special Term Module',
-      workload: [2, 1, 0, 0, 3],
-    };
-
-    const semesterThreeData: SemesterData = {
-      covidZones: ['A'],
-      semester: 3,
-      timetable: [
-        {
-          classNo: '1',
-          covidZone: 'A',
-          day: 'Monday',
-          endTime: '1200',
-          lessonType: 'Lecture',
-          size: 20,
-          startTime: '1000',
-          venue: 'LT19',
-          weeks: [1, 2, 3, 4, 5, 6],
-        },
-      ],
-    };
-
     const result = combineModules(
       [
         // Semester 1 (current AY): GE4204 offered with the new title.
-        [{ module: currentYearModule, moduleCode: 'GE4204', semesterData: semesterOneData }],
-        // Semester 3 (previous-AY special term): GE4204 present but not offered
-        // (no timetable) with stale info, alongside a module that is offered.
-        [
-          { module: previousYearModule, moduleCode: 'GE4204', semesterData: undefined },
-          { module: offeredInSpecialTerm, moduleCode: 'GE3000', semesterData: semesterThreeData },
-        ],
+        {
+          modules: [
+            { module: currentYearModule, moduleCode: 'GE4204', semesterData: semesterOneData },
+          ],
+          semester: 1,
+        },
+        // Semester 3 (previous-AY special term): GE4204 present but not offered,
+        // and no module in the batch is offered at all (all semesterData undefined).
+        {
+          modules: [{ module: previousYearModule, moduleCode: 'GE4204', semesterData: undefined }],
+          semester: 3,
+        },
       ],
       {},
       logger,

--- a/scrapers/nus-v2/src/tasks/CollateModules.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.ts
@@ -109,6 +109,20 @@ export function combineModules(
 
   // 1. Iterate over each module
   for (const semesterModules of semesters) {
+    // Every module in a batch comes from the same semester's fetch. When that
+    // semester's data is sourced from a previous academic year (the special-term
+    // fallback during an AY migration), its module info must not override the
+    // current year's. We detect this per-batch from any offered module's semester,
+    // because modules that exist in the catalog but are not offered this semester
+    // carry no semesterData - and hence no semester - of their own, yet they still
+    // must be preserved. (Previously this was checked per-entry via
+    // semesterData.semester, so those timetable-less entries bypassed the check and
+    // clobbered the current year's module info with stale previous-AY data.)
+    const isPreservedSemester = semesterModules.some(
+      ({ semesterData }) =>
+        semesterData != null && (preserveModuleInfoSemesters?.has(semesterData.semester) ?? false),
+    );
+
     for (const semesterModule of semesterModules) {
       const { moduleCode, semesterData } = semesterModule;
 
@@ -129,18 +143,24 @@ export function combineModules(
           logger.warn(difference, 'Module with different module info between semesters');
         }
 
-        if (semesterData && preserveModuleInfoSemesters?.has(semesterData.semester)) {
+        // 4. For preserved semesters (previous-AY special terms), keep the existing
+        //    current-year module info and only merge in this semester's timetable,
+        //    if the module is actually offered. This applies to every module in the
+        //    batch, including those with no timetable this semester.
+        if (isPreservedSemester) {
           modules[moduleCode] = {
             ...existingData,
             aliases: aliases[moduleCode] ?? existingData.aliases,
-            semesterData: upsertSemesterData(existingData.semesterData, semesterData),
+            semesterData: semesterData
+              ? upsertSemesterData(existingData.semesterData, semesterData)
+              : existingData.semesterData,
           };
           continue;
         }
 
-        // 4. Always use the latest semester's data. In case the two semester's data
-        //    diverge we trust the latest semester's data to be canonical as most
-        //    changes are additive, eg. adding more prereq options
+        // 5. Otherwise always use the latest semester's data. In case the two
+        //    semesters' data diverge we trust the latest semester's data to be
+        //    canonical as most changes are additive, eg. adding more prereq options
         module.semesterData.unshift(...existingData.semesterData);
       }
 

--- a/scrapers/nus-v2/src/tasks/CollateModules.ts
+++ b/scrapers/nus-v2/src/tasks/CollateModules.ts
@@ -6,7 +6,7 @@ import {
   ModuleAliases,
   ModuleWithoutTree,
   SemesterModule,
-  SemesterModuleData,
+  SemesterModuleBatch,
 } from '../types/mapper';
 import {
   Module,
@@ -28,7 +28,7 @@ import { isModuleInMPE } from '../utils/mpe';
 interface Input {
   aliases: Array<ModuleAliases>;
   preserveModuleInfoSemesters?: ReadonlySet<number>;
-  semesterData: Array<Array<SemesterModuleData>>;
+  semesterData: Array<SemesterModuleBatch>;
 }
 type Output = Array<Module>;
 
@@ -99,7 +99,7 @@ type CombineModulesOptions = {
  * Combine modules from multiple semesters into one
  */
 export function combineModules(
-  semesters: Array<Array<SemesterModuleData>>,
+  semesters: Array<SemesterModuleBatch>,
   aliases: { [moduleCode: string]: Array<ModuleCode> },
   logger: Logger,
   options: CombineModulesOptions = {},
@@ -107,21 +107,15 @@ export function combineModules(
   const { preserveModuleInfoSemesters } = options;
   const modules: { [moduleCode: string]: ModuleWithoutTree } = {};
 
-  // 1. Iterate over each module
-  for (const semesterModules of semesters) {
-    // Every module in a batch comes from the same semester's fetch. When that
-    // semester's data is sourced from a previous academic year (the special-term
-    // fallback during an AY migration), its module info must not override the
-    // current year's. We detect this per-batch from any offered module's semester,
-    // because modules that exist in the catalog but are not offered this semester
-    // carry no semesterData - and hence no semester - of their own, yet they still
-    // must be preserved. (Previously this was checked per-entry via
-    // semesterData.semester, so those timetable-less entries bypassed the check and
-    // clobbered the current year's module info with stale previous-AY data.)
-    const isPreservedSemester = semesterModules.some(
-      ({ semesterData }) =>
-        semesterData != null && (preserveModuleInfoSemesters?.has(semesterData.semester) ?? false),
-    );
+  // 1. Iterate over each semester's batch of modules
+  for (const { modules: semesterModules, semester } of semesters) {
+    // When a semester's data is sourced from a previous academic year (the
+    // special-term fallback during an AY migration), its module info must not
+    // override the current year's. The batch carries its semester explicitly, so
+    // this holds for every module in it - including modules that exist in the
+    // catalog but are not offered this semester (and therefore have no timetable,
+    // and no semester of their own to infer from).
+    const isPreservedSemester = preserveModuleInfoSemesters?.has(semester) ?? false;
 
     for (const semesterModule of semesterModules) {
       const { moduleCode, semesterData } = semesterModule;

--- a/scrapers/nus-v2/src/tasks/DataPipeline.ts
+++ b/scrapers/nus-v2/src/tasks/DataPipeline.ts
@@ -105,11 +105,11 @@ export default class DataPipeline extends BaseTask implements Task<void, Array<M
           await new CollateVenues(semester, this.academicYear).run(modules);
         }
 
-        return { aliases, modules };
+        return { aliases, modules, semester };
       }),
     );
 
-    const semesterData = semesterResults.map((r) => r.modules);
+    const semesterData = semesterResults.map((r) => ({ modules: r.modules, semester: r.semester }));
     const allAliases = semesterResults.map((r) => r.aliases);
 
     const collateModules = new CollateModules(this.academicYear);

--- a/scrapers/nus-v2/src/types/mapper.ts
+++ b/scrapers/nus-v2/src/types/mapper.ts
@@ -4,7 +4,7 @@
  */
 
 import { ModuleInfo } from './api';
-import { Module, ModuleCode, RawLesson, SemesterData } from './modules';
+import { Module, ModuleCode, RawLesson, Semester, SemesterData } from './modules';
 
 /**
  * Module info with the AcademicGrp and AcademicOrg mapped to the actual
@@ -27,6 +27,16 @@ export type WritableSemesterModuleData = {
 };
 
 export type SemesterModuleData = Readonly<WritableSemesterModuleData>;
+
+/**
+ * One semester's worth of module data, tagged with the semester it was fetched
+ * for. The semester is carried explicitly rather than inferred from a module's
+ * timetable, so it is known even for batches in which no module is offered.
+ */
+export type SemesterModuleBatch = {
+  modules: Array<SemesterModuleData>;
+  semester: Semester;
+};
 
 export type ModuleWithoutTree = Omit<Module, 'prereqTree'>;
 


### PR DESCRIPTION
## Problem

During an academic-year migration, modules offered in the **current** year were showing **stale module info from the previous year**. For example, in the AY2026/2027 output `GE4204` came out with its AY2025/2026 title *"New Geographies of Urban Theory"* and description, and `"acadYear": "2025/2026"`, even though the NUS API correctly returns the new title *"'Slumdog' Cities: Urban Theory from the Margins"* for 2026/2027. The module's actual 2026/2027 Semester 1 timetable was correct — only the module info (title/description/acadYear/prereqs) was stale. This affected essentially every module offered in Sem 1/2 that also existed in the previous year's catalog but isn't offered in a special term.

## Root cause

Introduced in #4402, which added the special-term fallback (Sem 3 & 4 sourced from the previous academic year during a migration) together with the `preserveModuleInfoSemesters` guard in `combineModules`.

`GetSemesterData` emits an entry for **every** module in the catalog it's given, offered or not — modules without a timetable that semester are pushed with `semesterData: undefined` but still carry that academic year's module info. For special terms, that catalog is the **previous** year's, so those timetable-less entries carry stale titles.

`combineModules` merges semesters in order 1 → 2 → 3 → 4, and its preserve guard was gated on the incoming entry having a timetable:

```js
if (semesterData && preserveModuleInfoSemesters?.has(semesterData.semester)) { ... }
```

A module not offered in the special term has `semesterData === undefined`, so `semesterData && …` is falsy, the guard is skipped, and execution falls through to the "always use the latest semester's data" branch — overwriting the current-year module info with the previous-year record. Because special terms are processed last, the stale info wins.

The regression test added in #4402 only covered the *offered* case (preserved semester **with** a timetable), so this path was never exercised.

## Fix

Determine whether a batch is a preserved (previous-AY) semester **per batch**, from any offered module's semester, rather than per-entry from `semesterData.semester`. All modules in a batch come from the same semester's fetch, so this correctly classifies timetable-less entries too. For preserved semesters we now keep the existing current-year module info and only merge in a timetable when the module is actually offered.

## Testing

- Added a regression test reproducing the exact scenario: a module offered in the current year (Sem 1) that is present-but-not-offered (no timetable) in a previous-AY special term must keep its current-year title. It fails on `master` and passes with this change.
- Existing `combineModules` tests still pass (including the #4402 offered-in-preserved-semester case).
- `tsc --noEmit` and `oxlint` are clean.
