### PR TITLE
fix: use `:path*` form in vercel.json for api rewrites

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -41,8 +41,8 @@
   ],
   "rewrites": [
     {
-      "source": "/api(/.*)?",
-      "destination": "https://api.nusmods.com$1"
+      "source": "/api/:path*",
+      "destination": "https://api.nusmods.com/:path*"
     }
   ],
   "redirects": [


### PR DESCRIPTION
## Problem

Requests to `nusmods.com/api/*` with a file extension returned a 404 instead of being proxied to `api.nusmods.com`. For example, `https://nusmods.com/api/2017-2018/moduleList.json` (used by v2.nusmods.com) 404'd even though the upstream `https://api.nusmods.com/2017-2018/moduleList.json` returns valid JSON.

Extension-less paths (e.g. `/api/2017-2018`) proxied fine, so the rewrite itself was working — but any path containing a `.ext` (`.json`, `.xml`, etc.) was silently dropped.

## Cause

The rewrite used a regex-capture source (`/api(/.*)?` → `https://api.nusmods.com$1`). Top-level `vercel.json` rewrites run in Vercel's "afterFiles" phase, i.e. after the path is resolved against the static build output. A path that looks like a static asset (has a file extension) is treated as an asset lookup; when no matching file exists in the build, Vercel returns a 404 at the filesystem stage before the external rewrite gets a chance to proxy it. Extension-less paths aren't treated as asset lookups, so they fell through to the rewrite and proxied correctly.

## Fix

Switch to Vercel's documented named path-segment form for external proxying:

- `source`: `/api/:path*`
- `destination`: `https://api.nusmods.com/:path*`

This forwards all `/api/*` paths — including those with file extensions — to the upstream API. Verified on a preview deployment: `/api/2017-2018/moduleList.json` and other `.json` paths now proxy correctly, while extension-less paths continue to work.

## Testing

- `nusmods.com/api/2017-2018/moduleList.json` → 200 JSON (was 404)
- `nusmods.com/api/2017-2018` → 200 (directory listing, unchanged)
- Serverless functions under `/api/nus/*` and `/api/optimiser/*` still resolve to the functions, not the proxy