### PR TITLE
fix(website): give api tsconfig Node types and matching module resolution

### DIFF
--- a/website/api/tsconfig.json
+++ b/website/api/tsconfig.json
@@ -3,6 +3,12 @@
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020"],
+    // Serverless functions run on Node, so pull in Node's globals (fs, path,
+    // __dirname, URL, console) rather than the DOM lib. Restricting `types`
+    // also stops TS from auto-loading every @types/* package (e.g. the
+    // conflicting React typings) into the program.
+    "types": ["node"],
+    "skipLibCheck": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
@@ -11,6 +17,14 @@
     "strictPropertyInitialization": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
-    "esModuleInterop": true
-  }
+    "esModuleInterop": true,
+    // Match the main tsconfig's module resolution so the src/* files these
+    // functions import (bare `types/*` imports, JSON data) resolve correctly.
+    "baseUrl": "../src/",
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
+  },
+  // Include the ambient globals (NUSMODS_ENV, etc.) injected at build time,
+  // which are referenced transitively via src/config.
+  "include": ["**/*.ts", "../src/types/global.d.ts"]
 }


### PR DESCRIPTION
## Problem

Opening any serverless function (or during Vercel builds) under `website/api/` (e.g. `api/nus/auth/login.ts`) surfaced a wall of TypeScript errors in the `src/serverless/*` files they import:

```
src/serverless/nus-auth.ts: Cannot find module 'fs'
src/serverless/nus-auth.ts: Cannot find module 'path'
src/serverless/nus-auth.ts: Cannot find name '__dirname'
src/serverless/nus-auth.ts: Cannot find name 'URL'
src/serverless/nus-auth.ts: Cannot find name 'console'
```

The errors come from `website/api/tsconfig.json`, which is significant for two reasons:

- `vercel.json` bundles it with the serverless functions via `includeFiles` and excludes the main `tsconfig.json`, so `@vercel/node` builds the functions with it.
- The IDE's TypeScript server uses it for any file under `api/` (it's the nearest config).

That config targeted `lib: ["ES2020"]` with **no `dom` and no Node types**. The functions run on Node and use `fs` / `path` / `__dirname` and the `URL` / `console` globals, so every one of those was reported as missing. The main `tsconfig.json` (which the full `pnpm typecheck` uses) already handles `api/` correctly, so this only affected the serverless-specific config.

## Fix

In `website/api/tsconfig.json`:

- `"types": ["node"]` — provides the Node globals (`fs`, `path`, `__dirname`, `URL`, `console`). Node types are the right fit for a serverless runtime rather than adding the DOM lib. Restricting `types` also stops TS from auto-loading every `@types/*` package (which had been dragging in conflicting React typings).
- `"skipLibCheck": true` — matches the main config; skips errors inside third-party `.d.ts` files.
- `baseUrl: "../src/"`, `resolveJsonModule`, `allowSyntheticDefaultImports` — mirror the main tsconfig so the `src/*` files these functions import transitively (bare `types/*` imports, JSON data in `src/config`) resolve correctly.
- Added the ambient `src/types/global.d.ts` to `include` for build-time globals like `NUSMODS_ENV` referenced via `src/config`.