### PR TITLE
fix(optimiser): retry and parallelise module data fetches to fix intermittent timeouts

### DIFF
--- a/website/api/optimiser/_client/client.go
+++ b/website/api/optimiser/_client/client.go
@@ -2,6 +2,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,10 +11,52 @@ import (
 	constants "github.com/nusmodifications/nusmods/website/api/optimiser/_constants"
 )
 
-var httpClient = &http.Client{Timeout: 10 * time.Second}
+var httpClient = &http.Client{Timeout: constants.HTTPRequestTimeout}
 
-// HTTP request to get Module data
+// badStatusError signals a non-200 response. It carries the status code so the
+// retry logic can decide whether the failure is worth retrying (5xx) or is a
+// permanent client error such as an unknown module (4xx).
+type badStatusError struct {
+	module     string
+	statusCode int
+}
+
+func (e *badStatusError) Error() string {
+	return fmt.Sprintf("failed to fetch module %s: status %d", e.module, e.statusCode)
+}
+
+// GetModuleData fetches a module's JSON data, retrying transient failures.
+//
+// Network errors and timeouts (the origin being briefly slow to respond) and
+// 5xx responses are retried with a fixed backoff. A 4xx response is treated as
+// permanent (e.g. an unknown module returns 404) and is not retried.
 func GetModuleData(acadYear string, module string) ([]byte, error) {
+	var lastErr error
+	for attempt := 1; attempt <= constants.HTTPMaxAttempts; attempt++ {
+		body, err := fetchModuleData(acadYear, module)
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+
+		// Don't retry permanent client errors (4xx) — retrying won't help.
+		var statusErr *badStatusError
+		if errors.As(err, &statusErr) &&
+			statusErr.statusCode >= http.StatusBadRequest &&
+			statusErr.statusCode < http.StatusInternalServerError {
+			return nil, err
+		}
+
+		// Don't sleep after the final attempt.
+		if attempt < constants.HTTPMaxAttempts {
+			time.Sleep(constants.HTTPRetryBackoff)
+		}
+	}
+	return nil, fmt.Errorf("giving up after %d attempts: %w", constants.HTTPMaxAttempts, lastErr)
+}
+
+// fetchModuleData performs a single HTTP request for a module's JSON data.
+func fetchModuleData(acadYear string, module string) ([]byte, error) {
 	url := fmt.Sprintf(constants.ModulesURL, acadYear, module)
 	res, err := httpClient.Get(url)
 	if err != nil {
@@ -22,7 +65,7 @@ func GetModuleData(acadYear string, module string) ([]byte, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to fetch module %s: status %d", module, res.StatusCode)
+		return nil, &badStatusError{module: module, statusCode: res.StatusCode}
 	}
 
 	body, err := io.ReadAll(res.Body)

--- a/website/api/optimiser/_constants/constants.go
+++ b/website/api/optimiser/_constants/constants.go
@@ -2,8 +2,25 @@ package constants
 
 import (
 	_ "embed"
+	"time"
 
 	models "github.com/nusmodifications/nusmods/website/api/optimiser/_models"
+)
+
+// HTTP client settings for fetching module data from the NUSMods API.
+const (
+	// HTTPRequestTimeout bounds a single request (connect + awaiting headers +
+	// reading the body), applied per attempt rather than across all retries.
+	// Observed failures are connection/transit stalls on the way to the origin
+	// (the origin itself serves in milliseconds), not slow origin compute, so
+	// this is kept short to fail fast and let a retry try a fresh connection
+	// instead of blocking the whole budget on one stalled attempt.
+	HTTPRequestTimeout = 4 * time.Second
+	// HTTPMaxAttempts is the total number of attempts (1 initial + retries) for
+	// a single module before giving up.
+	HTTPMaxAttempts = 3
+	// HTTPRetryBackoff is the fixed delay between attempts.
+	HTTPRetryBackoff = 300 * time.Millisecond
 )
 
 // Ensure in sync with all E-Venues in NUSMods

--- a/website/api/optimiser/_modules/modules.go
+++ b/website/api/optimiser/_modules/modules.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	client "github.com/nusmodifications/nusmods/website/api/optimiser/_client"
 	constants "github.com/nusmodifications/nusmods/website/api/optimiser/_constants"
@@ -36,72 +37,118 @@ func GetAllModuleSlots(
 
 	// These are default or backup slots for the partial timetable so that we can display some random slot for unallocated lessons
 	defaultSlots := make(models.ModuleDefaultSlotsMap)
-	for _, module := range optimiserRequest.Modules {
 
-		body, err := client.GetModuleData(optimiserRequest.AcadYear, strings.ToUpper(module))
-		if err != nil {
-			return nil, nil, nil, err
+	// Fetch and process each module concurrently. The modules are independent of
+	// one another, so a single slow fetch no longer blocks the others; the total
+	// wall-clock time is bounded by the slowest module rather than their sum.
+	// Results are written into per-index slots to avoid concurrent map writes,
+	// then assembled into the maps once all goroutines have finished.
+	type moduleResult struct {
+		merged   map[models.LessonType]map[models.ClassNo][]models.ModuleSlot
+		defaults map[models.LessonType][]models.ModuleSlot
+		err      error
+	}
+	results := make([]moduleResult, len(optimiserRequest.Modules))
+
+	var wg sync.WaitGroup
+	for i, module := range optimiserRequest.Modules {
+		wg.Add(1)
+		go func(i int, module string) {
+			defer wg.Done()
+			merged, defaults, err := processModule(
+				optimiserRequest,
+				module,
+				venues,
+				recordingsMap,
+				freeDaysMap,
+			)
+			results[i] = moduleResult{merged: merged, defaults: defaults, err: err}
+		}(i, module)
+	}
+	wg.Wait()
+
+	for i, module := range optimiserRequest.Modules {
+		if results[i].err != nil {
+			return nil, nil, nil, results[i].err
 		}
-
-		var moduleData struct {
-			SemesterData []struct {
-				Semester  int                 `json:"semester"`
-				Timetable []models.ModuleSlot `json:"timetable"`
-			} `json:"semesterData"`
-		}
-		err = json.Unmarshal(body, &moduleData)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		// Get the module timetable for the semester
-		var moduleTimetable []models.ModuleSlot
-		for _, semester := range moduleData.SemesterData {
-			if semester.Semester == optimiserRequest.AcadSem {
-				moduleTimetable = semester.Timetable
-				break
-			}
-		}
-
-		// Parse the weeks
-		for i := range moduleTimetable {
-
-			// Note: if weeks is not a []int, then skip parsing
-			// Currently we are not handling week conflict for non-[]int weeks
-			if _, ok := moduleTimetable[i].Weeks.([]any); !ok {
-				continue
-			}
-
-			moduleTimetable[i].WeeksSet = make(map[int]struct{})
-			weeks := moduleTimetable[i].Weeks.([]any)
-			weeksStrings := make([]string, 0, len(weeks))
-
-			for _, week := range weeks {
-				weekFloat, ok := week.(float64)
-				if !ok {
-					continue
-				}
-				weekInt := int(weekFloat)
-				moduleTimetable[i].WeeksSet[weekInt] = struct{}{}
-				weeksStrings = append(weeksStrings, strconv.Itoa(weekInt))
-			}
-			moduleTimetable[i].WeeksString = strings.Join(weeksStrings, ",")
-		}
-
-		// Store the module slots for the module
-		moduleSlots[module], defaultSlots[module] = mergeAndFilterModuleSlots(
-			moduleTimetable,
-			venues,
-			module,
-			recordingsMap,
-			freeDaysMap,
-			optimiserRequest.EarliestMin,
-			optimiserRequest.LatestMin,
-		)
-
+		moduleSlots[module] = results[i].merged
+		defaultSlots[module] = results[i].defaults
 	}
 
 	return moduleSlots, defaultSlots, recordingsMap, nil
+}
+
+// processModule fetches a single module's data and reduces it to its candidate
+// and default slots. It is safe to run concurrently for different modules since
+// it only reads the shared venues/recordings/freeDays maps and returns its
+// result rather than writing to shared state.
+func processModule(
+	optimiserRequest *models.OptimiserRequest,
+	module string,
+	venues map[string]models.Location,
+	recordingsMap map[string]struct{},
+	freeDaysMap map[string]struct{},
+) (map[models.LessonType]map[models.ClassNo][]models.ModuleSlot, map[models.LessonType][]models.ModuleSlot, error) {
+	body, err := client.GetModuleData(optimiserRequest.AcadYear, strings.ToUpper(module))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var moduleData struct {
+		SemesterData []struct {
+			Semester  int                 `json:"semester"`
+			Timetable []models.ModuleSlot `json:"timetable"`
+		} `json:"semesterData"`
+	}
+	err = json.Unmarshal(body, &moduleData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Get the module timetable for the semester
+	var moduleTimetable []models.ModuleSlot
+	for _, semester := range moduleData.SemesterData {
+		if semester.Semester == optimiserRequest.AcadSem {
+			moduleTimetable = semester.Timetable
+			break
+		}
+	}
+
+	// Parse the weeks
+	for i := range moduleTimetable {
+
+		// Note: if weeks is not a []int, then skip parsing
+		// Currently we are not handling week conflict for non-[]int weeks
+		if _, ok := moduleTimetable[i].Weeks.([]any); !ok {
+			continue
+		}
+
+		moduleTimetable[i].WeeksSet = make(map[int]struct{})
+		weeks := moduleTimetable[i].Weeks.([]any)
+		weeksStrings := make([]string, 0, len(weeks))
+
+		for _, week := range weeks {
+			weekFloat, ok := week.(float64)
+			if !ok {
+				continue
+			}
+			weekInt := int(weekFloat)
+			moduleTimetable[i].WeeksSet[weekInt] = struct{}{}
+			weeksStrings = append(weeksStrings, strconv.Itoa(weekInt))
+		}
+		moduleTimetable[i].WeeksString = strings.Join(weeksStrings, ",")
+	}
+
+	merged, defaults := mergeAndFilterModuleSlots(
+		moduleTimetable,
+		venues,
+		module,
+		recordingsMap,
+		freeDaysMap,
+		optimiserRequest.EarliestMin,
+		optimiserRequest.LatestMin,
+	)
+	return merged, defaults, nil
 }
 
 // Gets all venue information from venues.json


### PR DESCRIPTION
## Problem

Some optimiser requests were failing with errors like:

`solve failed: Get "https://api.nusmods.com/v2/2026-2027/modules/PC5102.json": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`

The optimiser fetched each module's timetable data from `api.nusmods.com` **sequentially**, with a single **10s client timeout and no retries**. Any one slow fetch aborted the entire solve.

## Root cause — the origin is healthy; the stall is in transit

Correlating the optimiser's error log (UTC) with the nginx origin access log (SGT, +0800). `14:59 UTC = 22:59 SGT`:

| Optimiser (UTC → SGT) | nginx origin (SGT) | |
| --- | --- | --- |
| `14:59:00.016` → `22:59:00` "request received" | `22:59:00` `PC5101` → `200` (785 B) | first module, served instantly |
| | `22:59:13` `PC5102` → `200` (703 B) | the "timed-out" fetch — served fine at origin |
| `14:59:11.795` → `22:59:11.8` "solve failed: PC5102 timeout" | | client gave up ~1.2s *before* origin logged PC5102 |

The optimiser dispatched `PC5102` at ~22:59:01–02, its 10s timeout fired at 22:59:11.8, and the origin didn't serve `PC5102` until 22:59:13 — ~11s after dispatch, and when it did, it was a trivially fast `200` for a 703-byte file. The origin never struggled; the request simply took ~11s to *reach* it.

Additional context from the log: 22:53–23:03 SGT shows a dense burst of `Go-http-client/2.0` requests across dozens of modules (many concurrent optimiser invocations, AY26/27 registration season). This is a **load-induced connection/transit stall on the optimiser → Cloudflare hop** (likely cold Vercel instances doing fresh TLS handshakes from shared egress IPs during a burst).

Ruled out:
- **Rate-limiting** — a Cloudflare/nginx limit returns a status code *with headers*, producing a different error; `awaiting headers` means no response headers arrived at all. No `429`/`503` anywhere in the origin log.
- **Origin slowness** — `PC5102.json` was served as a fast `200`/`304` hundreds of times that day, including seconds before and after the failure.

## Changes

- **Retry** transient failures (network errors, timeouts, 5xx) up to 3 attempts with a 300ms backoff. A `4xx` (e.g. unknown module `404`) is treated as permanent and not retried, so bad requests still fail fast.
- **Concurrent fetching** — modules are fetched/processed in parallel instead of sequentially. The traffic is HTTP/2 (confirmed in the logs), so Go's transport multiplexes all fetches over a single connection; wall-clock is bounded by the slowest module rather than their sum, without adding connection-setup load.
- **Shorter per-attempt timeout** — dropped from 10s to 4s. Since the failure mode is a connection/transit stall, failing fast and retrying on a fresh connection beats blocking the whole budget on one stalled attempt. Worst case ≈ 3×4s + 2×0.3s ≈ 12.6s, but a stall now recovers in ~4s instead of 10s.

## Note

This fix makes the optimiser resilient to the transit stalls. It does not address the underlying infra cause (Vercel egress / Cloudflare connection reuse under burst) — worth a follow-up with Cloudflare logs if timeouts persist after deploy.