### PR TITLE
feat(website): add timetable slot comparison view

### DIFF
--- a/website/src/actions/moduleBank-lru.ts
+++ b/website/src/actions/moduleBank-lru.ts
@@ -1,20 +1,28 @@
-import { flatMap, sortBy, get } from 'lodash-es';
+import { flatMap, sortBy, get, values } from 'lodash-es';
 
-import { ModulesMap } from 'types/reducers';
-import { TimetableConfig } from 'types/timetables';
+import { ModulesMap, TimetablesState } from 'types/reducers';
+import { SemTimetableConfig, TimetableConfig } from 'types/timetables';
 import { ModuleCode } from 'types/modules';
 
 // Module bank utils - exported separately so this does not become exported as an action creator
 
+// All lesson configs that pin their modules in the module bank: the live
+// timetable of every semester, plus every saved slot's snapshot
+export function getPinnedLessonConfigs(timetables: TimetablesState): SemTimetableConfig[] {
+  return [
+    ...values(timetables.lessons),
+    ...flatMap(values(timetables.slots), (slots) => slots.map((slot) => slot.data.lessons)),
+  ];
+}
+
 // Export for testing
-// eslint-disable-next-line import/prefer-default-export
 export function getLRUModules(
   modules: ModulesMap,
-  lessons: TimetableConfig,
+  lessons: TimetableConfig | SemTimetableConfig[],
   currentModule: string,
   toRemove = 1,
 ): ModuleCode[] {
-  // Pull all the modules in all the timetables
+  // Pull all the modules in all the timetables and saved slots
   const timetableModules = new Set(flatMap(lessons, (semester) => Object.keys(semester)));
 
   // Remove the module which is least recently used and which is not in timetable

--- a/website/src/actions/moduleBank.test.ts
+++ b/website/src/actions/moduleBank.test.ts
@@ -88,6 +88,19 @@ test('getLRUModule should return the LRU and non-timetable module', () => {
   expect(resultOfAction).toMatchSnapshot();
 });
 
+test('getLRUModule should not evict modules saved in timetable slots', () => {
+  const modules: any = {
+    ACC1001: { timestamp: 1 }, // in an inactive slot - must not be evicted
+    ACC1002: { timestamp: 2 }, // not referenced anywhere - evictable
+    ACC1003: { timestamp: 3 }, // in the live timetable
+  };
+
+  // Lesson configs may come from live timetables and saved slots alike
+  const lessonConfigs: any = [{ ACC1003: {} }, { ACC1001: {} }];
+
+  expect(getLRUModules(modules, lessonConfigs, 'ACC1004')).toEqual(['ACC1002']);
+});
+
 test('removeLRUModule should return an action', () => {
   const resultOfAction = actions.Internal.removeLRUModule(['ACC1001']);
   expect(resultOfAction).toMatchSnapshot();

--- a/website/src/actions/moduleBank.ts
+++ b/website/src/actions/moduleBank.ts
@@ -18,7 +18,7 @@ import {
   REMOVE_LRU_MODULE,
   UPDATE_MODULE_TIMESTAMP,
 } from './constants';
-import { getLRUModules } from './moduleBank-lru';
+import { getLRUModules, getPinnedLessonConfigs } from './moduleBank-lru';
 
 export function fetchModuleList() {
   return requestAction(FETCH_MODULE_LIST, {
@@ -102,7 +102,7 @@ export function fetchModule(moduleCode: ModuleCode) {
 
         const LRUModule = getLRUModules(
           moduleBank.modules,
-          timetables.lessons,
+          getPinnedLessonConfigs(timetables),
           moduleCode,
           overLimitCount,
         );

--- a/website/src/actions/timetables.test.ts
+++ b/website/src/actions/timetables.test.ts
@@ -98,6 +98,66 @@ describe(actions.addModule, () => {
   });
 });
 
+describe('timetable slot thunks', () => {
+  // Two slots for semester 1: '0' (inactive, holds CS1010S) and '1' (active, blank)
+  const slotState: any = {
+    moduleBank: { moduleCodes: {}, modules: {} },
+    timetables: {
+      ...initialState,
+      lessons: { [1]: {} },
+      slots: {
+        [1]: [
+          {
+            id: '0',
+            title: 'Timetable 1',
+            data: { lessons: { CS1010S: {} }, colors: { CS1010S: 0 }, hidden: [], ta: [] },
+          },
+          { id: '1', title: 'Timetable 2', data: { lessons: {}, colors: {}, hidden: [], ta: [] } },
+        ],
+      },
+      activeSlot: { [1]: '1' },
+    },
+  };
+
+  // Dispatch mock that executes thunks so nested fetch/validate thunks run
+  const makeDispatch = (state: any) => {
+    const dispatch: any = vi.fn((action) =>
+      typeof action === 'function' ? action(dispatch, () => state) : action,
+    );
+    return dispatch;
+  };
+
+  // The timetable cannot render modules missing from the module bank, so the
+  // incoming slot's modules must be fetched before its data is loaded into
+  // the live timetable
+  const actionTypes = (dispatch: any) =>
+    dispatch.mock.calls.map(([action]: [any]) =>
+      typeof action === 'function' ? 'thunk' : action.type,
+    );
+
+  test('switchTimetableSlot should fetch slot modules before switching', async () => {
+    const dispatch = makeDispatch(slotState);
+    await actions.switchTimetableSlot(1, '0')(dispatch, () => slotState);
+
+    expect(dispatch).toHaveBeenCalledWith(actions.Internal.switchTimetableSlot(1, '0'));
+
+    const calls = actionTypes(dispatch);
+    const switchIndex = calls.indexOf(actions.SWITCH_TIMETABLE_SLOT);
+    expect(calls.slice(0, switchIndex)).toContain('thunk');
+  });
+
+  test('deleteTimetableSlot should fetch neighbouring slot modules before deleting', async () => {
+    const dispatch = makeDispatch(slotState);
+    await actions.deleteTimetableSlot(1, '1')(dispatch, () => slotState);
+
+    expect(dispatch).toHaveBeenCalledWith(actions.Internal.deleteTimetableSlot(1, '1'));
+
+    const calls = actionTypes(dispatch);
+    const deleteIndex = calls.indexOf(actions.DELETE_TIMETABLE_SLOT);
+    expect(calls.slice(0, deleteIndex)).toContain('thunk');
+  });
+});
+
 test('removeLesson should return information to remove module', () => {
   const semester: Semester = 1;
   const moduleCode: ModuleCode = 'CS1010';

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -43,6 +43,8 @@ export const SET_TIMETABLE = 'SET_TIMETABLE' as const;
 export const ADD_MODULE = 'ADD_MODULE' as const;
 export const SET_HIDDEN_IMPORTED = 'SET_HIDDEN_IMPORTED' as const;
 export const SET_TA_IMPORTED = 'SET_TA_IMPORTED' as const;
+export const SWITCH_TIMETABLE_SLOT = 'SWITCH_TIMETABLE_SLOT' as const;
+export const DELETE_TIMETABLE_SLOT = 'DELETE_TIMETABLE_SLOT' as const;
 export const Internal = {
   setTimetable(
     semester: Semester,
@@ -67,7 +69,77 @@ export const Internal = {
       },
     };
   },
+
+  switchTimetableSlot(semester: Semester, slotId: string) {
+    return {
+      type: SWITCH_TIMETABLE_SLOT,
+      payload: { semester, slotId },
+    };
+  },
+
+  deleteTimetableSlot(semester: Semester, slotId: string) {
+    return {
+      type: DELETE_TIMETABLE_SLOT,
+      payload: { semester, slotId },
+    };
+  },
 };
+
+export const ADD_TIMETABLE_SLOT = 'ADD_TIMETABLE_SLOT' as const;
+export function addTimetableSlot(
+  semester: Semester,
+  options: { title?: string; duplicateCurrent?: boolean } = {},
+) {
+  return {
+    type: ADD_TIMETABLE_SLOT,
+    payload: {
+      semester,
+      title: options.title,
+      duplicateCurrent: options.duplicateCurrent ?? false,
+    },
+  };
+}
+
+export const RENAME_TIMETABLE_SLOT = 'RENAME_TIMETABLE_SLOT' as const;
+export function renameTimetableSlot(semester: Semester, slotId: string, title: string) {
+  return {
+    type: RENAME_TIMETABLE_SLOT,
+    payload: { semester, slotId, title },
+  };
+}
+
+// The timetable cannot render modules that are missing from the module bank,
+// so a slot's modules must be fetched BEFORE its data is loaded into the live
+// timetable. Modules only referenced by a saved slot may have been evicted
+// from the module bank by older versions of the LRU logic.
+export function switchTimetableSlot(semester: Semester, slotId: string) {
+  return (dispatch: Dispatch, getState: GetState) => {
+    const slot = getState().timetables.slots[semester]?.find((s) => s.id === slotId);
+    return dispatch(fetchTimetableModules([slot?.data.lessons ?? {}])).then(() => {
+      dispatch(Internal.switchTimetableSlot(semester, slotId));
+      return dispatch(validateTimetable(semester));
+    });
+  };
+}
+
+export function deleteTimetableSlot(semester: Semester, slotId: string) {
+  return (dispatch: Dispatch, getState: GetState) => {
+    const { slots, activeSlot } = getState().timetables;
+    const semesterSlots = slots[semester] ?? [];
+    const index = semesterSlots.findIndex((slot) => slot.id === slotId);
+    // Deleting the active slot loads the neighbouring slot's timetable, so
+    // fetch the neighbour's modules first
+    const neighbour =
+      activeSlot[semester] === slotId
+        ? (semesterSlots[index + 1] ?? semesterSlots[index - 1])
+        : undefined;
+
+    return dispatch(fetchTimetableModules([neighbour?.data.lessons ?? {}])).then(() => {
+      dispatch(Internal.deleteTimetableSlot(semester, slotId));
+      return dispatch(validateTimetable(semester));
+    });
+  };
+}
 
 export function addModule(semester: Semester, moduleCode: ModuleCode) {
   return (dispatch: Dispatch, getState: GetState) =>

--- a/website/src/reducers/index.test.ts
+++ b/website/src/reducers/index.test.ts
@@ -2,6 +2,8 @@ import { ExportData } from 'types/export';
 import { VERTICAL } from 'types/reducers';
 import reducers from 'reducers';
 import { setExportedData } from 'actions/export';
+import { addTimetableSlot, Internal } from 'actions/timetables';
+import { undo } from 'actions/undoHistory';
 import modules from '__mocks__/modules/index';
 import { DARK_COLOR_SCHEME, DARK_COLOR_SCHEME_PREFERENCE } from 'types/settings';
 import { SemTimetableConfig, TimetableConfig } from 'types/timetables';
@@ -74,6 +76,8 @@ test('reducers should set export data state', () => {
     },
     hidden: { [1]: ['PC1222'] },
     ta: { [1]: ['CS1010S'] },
+    slots: {},
+    activeSlot: {},
     academicYear: expect.any(String),
     archive: {},
   });
@@ -87,4 +91,18 @@ test('reducers should set export data state', () => {
     timetableOrientation: VERTICAL,
     showTitle: true,
   });
+});
+
+test('undo should restore a deleted timetable slot', () => {
+  let state = reducers({} as any, { type: 'INIT', payload: null } as any);
+  state = reducers(state, addTimetableSlot(1, { duplicateCurrent: true }));
+  const beforeDelete = state;
+  expect(state.timetables.slots[1]).toHaveLength(2);
+
+  state = reducers(state, Internal.deleteTimetableSlot(1, '0'));
+  expect(state.timetables.slots[1]).toHaveLength(1);
+
+  state = reducers(state, undo());
+  expect(state.timetables.slots[1]).toEqual(beforeDelete.timetables.slots[1]);
+  expect(state.timetables.activeSlot[1]).toBe(beforeDelete.timetables.activeSlot[1]);
 });

--- a/website/src/reducers/index.ts
+++ b/website/src/reducers/index.ts
@@ -1,6 +1,6 @@
 import { Reducer } from 'redux';
 
-import { REMOVE_MODULE, SET_TIMETABLE } from 'actions/timetables';
+import { DELETE_TIMETABLE_SLOT, REMOVE_MODULE, SET_TIMETABLE } from 'actions/timetables';
 
 import persistReducer from 'storage/persistReducer';
 import { withReduxStateSync, receiveState } from 'middlewares/state-sync-middleware';
@@ -32,7 +32,10 @@ const planner = persistReducer('planner', plannerReducer, plannerPersistConfig);
 const defaultState = {} as unknown as State;
 const undoReducer = createUndoReducer<State>({
   limit: 1,
-  actionsToWatch: [REMOVE_MODULE, SET_TIMETABLE],
+  // SWITCH/ADD_TIMETABLE_SLOT are deliberately not watched: switching is
+  // losslessly reversible by switching back, and with limit: 1 watching them
+  // would clobber the user's single undo step
+  actionsToWatch: [REMOVE_MODULE, SET_TIMETABLE, DELETE_TIMETABLE_SLOT],
   storedKeyPaths: ['timetables', 'theme.colors'],
 });
 

--- a/website/src/reducers/timetables.test.ts
+++ b/website/src/reducers/timetables.test.ts
@@ -1,5 +1,10 @@
 import { PersistConfig } from 'redux-persist/es/types';
-import reducer, { defaultTimetableState, persistConfig } from 'reducers/timetables';
+import reducer, {
+  defaultTimetableState,
+  migrateV2toV3,
+  nextSlotId,
+  persistConfig,
+} from 'reducers/timetables';
 import {
   ADD_MODULE,
   hideLessonInTimetable,
@@ -13,11 +18,13 @@ import {
   addLesson,
   removeLesson,
   changeLesson,
+  addTimetableSlot,
+  renameTimetableSlot,
 } from 'actions/timetables';
 import { TimetablesState } from 'types/reducers';
 import config from 'config';
 import { ModuleLessonConfig, TimetableConfig } from 'types/timetables';
-import { LessonId } from 'types/modules';
+import { LessonId, Semester } from 'types/modules';
 
 const initialState = defaultTimetableState;
 
@@ -331,6 +338,8 @@ describe('stateReconciler', () => {
       [1]: ['CS1010S'],
     },
     ta: {},
+    slots: {},
+    activeSlot: {},
     academicYear: config.academicYear,
     archive: oldArchive,
   };
@@ -399,6 +408,218 @@ describe('import timetable', () => {
       reducer(stateWithHidden, Internal.setTimetable(1, {}, {}, stateWithHidden.hidden[1])).hidden,
     ).toMatchObject({
       '1': ['CS1101S', 'CS1231S'],
+    });
+  });
+});
+
+describe(nextSlotId, () => {
+  test('should return 0 for no slots', () => {
+    expect(nextSlotId([])).toBe('0');
+  });
+
+  test('should return one more than the largest id, even past deletions', () => {
+    const slot = (id: string) => ({ id, title: id, data: emptySlotData });
+    expect(nextSlotId([slot('0')])).toBe('1');
+    expect(nextSlotId([slot('0'), slot('2')])).toBe('3');
+  });
+});
+
+describe(migrateV2toV3, () => {
+  test('should add empty slot maps and leave everything else untouched', () => {
+    const v2State = {
+      ...initialState,
+      lessons: { [1]: sem1Lessons },
+      _persist: { version: 2, rehydrated: true },
+    };
+
+    expect(migrateV2toV3(v2State)).toEqual({
+      ...v2State,
+      slots: {},
+      activeSlot: {},
+    });
+  });
+});
+
+const sem1Lessons = {
+  CS1010S: {
+    Lecture: ['1|WED|1000|1200|LT26|1_2_3_4_5_6_7_8_9_10_11_12_13'],
+  },
+} satisfies TimetableConfig[Semester];
+
+const emptySlotData = { lessons: {}, colors: {}, hidden: [], ta: [] };
+
+// State as a user would have it before ever using slots: one timetable, no
+// materialized slot entries
+const preSlotState: TimetablesState = {
+  ...initialState,
+  lessons: { [1]: sem1Lessons },
+  colors: { [1]: { CS1010S: 0 } },
+  hidden: { [1]: ['CS1010S'] },
+  ta: { [1]: [] },
+};
+
+const sem1SlotData = {
+  lessons: sem1Lessons,
+  colors: { CS1010S: 0 },
+  hidden: ['CS1010S'],
+  ta: [],
+};
+
+describe('timetable slot reducer', () => {
+  describe('ADD_TIMETABLE_SLOT', () => {
+    test('should materialize the implicit slot and activate a new blank slot', () => {
+      const state = reducer(preSlotState, addTimetableSlot(1));
+
+      expect(state.slots[1]).toHaveLength(2);
+      expect(state.slots[1][0]).toEqual({ id: '0', title: 'Timetable 1', data: sem1SlotData });
+      expect(state.slots[1][1]).toEqual({ id: '1', title: 'Timetable 2', data: emptySlotData });
+      expect(state.activeSlot[1]).toBe('1');
+
+      // Live maps now hold the new blank slot
+      expect(state.lessons[1]).toEqual({});
+      expect(state.colors[1]).toEqual({});
+      expect(state.hidden[1]).toEqual([]);
+      expect(state.ta[1]).toEqual([]);
+    });
+
+    test('should copy the current timetable when duplicating', () => {
+      const state = reducer(preSlotState, addTimetableSlot(1, { duplicateCurrent: true }));
+
+      expect(state.slots[1][1]).toEqual({ id: '1', title: 'Timetable 2', data: sem1SlotData });
+      expect(state.activeSlot[1]).toBe('1');
+      // Live maps keep the duplicated content
+      expect(state.lessons[1]).toEqual(sem1Lessons);
+    });
+
+    test('should use the provided title', () => {
+      const state = reducer(preSlotState, addTimetableSlot(1, { title: 'Backup plan' }));
+      expect(state.slots[1][1].title).toBe('Backup plan');
+    });
+
+    test('should generate ids one past the largest existing id', () => {
+      let state = reducer(preSlotState, addTimetableSlot(1)); // ids 0, 1 (active: 1)
+      state = reducer(state, Internal.deleteTimetableSlot(1, '0')); // ids 1
+      state = reducer(state, addTimetableSlot(1)); // new id is max(1) + 1 = 2
+
+      expect(state.slots[1].map((slot) => slot.id)).toEqual(['1', '2']);
+    });
+  });
+
+  describe('SWITCH_TIMETABLE_SLOT', () => {
+    test('should save the outgoing slot and load the target slot', () => {
+      // Active slot 1 is blank; slot 0 holds the original timetable
+      const twoSlots = reducer(preSlotState, addTimetableSlot(1));
+      const state = reducer(twoSlots, Internal.switchTimetableSlot(1, '0'));
+
+      expect(state.activeSlot[1]).toBe('0');
+      expect(state.lessons[1]).toEqual(sem1Lessons);
+      expect(state.colors[1]).toEqual({ CS1010S: 0 });
+      expect(state.hidden[1]).toEqual(['CS1010S']);
+
+      // Outgoing slot 1's data was refreshed from the (blank) live maps
+      expect(state.slots[1][1].data).toEqual(emptySlotData);
+    });
+
+    test('should preserve both timetables exactly across a round trip', () => {
+      const otherLessons = {
+        CS3216: {
+          Lecture: ['1|MON|1830|2030|VCRm|1_2_3_4_5_6_7_8_9_10_11_12_13'],
+        },
+      } satisfies TimetableConfig[Semester];
+
+      let state = reducer(preSlotState, addTimetableSlot(1));
+      state = reducer(state, Internal.setTimetable(1, otherLessons, { CS3216: 1 }));
+      state = reducer(state, Internal.switchTimetableSlot(1, '0'));
+
+      expect(state.lessons[1]).toEqual(sem1Lessons);
+
+      state = reducer(state, Internal.switchTimetableSlot(1, '1'));
+
+      expect(state.lessons[1]).toEqual(otherLessons);
+      expect(state.colors[1]).toEqual({ CS3216: 1 });
+      expect(state.slots[1][0].data).toEqual(sem1SlotData);
+    });
+
+    test('should be a no-op when switching to the active slot', () => {
+      const twoSlots = reducer(preSlotState, addTimetableSlot(1));
+      expect(reducer(twoSlots, Internal.switchTimetableSlot(1, '1'))).toBe(twoSlots);
+    });
+
+    test('should be a no-op for an unknown slot', () => {
+      const twoSlots = reducer(preSlotState, addTimetableSlot(1));
+      expect(reducer(twoSlots, Internal.switchTimetableSlot(1, '99'))).toBe(twoSlots);
+      expect(reducer(preSlotState, Internal.switchTimetableSlot(1, '99'))).toBe(preSlotState);
+    });
+  });
+
+  describe('RENAME_TIMETABLE_SLOT', () => {
+    test('should rename a slot', () => {
+      const twoSlots = reducer(preSlotState, addTimetableSlot(1));
+      const state = reducer(twoSlots, renameTimetableSlot(1, '0', 'Plan A'));
+      expect(state.slots[1][0].title).toBe('Plan A');
+    });
+
+    test('should materialize and rename the implicit slot', () => {
+      const state = reducer(preSlotState, renameTimetableSlot(1, '0', 'Plan A'));
+      expect(state.slots[1]).toEqual([{ id: '0', title: 'Plan A', data: sem1SlotData }]);
+      expect(state.activeSlot[1]).toBe('0');
+    });
+
+    test('should ignore blank titles and unknown slots', () => {
+      const twoSlots = reducer(preSlotState, addTimetableSlot(1));
+      expect(reducer(twoSlots, renameTimetableSlot(1, '0', '   '))).toBe(twoSlots);
+      expect(reducer(twoSlots, renameTimetableSlot(1, '99', 'Plan A'))).toBe(twoSlots);
+    });
+  });
+
+  describe('DELETE_TIMETABLE_SLOT', () => {
+    test('should delete an inactive slot without touching the live timetable', () => {
+      const twoSlots = reducer(preSlotState, addTimetableSlot(1, { duplicateCurrent: true }));
+      const state = reducer(twoSlots, Internal.deleteTimetableSlot(1, '0'));
+
+      expect(state.slots[1].map((slot) => slot.id)).toEqual(['1']);
+      expect(state.activeSlot[1]).toBe('1');
+      expect(state.lessons[1]).toEqual(sem1Lessons);
+    });
+
+    test('should activate the neighbouring slot when deleting the active slot', () => {
+      // Slots: 0 (original), 1 (blank, active)
+      const twoSlots = reducer(preSlotState, addTimetableSlot(1));
+      const state = reducer(twoSlots, Internal.deleteTimetableSlot(1, '1'));
+
+      expect(state.slots[1].map((slot) => slot.id)).toEqual(['0']);
+      expect(state.activeSlot[1]).toBe('0');
+      // Slot 0's timetable was loaded into the live maps
+      expect(state.lessons[1]).toEqual(sem1Lessons);
+      expect(state.colors[1]).toEqual({ CS1010S: 0 });
+    });
+
+    test('should be a no-op for the last remaining slot or unknown slots', () => {
+      expect(reducer(preSlotState, Internal.deleteTimetableSlot(1, '0'))).toBe(preSlotState);
+
+      const twoSlots = reducer(preSlotState, addTimetableSlot(1));
+      expect(reducer(twoSlots, Internal.deleteTimetableSlot(1, '99'))).toBe(twoSlots);
+
+      const oneSlot = reducer(twoSlots, Internal.deleteTimetableSlot(1, '1'));
+      expect(reducer(oneSlot, Internal.deleteTimetableSlot(1, '0'))).toBe(oneSlot);
+    });
+  });
+
+  describe('interaction with existing actions', () => {
+    test('should not modify slots when the timetable is edited', () => {
+      const twoSlots = reducer(preSlotState, addTimetableSlot(1, { duplicateCurrent: true }));
+      const state = reducer(twoSlots, removeModule(1, 'CS1010S'));
+
+      expect(state.slots).toBe(twoSlots.slots);
+      expect(state.activeSlot).toBe(twoSlots.activeSlot);
+    });
+
+    test('should keep slots independent across semesters', () => {
+      const state = reducer(preSlotState, addTimetableSlot(2));
+
+      expect(state.slots[2]).toHaveLength(2);
+      expect(state.slots[1]).toBeUndefined();
+      expect(state.lessons[1]).toEqual(sem1Lessons);
     });
   });
 });

--- a/website/src/reducers/timetables.ts
+++ b/website/src/reducers/timetables.ts
@@ -1,11 +1,12 @@
 import { difference, get, omit, uniq, values } from 'lodash-es';
-import { produce } from 'immer';
+import { Draft, produce } from 'immer';
 import { createMigrate } from 'redux-persist';
+import { PersistedState } from 'redux-persist/es/types';
 
 import { PersistConfig } from 'storage/persistReducer';
-import { LessonId, ModuleCode } from 'types/modules';
+import { LessonId, ModuleCode, Semester } from 'types/modules';
 import { ModuleLessonConfig, SemTimetableConfig } from 'types/timetables';
-import { ColorMapping, TimetablesState } from 'types/reducers';
+import { ColorMapping, TimetableSlot, TimetableSlotData, TimetablesState } from 'types/reducers';
 
 import config from 'config';
 import {
@@ -24,10 +25,28 @@ import {
   SET_TIMETABLE,
   SHOW_LESSON_IN_TIMETABLE,
   REMOVE_TA_MODULE,
+  ADD_TIMETABLE_SLOT,
+  RENAME_TIMETABLE_SLOT,
+  SWITCH_TIMETABLE_SLOT,
+  DELETE_TIMETABLE_SLOT,
 } from 'actions/timetables';
 import { getNewColor } from 'utils/colors';
 import { SET_EXPORTED_DATA } from 'actions/constants';
 import { Actions } from '../types/actions';
+
+// v3 introduces timetable save slots. Existing timetables become the implicit
+// default slot lazily (see ensureSlots), so the migration only has to add the
+// new empty maps.
+export const migrateV2toV3 = (state: PersistedState) => ({
+  ...state,
+  slots: {},
+  activeSlot: {},
+  // FIXME: Remove the next line when _persist is optional again.
+  // Cause: https://github.com/rt2zz/redux-persist/pull/919
+  // Issue: https://github.com/rt2zz/redux-persist/pull/1170
+  // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
+  _persist: state?._persist!,
+});
 
 export const persistConfig = {
   /* eslint-disable no-useless-computed-key */
@@ -50,9 +69,10 @@ export const persistConfig = {
       // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
       _persist: state?._persist!,
     }),
+    3: migrateV2toV3,
   }),
   /* eslint-enable */
-  version: 2,
+  version: 3,
 
   // Our own state reconciler archives old timetables if the acad year is different,
   // otherwise use the persisted timetable state
@@ -73,6 +93,9 @@ export const persistConfig = {
       );
     }
 
+    // Only the active timetable's lessons are archived - saved slots are
+    // dropped along with the rest of last year's state, since the archive
+    // shape only holds one TimetableConfig per academic year
     return {
       ...original,
       archive: {
@@ -225,11 +248,52 @@ function semTaModules(state = DEFAULT_TA_STATE, action: Actions): ModuleCode[] {
   }
 }
 
+export const DEFAULT_SLOT_ID = '0';
+export const DEFAULT_SLOT_TITLE = 'Timetable 1';
+const DEFAULT_SLOT_DATA: TimetableSlotData = { lessons: {}, colors: {}, hidden: [], ta: [] };
+
+export function nextSlotId(slots: TimetableSlot[]): string {
+  const ids = slots.map((slot) => Number(slot.id));
+  if (ids.length === 0) return DEFAULT_SLOT_ID;
+  return String(Math.max(...ids) + 1);
+}
+
+function snapshotSlotData(state: TimetablesState, semester: Semester): TimetableSlotData {
+  return {
+    lessons: state.lessons[semester] ?? DEFAULT_SEM_TIMETABLE_CONFIG,
+    colors: state.colors[semester] ?? DEFAULT_SEM_COLOR_MAP,
+    hidden: state.hidden[semester] ?? DEFAULT_HIDDEN_STATE,
+    ta: state.ta[semester] ?? DEFAULT_TA_STATE,
+  };
+}
+
+// Semesters that have never used slots implicitly have a single active slot
+// holding the live timetable. Materialize it before any slot manipulation.
+function ensureSlots(
+  draft: Draft<TimetablesState>,
+  semester: Semester,
+  liveData: TimetableSlotData,
+) {
+  if (!draft.slots[semester] || draft.slots[semester].length === 0) {
+    draft.slots[semester] = [{ id: DEFAULT_SLOT_ID, title: DEFAULT_SLOT_TITLE, data: liveData }];
+    draft.activeSlot[semester] = DEFAULT_SLOT_ID;
+  }
+}
+
+function loadSlotData(draft: Draft<TimetablesState>, semester: Semester, data: TimetableSlotData) {
+  draft.lessons[semester] = data.lessons;
+  draft.colors[semester] = data.colors;
+  draft.hidden[semester] = data.hidden;
+  draft.ta[semester] = data.ta;
+}
+
 export const defaultTimetableState: TimetablesState = {
   lessons: {},
   colors: {},
   hidden: {},
   ta: {},
+  slots: {},
+  activeSlot: {},
   academicYear: config.academicYear,
   archive: {},
 };
@@ -284,6 +348,88 @@ function timetables(
         draft.colors[semester] = semColors(state.colors[semester], action);
         draft.hidden[semester] = semHiddenModules(state.hidden[semester], action);
         draft.ta[semester] = semTaModules(state.ta[semester], action);
+      });
+    }
+
+    case ADD_TIMETABLE_SLOT: {
+      const { semester, title, duplicateCurrent } = action.payload;
+
+      return produce(state, (draft) => {
+        const liveData = snapshotSlotData(state, semester);
+        ensureSlots(draft, semester, liveData);
+        const slots = draft.slots[semester];
+
+        // Persist the current timetable into the outgoing active slot
+        const active = slots.find((slot) => slot.id === draft.activeSlot[semester]);
+        if (active) active.data = liveData;
+
+        const newSlot = {
+          id: nextSlotId(slots),
+          title: title?.trim() || `Timetable ${slots.length + 1}`,
+          data: duplicateCurrent ? liveData : DEFAULT_SLOT_DATA,
+        };
+        slots.push(newSlot);
+        draft.activeSlot[semester] = newSlot.id;
+        loadSlotData(draft, semester, newSlot.data);
+      });
+    }
+
+    case SWITCH_TIMETABLE_SLOT: {
+      const { semester, slotId } = action.payload;
+      const slots = state.slots[semester];
+      // Semesters without materialized slots only have the implicit active
+      // slot, so there is nothing to switch to
+      if (!slots || slots.length === 0) return state;
+
+      const activeId = state.activeSlot[semester] ?? DEFAULT_SLOT_ID;
+      const target = slots.find((slot) => slot.id === slotId);
+      if (slotId === activeId || !target) return state;
+
+      return produce(state, (draft) => {
+        const active = draft.slots[semester].find((slot) => slot.id === activeId);
+        if (active) active.data = snapshotSlotData(state, semester);
+        draft.activeSlot[semester] = slotId;
+        loadSlotData(draft, semester, target.data);
+      });
+    }
+
+    case RENAME_TIMETABLE_SLOT: {
+      const { semester, slotId, title } = action.payload;
+      const trimmedTitle = title.trim();
+      if (!trimmedTitle) return state;
+
+      const slots = state.slots[semester];
+      const slotExists =
+        slots && slots.length > 0
+          ? slots.some((slot) => slot.id === slotId)
+          : slotId === DEFAULT_SLOT_ID;
+      if (!slotExists) return state;
+
+      return produce(state, (draft) => {
+        ensureSlots(draft, semester, snapshotSlotData(state, semester));
+        const slot = draft.slots[semester].find((s) => s.id === slotId);
+        if (slot) slot.title = trimmedTitle;
+      });
+    }
+
+    case DELETE_TIMETABLE_SLOT: {
+      const { semester, slotId } = action.payload;
+      const slots = state.slots[semester];
+      // The last remaining (or implicit) slot cannot be deleted
+      if (!slots || slots.length <= 1) return state;
+
+      const index = slots.findIndex((slot) => slot.id === slotId);
+      if (index === -1) return state;
+
+      return produce(state, (draft) => {
+        draft.slots[semester].splice(index, 1);
+
+        if (state.activeSlot[semester] === slotId) {
+          // Activate the neighbouring slot and load its saved timetable
+          const neighbour = slots[index + 1] ?? slots[index - 1];
+          draft.activeSlot[semester] = neighbour.id;
+          loadSlotData(draft, semester, neighbour.data);
+        }
       });
     }
 

--- a/website/src/selectors/timetables.test.ts
+++ b/website/src/selectors/timetables.test.ts
@@ -1,0 +1,107 @@
+import { defaultTimetableState } from 'reducers/timetables';
+import { TimetablesState } from 'types/reducers';
+import { State } from 'types/state';
+
+import { getActiveSlotId, getSlotTimetableData, getTimetableSlots } from './timetables';
+
+vi.mock('config');
+
+const makeState = (timetables: TimetablesState) => ({ timetables }) as State;
+
+const sem1Lessons = {
+  CS1010S: {
+    Lecture: ['1|WED|1000|1200|LT26|1_2_3_4_5_6_7_8_9_10_11_12_13'],
+  },
+};
+
+const liveState = makeState({
+  ...defaultTimetableState,
+  lessons: { [1]: sem1Lessons },
+  colors: { [1]: { CS1010S: 0 } },
+  hidden: { [1]: ['CS1010S'] },
+});
+
+const slotZero = {
+  id: '0',
+  title: 'Plan A',
+  data: { lessons: sem1Lessons, colors: { CS1010S: 0 }, hidden: ['CS1010S'], ta: [] },
+};
+const slotOne = {
+  id: '1',
+  title: 'Plan B',
+  data: { lessons: {}, colors: {}, hidden: [], ta: [] },
+};
+
+const materializedState = makeState({
+  ...defaultTimetableState,
+  lessons: { [1]: sem1Lessons },
+  colors: { [1]: { CS1010S: 0 } },
+  hidden: { [1]: ['CS1010S'] },
+  slots: { [1]: [slotZero, slotOne] },
+  activeSlot: { [1]: '0' },
+});
+
+describe(getTimetableSlots, () => {
+  test('should return the implicit default slot for semesters without slots', () => {
+    const slots = getTimetableSlots(liveState)(1);
+
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({ id: '0', title: 'Timetable 1' });
+  });
+
+  test('should return a stable reference for the implicit slot', () => {
+    const getSlots = getTimetableSlots(liveState);
+    expect(getSlots(1)).toBe(getSlots(1));
+  });
+
+  test('should return materialized slots directly', () => {
+    expect(getTimetableSlots(materializedState)(1)).toBe(materializedState.timetables.slots[1]);
+  });
+});
+
+describe(getActiveSlotId, () => {
+  test('should default to the implicit slot id', () => {
+    expect(getActiveSlotId(liveState)(1)).toBe('0');
+  });
+
+  test('should return the recorded active slot', () => {
+    const state = makeState({
+      ...materializedState.timetables,
+      activeSlot: { [1]: '1' },
+    });
+    expect(getActiveSlotId(state)(1)).toBe('1');
+  });
+});
+
+describe(getSlotTimetableData, () => {
+  test('should compose the active slot data from the live timetable', () => {
+    expect(getSlotTimetableData(materializedState)(1, '0')).toEqual({
+      lessons: sem1Lessons,
+      colors: { CS1010S: 0 },
+      hidden: ['CS1010S'],
+      ta: [],
+    });
+  });
+
+  test('should compose live data for the implicit active slot', () => {
+    expect(getSlotTimetableData(liveState)(1, '0')).toEqual({
+      lessons: sem1Lessons,
+      colors: { CS1010S: 0 },
+      hidden: ['CS1010S'],
+      ta: [],
+    });
+  });
+
+  test('should return the stored snapshot for inactive slots', () => {
+    expect(getSlotTimetableData(materializedState)(1, '1')).toBe(slotOne.data);
+  });
+
+  test('should return empty data for unknown slots', () => {
+    expect(getSlotTimetableData(materializedState)(1, '99')).toEqual({
+      lessons: {},
+      colors: {},
+      hidden: [],
+      ta: [],
+    });
+  });
+});

--- a/website/src/selectors/timetables.ts
+++ b/website/src/selectors/timetables.ts
@@ -1,10 +1,12 @@
 import { createSelector } from 'reselect';
 
 import type { ModuleCode, Semester } from 'types/modules';
+import type { TimetableSlot, TimetableSlotData } from 'types/reducers';
 import type { State } from 'types/state';
 
 import { fetchArchiveRequest } from 'actions/constants';
 import config from 'config';
+import { DEFAULT_SLOT_ID, DEFAULT_SLOT_TITLE } from 'reducers/timetables';
 import { isOngoing, isSuccess } from 'selectors/requests';
 
 export function isArchiveLoading(state: State, moduleCode: ModuleCode) {
@@ -54,4 +56,59 @@ export const getSemesterTimetableTaLessons = createSelector(
   ({ timetables }: State) => timetables.ta,
   (ta) => (semester: Semester | null) =>
     semester === null ? EMPTY_OBJECT : (ta[semester] ?? EMPTY_OBJECT),
+);
+
+const EMPTY_SLOT_DATA: TimetableSlotData = { lessons: {}, colors: {}, hidden: [], ta: [] };
+
+// Semesters that have never used slots have a single implicit slot. Its
+// `data` is empty because the implicit slot is always active, and an active
+// slot's timetable lives in the live maps - read it via getSlotTimetableData.
+const IMPLICIT_SLOTS: TimetableSlot[] = [
+  { id: DEFAULT_SLOT_ID, title: DEFAULT_SLOT_TITLE, data: EMPTY_SLOT_DATA },
+];
+
+/**
+ * Extract the saved timetable slots for a specific semester.
+ */
+export const getTimetableSlots = createSelector(
+  ({ timetables }: State) => timetables.slots,
+  (slots) =>
+    (semester: Semester): TimetableSlot[] => {
+      const semesterSlots = slots[semester];
+      return semesterSlots && semesterSlots.length > 0 ? semesterSlots : IMPLICIT_SLOTS;
+    },
+);
+
+/**
+ * Extract the active slot id for a specific semester.
+ */
+export const getActiveSlotId = createSelector(
+  ({ timetables }: State) => timetables.activeSlot,
+  (activeSlot) =>
+    (semester: Semester): string =>
+      activeSlot[semester] ?? DEFAULT_SLOT_ID,
+);
+
+/**
+ * Extract a slot's timetable data. This is the single source of truth for
+ * reading slot data: the active slot's data is composed from the live
+ * timetable maps, while inactive slots return their stored snapshot.
+ */
+export const getSlotTimetableData = createSelector(
+  ({ timetables }: State) => timetables,
+  (timetables) =>
+    (semester: Semester, slotId: string): TimetableSlotData => {
+      const activeId = timetables.activeSlot[semester] ?? DEFAULT_SLOT_ID;
+      if (slotId === activeId) {
+        return {
+          lessons: timetables.lessons[semester] ?? EMPTY_OBJECT,
+          colors: timetables.colors[semester] ?? EMPTY_OBJECT,
+          hidden: timetables.hidden[semester] ?? EMPTY_SLOT_DATA.hidden,
+          ta: timetables.ta[semester] ?? EMPTY_SLOT_DATA.ta,
+        };
+      }
+
+      const slot = timetables.slots[semester]?.find((s) => s.id === slotId);
+      return slot ? slot.data : EMPTY_SLOT_DATA;
+    },
 );

--- a/website/src/types/reducers.ts
+++ b/website/src/types/reducers.ts
@@ -5,6 +5,7 @@ import { ColorSchemePreference } from './settings';
 import {
   ColorIndex,
   Lesson,
+  SemTimetableConfig,
   TaModulesConfigV1,
   TimetableConfig,
   TimetableConfigV1,
@@ -123,11 +124,36 @@ export type HiddenModulesMap = { [semester: Semester]: ModuleCode[] };
 export type TaModulesMap = { [semester: Semester]: ModuleCode[] };
 export type TaModulesMapV1 = { [semester: Semester]: TaModulesConfigV1 };
 
+// A saved timetable arrangement ("save slot") for a single semester
+export type TimetableSlotData = {
+  readonly lessons: SemTimetableConfig;
+  readonly colors: ColorMapping;
+  readonly hidden: ModuleCode[];
+  readonly ta: ModuleCode[];
+};
+
+export type TimetableSlot = {
+  readonly id: string;
+  readonly title: string;
+  // Snapshot of this slot's timetable. Authoritative for INACTIVE slots only;
+  // the active slot's live data is in TimetablesState.{lessons,colors,hidden,ta}
+  // and this snapshot is only refreshed when the user switches away from it.
+  readonly data: TimetableSlotData;
+};
+
+// Slots are ordered - the array order is the display order
+export type TimetableSlotsMap = { [semester: Semester]: TimetableSlot[] };
+export type ActiveSlotMap = { [semester: Semester]: string };
+
 export type TimetablesState = {
   readonly lessons: TimetableConfig;
   readonly colors: SemesterColorMap;
   readonly hidden: HiddenModulesMap;
   readonly ta: TaModulesMap;
+  // Saved timetable arrangements per semester. Semesters without an entry
+  // implicitly have a single active slot holding the live timetable.
+  readonly slots: TimetableSlotsMap;
+  readonly activeSlot: ActiveSlotMap;
   readonly academicYear: string;
   // Mapping of academic year to old timetable config
   readonly archive: { [key: string]: TimetableConfig | TimetableConfigV2 | TimetableConfigV1 };

--- a/website/src/views/timetable/TimetableContainer.test.tsx
+++ b/website/src/views/timetable/TimetableContainer.test.tsx
@@ -1,5 +1,5 @@
 import type { MockInstance } from 'vitest';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import type { RenderOptions } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import axios, { AxiosHeaders, AxiosResponse } from 'axios';
@@ -208,6 +208,49 @@ describe(TimetableContainerComponent, () => {
 
     // Expect import header to still be present
     expect(screen.getByRole('button', { name: 'Import' })).toBeInTheDocument();
+  });
+
+  test('should import shared timetable as a new slot without replacing the saved one', async () => {
+    const semester = 1;
+    const savedTimetable = { CS1010S: { Lecture: ['1'] } };
+    const importedTimetable = {
+      [moduleCodeThatCanBeLoaded]: {
+        'Sectional Teaching': ['A1'],
+      },
+    };
+    const location = timetableShare(semester, importedTimetable, [], []);
+    const { store } = make(location);
+
+    // Wait for redux-persist rehydration so it does not clobber the timetable
+    // we are about to dispatch
+    await waitFor(() =>
+      // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
+      expect((store.getState().timetables as any)._persist?.rehydrated).toBe(true),
+    );
+
+    // Populate the user's existing saved timetable
+    await act(async () => {
+      store.dispatch({ type: SUCCESS_KEY(FETCH_MODULE), payload: CS1010S });
+      (store.dispatch as Dispatch)(setTimetable(semester, savedTimetable));
+    });
+
+    const importAsNewButton = await screen.findByRole('button', {
+      name: 'Import as new timetable',
+    });
+    await act(async () => {
+      fireEvent.click(importAsNewButton);
+    });
+
+    const { timetables } = store.getState();
+
+    // The original timetable is preserved in the first slot
+    expect(timetables.slots[semester]).toHaveLength(2);
+    expect(timetables.slots[semester][0].data.lessons).toEqual(savedTimetable);
+
+    // The imported timetable is active in the new slot
+    expect(timetables.activeSlot[semester]).toBe(timetables.slots[semester][1].id);
+    expect(timetables.slots[semester][1].title).toBe('Imported');
+    expect(timetables.lessons[semester]).toHaveProperty(moduleCodeThatCanBeLoaded);
   });
 
   test('should display saved timetable when there is no imported timetable', async () => {

--- a/website/src/views/timetable/TimetableContainer.tsx
+++ b/website/src/views/timetable/TimetableContainer.tsx
@@ -12,6 +12,7 @@ import type { SemTimetableConfig } from 'types/timetables';
 import { selectSemester } from 'actions/settings';
 import { getSemesterTimetableColors, getSemesterTimetableLessons } from 'selectors/timetables';
 import {
+  addTimetableSlot,
   fetchModules,
   setHiddenModulesFromImport,
   setTaModulesFromImport,
@@ -32,6 +33,7 @@ import qs from 'query-string';
 import { keys } from 'lodash-es';
 import styles from './TimetableContainer.scss';
 import TimetableContent from './TimetableContent';
+import TimetableSlotsSwitcher from './TimetableSlotsSwitcher';
 
 type Params = {
   action: string;
@@ -101,6 +103,16 @@ const SharingHeader: FC<{
     semester,
   ]);
 
+  // Imports into a fresh slot, leaving the user's current timetable untouched
+  // in its own slot
+  const importTimetableAsNew = useCallback(() => {
+    if (!importedTimetable) {
+      return;
+    }
+    dispatch(addTimetableSlot(semester, { title: 'Imported' }));
+    importTimetable();
+  }, [dispatch, importedTimetable, importTimetable, semester]);
+
   if (!importedTimetable) {
     return null;
   }
@@ -113,13 +125,17 @@ const SharingHeader: FC<{
         <div className={classnames('col')}>
           <h3>This timetable was shared with you</h3>
           <p>
-            Clicking import will <strong>replace</strong> your saved timetable with the one below.
+            Clicking import will <strong>replace</strong> your current timetable with the one below.
+            Import as new timetable keeps both.
           </p>
         </div>
 
         <div className={classnames('col-md-auto', styles.actions)}>
           <button className="btn btn-success" type="button" onClick={importTimetable}>
             Import
+          </button>
+          <button className="btn btn-outline-success" type="button" onClick={importTimetableAsNew}>
+            Import as new timetable
           </button>
           <button
             className="btn btn-outline-primary"
@@ -153,11 +169,14 @@ const TimetableHeader: FC<{
   );
 
   return (
-    <SemesterSwitcher
-      semester={semester}
-      onSelectSemester={handleSelectSemester}
-      readOnly={readOnly}
-    />
+    <>
+      <SemesterSwitcher
+        semester={semester}
+        onSelectSemester={handleSelectSemester}
+        readOnly={readOnly}
+      />
+      {!readOnly && <TimetableSlotsSwitcher semester={semester} />}
+    </>
   );
 };
 

--- a/website/src/views/timetable/TimetableContainer.tsx
+++ b/website/src/views/timetable/TimetableContainer.tsx
@@ -10,7 +10,12 @@ import type { State } from 'types/state';
 import type { SemTimetableConfig } from 'types/timetables';
 
 import { selectSemester } from 'actions/settings';
-import { getSemesterTimetableColors, getSemesterTimetableLessons } from 'selectors/timetables';
+import {
+  getActiveSlotId,
+  getSemesterTimetableColors,
+  getSemesterTimetableLessons,
+  getTimetableSlots,
+} from 'selectors/timetables';
 import {
   addTimetableSlot,
   fetchModules,
@@ -33,6 +38,7 @@ import qs from 'query-string';
 import { keys } from 'lodash-es';
 import styles from './TimetableContainer.scss';
 import TimetableContent from './TimetableContent';
+import TimetableSlotsCompare from './TimetableSlotsCompare';
 import TimetableSlotsSwitcher from './TimetableSlotsSwitcher';
 
 type Params = {
@@ -153,7 +159,8 @@ const SharingHeader: FC<{
 const TimetableHeader: FC<{
   semester: Semester;
   readOnly?: boolean;
-}> = ({ semester, readOnly }) => {
+  onCompare?: () => void;
+}> = ({ semester, readOnly, onCompare }) => {
   const history = useHistory();
   const dispatch = useDispatch();
 
@@ -175,7 +182,7 @@ const TimetableHeader: FC<{
         onSelectSemester={handleSelectSemester}
         readOnly={readOnly}
       />
-      {!readOnly && <TimetableSlotsSwitcher semester={semester} />}
+      {!readOnly && <TimetableSlotsSwitcher semester={semester} onCompare={onCompare} />}
     </>
   );
 };
@@ -204,6 +211,12 @@ export const TimetableContainerComponent: FC = () => {
   const [importedHidden, setImportedHidden] = useState<ModuleCode[] | null>(null);
 
   const [importedTa, setImportedTa] = useState<ModuleCode[] | null>(null);
+
+  // When set, the timetable is replaced by a side-by-side comparison of the
+  // two slots
+  const [compareSlots, setCompareSlots] = useState<[string, string] | null>(null);
+  const getSlots = useSelector(getTimetableSlots);
+  const getActiveSlot = useSelector(getActiveSlotId);
 
   const dispatch = useDispatch();
 
@@ -271,6 +284,21 @@ export const TimetableContainerComponent: FC = () => {
   );
   const readOnly = displayedTimetable === importedTimetable;
 
+  // Leave compare mode when the semester changes - the slot ids refer to the
+  // previous semester's slots
+  useEffect(() => {
+    setCompareSlots(null);
+  }, [semester]);
+
+  const startCompare = useCallback(() => {
+    if (semester == null) return;
+    const slots = getSlots(semester);
+    const activeSlotId = getActiveSlot(semester);
+    const otherSlot = slots.find((slot) => slot.id !== activeSlotId);
+    if (!otherSlot) return;
+    setCompareSlots([activeSlotId, otherSlot.id]);
+  }, [semester, getSlots, getActiveSlot]);
+
   useScrollToTop();
 
   // 1. If the URL doesn't look correct, we'll direct the user to the home page
@@ -282,6 +310,24 @@ export const TimetableContainerComponent: FC = () => {
   //    loaded first, and display a spinner if they're not.
   if (isLoading) {
     return <LoadingSpinner />;
+  }
+
+  // 3. Comparison mode replaces the interactive timetable with two read-only
+  //    grids of the chosen slots.
+  if (compareSlots) {
+    return (
+      <div className="page-container">
+        <TimetableHeader semester={semester} readOnly />
+        <TimetableSlotsCompare
+          semester={semester}
+          slotIds={compareSlots}
+          onSelectSlot={(pane, slotId) =>
+            setCompareSlots(pane === 0 ? [slotId, compareSlots[1]] : [compareSlots[0], slotId])
+          }
+          onExit={() => setCompareSlots(null)}
+        />
+      </div>
+    );
   }
 
   return (
@@ -302,7 +348,7 @@ export const TimetableContainerComponent: FC = () => {
             taImportedModules={importedTa}
             setImportedTimetable={setImportedTimetable}
           />
-          <TimetableHeader semester={semester} readOnly={readOnly} />
+          <TimetableHeader semester={semester} readOnly={readOnly} onCompare={startCompare} />
         </>
       }
       readOnly={readOnly}

--- a/website/src/views/timetable/TimetableSlotsCompare.scss
+++ b/website/src/views/timetable/TimetableSlotsCompare.scss
@@ -1,0 +1,41 @@
+@import '~styles/utils/modules-entry';
+
+.compare {
+  margin-top: 0.5rem;
+}
+
+.compareHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.8rem;
+
+  h2 {
+    margin: 0;
+    font-size: 1.4rem;
+  }
+}
+
+.pane {
+  margin-bottom: 1.5rem;
+}
+
+.paneHeader {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  gap: 0.5rem;
+
+  select {
+    max-width: 14rem;
+  }
+}
+
+.moduleCount {
+  flex: 1;
+  font-size: $font-size-sm;
+}
+
+.grid {
+  overflow-x: auto;
+}

--- a/website/src/views/timetable/TimetableSlotsCompare.test.tsx
+++ b/website/src/views/timetable/TimetableSlotsCompare.test.tsx
@@ -1,0 +1,112 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { produce } from 'immer';
+
+import type { Dispatch } from 'types/redux';
+
+import { FETCH_MODULE, FETCH_MODULE_LIST } from 'actions/constants';
+import { addTimetableSlot, setTimetable } from 'actions/timetables';
+import configureStore from 'bootstrapping/configure-store';
+import { SUCCESS_KEY } from 'middlewares/requests-middleware';
+import reducers from 'reducers';
+import { mockDom, mockDomReset } from 'test-utils/mockDom';
+import { initAction } from 'test-utils/redux';
+
+import { CS1010S, CS3216 } from '__mocks__/modules';
+import modulesList from '__mocks__/moduleList.json';
+
+import TimetableSlotsCompare from './TimetableSlotsCompare';
+
+const initialState = reducers(undefined, initAction());
+
+async function makeCompare(slotIds: [string, string] = ['0', '1']) {
+  const { store } = configureStore(produce(initialState, () => {}));
+  store.dispatch({ type: SUCCESS_KEY(FETCH_MODULE_LIST), payload: modulesList });
+  store.dispatch({ type: SUCCESS_KEY(FETCH_MODULE), payload: CS1010S });
+  store.dispatch({ type: SUCCESS_KEY(FETCH_MODULE), payload: CS3216 });
+
+  // Slot '0' holds CS1010S; slot '1' (active) holds CS3216
+  await act(async () => {
+    (store.dispatch as Dispatch)(setTimetable(1, { CS1010S: { Lecture: ['1'] } }));
+    store.dispatch(addTimetableSlot(1));
+    (store.dispatch as Dispatch)(setTimetable(1, { CS3216: { Lecture: ['1'] } }));
+  });
+
+  const onSelectSlot = vi.fn();
+  const onExit = vi.fn();
+
+  const view = render(
+    <Provider store={store}>
+      <TimetableSlotsCompare
+        semester={1}
+        slotIds={slotIds}
+        onSelectSlot={onSelectSlot}
+        onExit={onExit}
+      />
+    </Provider>,
+  );
+
+  return { store, onSelectSlot, onExit, ...view };
+}
+
+describe(TimetableSlotsCompare, () => {
+  beforeEach(() => mockDom());
+  afterEach(() => mockDomReset());
+
+  test('should render two read-only timetable grids for the chosen slots', async () => {
+    const { container } = await makeCompare();
+
+    expect(container.querySelectorAll('.timetable')).toHaveLength(2);
+    // Slot 0's module and the active slot's module both appear
+    expect(screen.getByText(/CS1010S/)).toBeInTheDocument();
+    expect(screen.getByText(/CS3216/)).toBeInTheDocument();
+  });
+
+  test('should show slot titles in the pane pickers', async () => {
+    await makeCompare();
+
+    const pickers = screen.getAllByRole('combobox');
+    expect(pickers).toHaveLength(2);
+    expect(pickers[0]).toHaveValue('0');
+    expect(pickers[1]).toHaveValue('1');
+  });
+
+  test('should notify when a different slot is picked for a pane', async () => {
+    const { onSelectSlot } = await makeCompare();
+
+    const [firstPicker] = screen.getAllByRole('combobox');
+    fireEvent.change(firstPicker, { target: { value: '1' } });
+
+    expect(onSelectSlot).toHaveBeenCalledWith(0, '1');
+  });
+
+  test('should switch to the pane slot and exit when "Use this timetable" is clicked', async () => {
+    const { store, onExit } = await makeCompare();
+
+    // The active slot's pane shows a disabled "Current timetable" button instead
+    expect(screen.getByRole('button', { name: 'Current timetable' })).toBeDisabled();
+
+    const useButton = screen.getByRole('button', { name: 'Use this timetable' });
+    // switchTimetableSlot fetches the slot's modules before dispatching the
+    // switch, so the state update settles asynchronously after the click
+    await act(async () => {
+      fireEvent.click(useButton);
+    });
+    await waitFor(() => expect(store.getState().timetables.activeSlot[1]).toBe('0'));
+
+    // validateTimetable (run as part of the switch) fills in any of
+    // CS1010S's other required lesson types alongside the Lecture selection
+    // from the slot - so only assert the selection we set is preserved
+    expect(store.getState().timetables.lessons[1]).toMatchObject({
+      CS1010S: expect.objectContaining({ Lecture: ['1'] }),
+    });
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  test('should exit compare mode from the close button', async () => {
+    const { onExit } = await makeCompare();
+
+    fireEvent.click(screen.getByRole('button', { name: /Exit comparison/ }));
+    expect(onExit).toHaveBeenCalled();
+  });
+});

--- a/website/src/views/timetable/TimetableSlotsCompare.tsx
+++ b/website/src/views/timetable/TimetableSlotsCompare.tsx
@@ -1,0 +1,171 @@
+import { FC, useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import classnames from 'classnames';
+import { X } from 'react-feather';
+import { omit } from 'lodash-es';
+
+import type { Semester } from 'types/modules';
+import type { ModulesMap, TimetableSlot, TimetableSlotData } from 'types/reducers';
+import type { ColoredLesson } from 'types/timetables';
+import type { State } from 'types/state';
+
+import { fetchTimetableModules, switchTimetableSlot } from 'actions/timetables';
+import { getActiveSlotId, getSlotTimetableData, getTimetableSlots } from 'selectors/timetables';
+import {
+  arrangeLessonsForWeek,
+  hydrateSemTimetableWithLessons,
+  timetableLessonsArray,
+} from 'utils/timetables';
+import { fillColorMapping } from 'utils/colors';
+
+import Timetable from './Timetable';
+import styles from './TimetableSlotsCompare.scss';
+
+type PaneIndex = 0 | 1;
+
+type PaneProps = {
+  semester: Semester;
+  slotId: string;
+  pane: PaneIndex;
+  slots: TimetableSlot[];
+  data: TimetableSlotData;
+  modules: ModulesMap;
+  isActive: boolean;
+  onSelectSlot: (pane: PaneIndex, slotId: string) => void;
+  onUseSlot: (slotId: string) => void;
+};
+
+const ComparePane: FC<PaneProps> = ({
+  semester,
+  slotId,
+  pane,
+  slots,
+  data,
+  modules,
+  isActive,
+  onSelectSlot,
+  onUseSlot,
+}) => {
+  const arrangedLessons = useMemo(() => {
+    // Hidden modules are excluded from the grid, matching the main timetable
+    const visibleConfig = omit(data.lessons, data.hidden);
+    const withLessons = hydrateSemTimetableWithLessons(visibleConfig, modules, semester);
+    const colors = fillColorMapping(data.lessons, data.colors);
+    const coloredLessons: ColoredLesson[] = timetableLessonsArray(withLessons).map((lesson) => ({
+      ...lesson,
+      colorIndex: colors[lesson.moduleCode],
+    }));
+    return arrangeLessonsForWeek(coloredLessons);
+  }, [data, modules, semester]);
+
+  const moduleCount = Object.keys(data.lessons).length;
+
+  return (
+    <div className={styles.pane}>
+      <div className={styles.paneHeader}>
+        <select
+          className="form-control"
+          aria-label={`Timetable for pane ${pane + 1}`}
+          value={slotId}
+          onChange={(evt) => onSelectSlot(pane, evt.target.value)}
+        >
+          {slots.map((slot) => (
+            <option key={slot.id} value={slot.id}>
+              {slot.title}
+            </option>
+          ))}
+        </select>
+
+        <span className={styles.moduleCount}>
+          {moduleCount} {moduleCount === 1 ? 'course' : 'courses'}
+        </span>
+
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-primary"
+          disabled={isActive}
+          onClick={() => onUseSlot(slotId)}
+        >
+          {isActive ? 'Current timetable' : 'Use this timetable'}
+        </button>
+      </div>
+
+      <div className={classnames(styles.grid, 'verticalMode')}>
+        <Timetable lessons={arrangedLessons} isVerticalOrientation />
+      </div>
+    </div>
+  );
+};
+
+type Props = {
+  semester: Semester;
+  slotIds: [string, string];
+  onSelectSlot: (pane: PaneIndex, slotId: string) => void;
+  onExit: () => void;
+};
+
+/**
+ * Side-by-side comparison of two saved timetable arrangements.
+ * See https://github.com/nusmodifications/nusmods/issues/4455
+ */
+const TimetableSlotsCompare: FC<Props> = ({ semester, slotIds, onSelectSlot, onExit }) => {
+  const dispatch = useDispatch();
+
+  const slots = useSelector(getTimetableSlots)(semester);
+  const activeSlotId = useSelector(getActiveSlotId)(semester);
+  const getSlotData = useSelector(getSlotTimetableData);
+  const modules = useSelector(({ moduleBank }: State) => moduleBank.modules);
+
+  const [slotIdA, slotIdB] = slotIds;
+  const dataA = getSlotData(semester, slotIdA);
+  const dataB = getSlotData(semester, slotIdB);
+
+  // Inactive slots may reference modules that have been evicted from the
+  // module bank, so fetch them before hydrating
+  useEffect(() => {
+    dispatch(fetchTimetableModules([dataA.lessons, dataB.lessons]));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, semester, slotIdA, slotIdB]);
+
+  const useSlot = (slotId: string) => {
+    dispatch(switchTimetableSlot(semester, slotId));
+    onExit();
+  };
+
+  return (
+    <div className={styles.compare}>
+      <div className={styles.compareHeader}>
+        <h2>Compare timetables</h2>
+        <button
+          type="button"
+          className="btn btn-outline-primary btn-svg"
+          onClick={onExit}
+          aria-label="Exit comparison"
+        >
+          <X className="svg svg-small" />
+          Exit comparison
+        </button>
+      </div>
+
+      <div className="row">
+        {([0, 1] as const).map((pane) => (
+          <div className="col-md-6" key={pane}>
+            <ComparePane
+              semester={semester}
+              pane={pane}
+              slotId={slotIds[pane]}
+              slots={slots}
+              data={pane === 0 ? dataA : dataB}
+              modules={modules}
+              isActive={slotIds[pane] === activeSlotId}
+              onSelectSlot={onSelectSlot}
+              onUseSlot={useSlot}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TimetableSlotsCompare;

--- a/website/src/views/timetable/TimetableSlotsSwitcher.scss
+++ b/website/src/views/timetable/TimetableSlotsSwitcher.scss
@@ -1,0 +1,50 @@
+@import '~styles/utils/modules-entry';
+
+.slotsSwitcher {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 0.6rem;
+  gap: 0.4rem;
+}
+
+.tab {
+  overflow: hidden;
+  max-width: 12rem;
+  border-radius: 10rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.iconButton {
+  border-radius: 10rem;
+}
+
+.menu {
+  position: relative;
+
+  .dropdownMenu {
+    svg {
+      margin-right: 0.2rem;
+      vertical-align: middle;
+    }
+
+    @include media-breakpoint-up(md) {
+      font-size: $font-size-sm;
+    }
+  }
+}
+
+.modalHeader {
+  svg {
+    width: 3.8rem;
+    height: 3.8rem;
+    margin-bottom: 0.6rem;
+    color: theme-color();
+  }
+}
+
+.modalAction {
+  margin-top: 1rem;
+}

--- a/website/src/views/timetable/TimetableSlotsSwitcher.test.tsx
+++ b/website/src/views/timetable/TimetableSlotsSwitcher.test.tsx
@@ -19,6 +19,7 @@ function makeSwitcher(slots: TimetableSlot[] = twoSlots, activeSlotId = '0') {
   const onAddSlot = vi.fn();
   const onRenameSlot = vi.fn();
   const onDeleteSlot = vi.fn();
+  const onCompare = vi.fn();
 
   const wrapper = mount(
     <TimetableSlotsSwitcherComponent
@@ -28,10 +29,11 @@ function makeSwitcher(slots: TimetableSlot[] = twoSlots, activeSlotId = '0') {
       onAddSlot={onAddSlot}
       onRenameSlot={onRenameSlot}
       onDeleteSlot={onDeleteSlot}
+      onCompare={onCompare}
     />,
   );
 
-  return { wrapper, onSwitchSlot, onAddSlot, onRenameSlot, onDeleteSlot };
+  return { wrapper, onSwitchSlot, onAddSlot, onRenameSlot, onDeleteSlot, onCompare };
 }
 
 const findTabs = (wrapper: ReturnType<typeof mount>) => wrapper.find(`button.${styles.tab}`);
@@ -114,6 +116,24 @@ describe(TimetableSlotsSwitcherComponent, () => {
     confirmButton.simulate('click');
 
     expect(onDeleteSlot).toHaveBeenCalledWith('0');
+  });
+
+  test('should start comparison from the options menu', () => {
+    const { wrapper, onCompare } = makeSwitcher();
+    clickMenuItem(wrapper, 'Compare', 'Timetable options');
+
+    expect(onCompare).toHaveBeenCalled();
+  });
+
+  test('should not offer comparison with a single slot', () => {
+    const { wrapper } = makeSwitcher([twoSlots[0]]);
+    wrapper.find('button[aria-label="Timetable options"]').simulate('click');
+
+    expect(
+      wrapper
+        .find('button.dropdown-item')
+        .filterWhere((button) => button.text().includes('Compare')),
+    ).toHaveLength(0);
   });
 
   test('should not allow deleting the last remaining slot', () => {

--- a/website/src/views/timetable/TimetableSlotsSwitcher.test.tsx
+++ b/website/src/views/timetable/TimetableSlotsSwitcher.test.tsx
@@ -1,0 +1,131 @@
+import { mount } from 'enzyme';
+import { setupDownshiftTimers } from 'test-utils/downshiftTimers';
+
+import { TimetableSlot } from 'types/reducers';
+import Modal from 'views/components/Modal';
+
+import { TimetableSlotsSwitcherComponent } from './TimetableSlotsSwitcher';
+import styles from './TimetableSlotsSwitcher.scss';
+
+const emptyData = { lessons: {}, colors: {}, hidden: [], ta: [] };
+
+const twoSlots: TimetableSlot[] = [
+  { id: '0', title: 'Timetable 1', data: emptyData },
+  { id: '1', title: 'Backup plan', data: emptyData },
+];
+
+function makeSwitcher(slots: TimetableSlot[] = twoSlots, activeSlotId = '0') {
+  const onSwitchSlot = vi.fn();
+  const onAddSlot = vi.fn();
+  const onRenameSlot = vi.fn();
+  const onDeleteSlot = vi.fn();
+
+  const wrapper = mount(
+    <TimetableSlotsSwitcherComponent
+      slots={slots}
+      activeSlotId={activeSlotId}
+      onSwitchSlot={onSwitchSlot}
+      onAddSlot={onAddSlot}
+      onRenameSlot={onRenameSlot}
+      onDeleteSlot={onDeleteSlot}
+    />,
+  );
+
+  return { wrapper, onSwitchSlot, onAddSlot, onRenameSlot, onDeleteSlot };
+}
+
+const findTabs = (wrapper: ReturnType<typeof mount>) => wrapper.find(`button.${styles.tab}`);
+const clickMenuItem = (wrapper: ReturnType<typeof mount>, label: string, menuLabel: string) => {
+  wrapper.find(`button[aria-label="${menuLabel}"]`).simulate('click');
+  const item = wrapper
+    .find('button.dropdown-item')
+    .filterWhere((button) => button.text().includes(label));
+  item.simulate('click');
+};
+
+setupDownshiftTimers();
+
+describe(TimetableSlotsSwitcherComponent, () => {
+  test('should render a tab for each slot with the active tab marked', () => {
+    const { wrapper } = makeSwitcher();
+    const tabs = findTabs(wrapper);
+
+    expect(tabs).toHaveLength(2);
+    expect(tabs.at(0).text()).toContain('Timetable 1');
+    expect(tabs.at(1).text()).toContain('Backup plan');
+    expect(tabs.at(0).prop('aria-selected')).toBe(true);
+    expect(tabs.at(1).prop('aria-selected')).toBe(false);
+  });
+
+  test('should switch to an inactive slot when its tab is clicked', () => {
+    const { wrapper, onSwitchSlot } = makeSwitcher();
+    findTabs(wrapper).at(1).simulate('click');
+
+    expect(onSwitchSlot).toHaveBeenCalledWith('1');
+  });
+
+  test('should not switch when the active tab is clicked', () => {
+    const { wrapper, onSwitchSlot } = makeSwitcher();
+    findTabs(wrapper).at(0).simulate('click');
+
+    expect(onSwitchSlot).not.toHaveBeenCalled();
+  });
+
+  test('should add a blank timetable from the add menu', () => {
+    const { wrapper, onAddSlot } = makeSwitcher();
+    clickMenuItem(wrapper, 'New empty timetable', 'Add timetable');
+
+    expect(onAddSlot).toHaveBeenCalledWith({});
+  });
+
+  test('should duplicate the current timetable from the add menu', () => {
+    const { wrapper, onAddSlot } = makeSwitcher();
+    clickMenuItem(wrapper, 'Duplicate current timetable', 'Add timetable');
+
+    expect(onAddSlot).toHaveBeenCalledWith({ duplicateCurrent: true });
+  });
+
+  test('should rename the active slot through the rename modal', () => {
+    const { wrapper, onRenameSlot } = makeSwitcher();
+    clickMenuItem(wrapper, 'Rename', 'Timetable options');
+
+    const modal = wrapper.find(Modal).filterWhere((m) => !!m.prop('isOpen'));
+    expect(modal.exists()).toBe(true);
+
+    const input = wrapper.find('input[type="text"]');
+    expect(input.prop('value')).toBe('Timetable 1');
+
+    input.simulate('change', { target: { value: 'Plan A' } });
+    wrapper.find('form').simulate('submit');
+
+    expect(onRenameSlot).toHaveBeenCalledWith('0', 'Plan A');
+  });
+
+  test('should delete the active slot after confirmation', () => {
+    const { wrapper, onDeleteSlot } = makeSwitcher();
+    clickMenuItem(wrapper, 'Delete', 'Timetable options');
+
+    expect(onDeleteSlot).not.toHaveBeenCalled();
+
+    const confirmButton = wrapper
+      .find('button')
+      .filterWhere((button) => button.text() === 'Delete')
+      .last();
+    confirmButton.simulate('click');
+
+    expect(onDeleteSlot).toHaveBeenCalledWith('0');
+  });
+
+  test('should not allow deleting the last remaining slot', () => {
+    const { wrapper, onDeleteSlot } = makeSwitcher([twoSlots[0]]);
+    clickMenuItem(wrapper, 'Delete', 'Timetable options');
+
+    expect(
+      wrapper
+        .find(Modal)
+        .filterWhere((m) => !!m.prop('isOpen'))
+        .exists(),
+    ).toBe(false);
+    expect(onDeleteSlot).not.toHaveBeenCalled();
+  });
+});

--- a/website/src/views/timetable/TimetableSlotsSwitcher.tsx
+++ b/website/src/views/timetable/TimetableSlotsSwitcher.tsx
@@ -1,0 +1,278 @@
+import { FC, FormEvent, useCallback, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import Downshift from 'downshift';
+import classnames from 'classnames';
+import { Copy, Edit2, FilePlus, MoreHorizontal, Plus, Trash2 } from 'react-feather';
+
+import type { Semester } from 'types/modules';
+import type { TimetableSlot } from 'types/reducers';
+
+import {
+  addTimetableSlot,
+  deleteTimetableSlot,
+  renameTimetableSlot,
+  switchTimetableSlot,
+} from 'actions/timetables';
+import { getActiveSlotId, getTimetableSlots } from 'selectors/timetables';
+import Modal from 'views/components/Modal';
+import CloseButton from 'views/components/CloseButton';
+
+import styles from './TimetableSlotsSwitcher.scss';
+
+type AddAction = 'NEW' | 'DUPLICATE';
+type ManageAction = 'RENAME' | 'DELETE';
+
+type Props = {
+  slots: TimetableSlot[];
+  activeSlotId: string;
+  onSwitchSlot: (slotId: string) => void;
+  onAddSlot: (options: { title?: string; duplicateCurrent?: boolean }) => void;
+  onRenameSlot: (slotId: string, title: string) => void;
+  onDeleteSlot: (slotId: string) => void;
+};
+
+export const TimetableSlotsSwitcherComponent: FC<Props> = ({
+  slots,
+  activeSlotId,
+  onSwitchSlot,
+  onAddSlot,
+  onRenameSlot,
+  onDeleteSlot,
+}) => {
+  const [isRenameOpen, setRenameOpen] = useState(false);
+  const [isDeleteOpen, setDeleteOpen] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+
+  const activeSlot = slots.find((slot) => slot.id === activeSlotId) ?? slots[0];
+  const canDelete = slots.length > 1;
+
+  const openRenameModal = useCallback(() => {
+    setNewTitle(activeSlot.title);
+    setRenameOpen(true);
+  }, [activeSlot]);
+
+  const submitRename = useCallback(
+    (evt: FormEvent) => {
+      evt.preventDefault();
+      onRenameSlot(activeSlot.id, newTitle);
+      setRenameOpen(false);
+    },
+    [activeSlot, newTitle, onRenameSlot],
+  );
+
+  const confirmDelete = useCallback(() => {
+    onDeleteSlot(activeSlot.id);
+    setDeleteOpen(false);
+  }, [activeSlot, onDeleteSlot]);
+
+  const onSelectAddAction = useCallback(
+    (item: AddAction | null) => {
+      if (item === 'NEW') onAddSlot({});
+      if (item === 'DUPLICATE') onAddSlot({ duplicateCurrent: true });
+    },
+    [onAddSlot],
+  );
+
+  const onSelectManageAction = useCallback(
+    (item: ManageAction | null) => {
+      if (item === 'RENAME') openRenameModal();
+      if (item === 'DELETE' && canDelete) setDeleteOpen(true);
+    },
+    [canDelete, openRenameModal],
+  );
+
+  return (
+    <div className={styles.slotsSwitcher} role="tablist" aria-label="Saved timetables">
+      {slots.map((slot) => {
+        const isActive = slot.id === activeSlotId;
+        return (
+          <button
+            key={slot.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            className={classnames(styles.tab, 'btn btn-sm', {
+              'btn-primary': isActive,
+              'btn-outline-primary': !isActive,
+            })}
+            onClick={() => {
+              if (!isActive) onSwitchSlot(slot.id);
+            }}
+          >
+            {slot.title}
+          </button>
+        );
+      })}
+
+      <Downshift onSelect={onSelectAddAction}>
+        {({ isOpen, getItemProps, getMenuProps, toggleMenu, highlightedIndex }) => (
+          <div className={styles.menu}>
+            <button
+              type="button"
+              aria-label="Add timetable"
+              className={classnames(styles.iconButton, 'btn btn-sm btn-outline-primary btn-svg')}
+              onClick={() => toggleMenu()}
+            >
+              <Plus className="svg svg-small" />
+            </button>
+
+            <div
+              className={classnames('dropdown-menu', styles.dropdownMenu, { show: isOpen })}
+              {...getMenuProps()}
+            >
+              <button
+                type="button"
+                className={classnames('dropdown-item', {
+                  'dropdown-selected': highlightedIndex === 0,
+                })}
+                {...getItemProps({ item: 'NEW' })}
+              >
+                <FilePlus className="svg svg-small" /> New empty timetable
+              </button>
+              <button
+                type="button"
+                className={classnames('dropdown-item', {
+                  'dropdown-selected': highlightedIndex === 1,
+                })}
+                {...getItemProps({ item: 'DUPLICATE' })}
+              >
+                <Copy className="svg svg-small" /> Duplicate current timetable
+              </button>
+            </div>
+          </div>
+        )}
+      </Downshift>
+
+      <Downshift onSelect={onSelectManageAction}>
+        {({ isOpen, getItemProps, getMenuProps, toggleMenu, highlightedIndex }) => (
+          <div className={styles.menu}>
+            <button
+              type="button"
+              aria-label="Timetable options"
+              className={classnames(styles.iconButton, 'btn btn-sm btn-outline-primary btn-svg')}
+              onClick={() => toggleMenu()}
+            >
+              <MoreHorizontal className="svg svg-small" />
+            </button>
+
+            <div
+              className={classnames('dropdown-menu', styles.dropdownMenu, { show: isOpen })}
+              {...getMenuProps()}
+            >
+              <button
+                type="button"
+                className={classnames('dropdown-item', {
+                  'dropdown-selected': highlightedIndex === 0,
+                })}
+                {...getItemProps({ item: 'RENAME' })}
+              >
+                <Edit2 className="svg svg-small" /> Rename
+              </button>
+              <button
+                type="button"
+                disabled={!canDelete}
+                title={canDelete ? undefined : 'The last timetable cannot be deleted'}
+                className={classnames('dropdown-item', {
+                  'dropdown-selected': highlightedIndex === 1,
+                })}
+                {...getItemProps({ item: 'DELETE', disabled: !canDelete })}
+              >
+                <Trash2 className="svg svg-small" /> Delete
+              </button>
+            </div>
+          </div>
+        )}
+      </Downshift>
+
+      <Modal isOpen={isRenameOpen} onRequestClose={() => setRenameOpen(false)} animate>
+        <CloseButton absolutePositioned onClick={() => setRenameOpen(false)} />
+        <div className={styles.modalHeader}>
+          <Edit2 />
+          <h3>Rename timetable</h3>
+        </div>
+        <form onSubmit={submitRename}>
+          <input
+            type="text"
+            className="form-control"
+            value={newTitle}
+            onChange={(evt) => setNewTitle(evt.target.value)}
+            maxLength={40}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+          />
+          <button
+            type="submit"
+            className={classnames(styles.modalAction, 'btn btn-primary btn-block')}
+            disabled={!newTitle.trim()}
+          >
+            Rename
+          </button>
+        </form>
+      </Modal>
+
+      <Modal isOpen={isDeleteOpen} onRequestClose={() => setDeleteOpen(false)} animate>
+        <CloseButton absolutePositioned onClick={() => setDeleteOpen(false)} />
+        <div className={styles.modalHeader}>
+          <Trash2 />
+          <h3>Delete &lsquo;{activeSlot.title}&rsquo;?</h3>
+          <p>
+            This will permanently remove this timetable and all courses in it. You can undo this
+            immediately afterwards, but it cannot be recovered later.
+          </p>
+        </div>
+        <button
+          type="button"
+          className={classnames(styles.modalAction, 'btn btn-primary btn-block')}
+          onClick={confirmDelete}
+        >
+          Delete
+        </button>
+      </Modal>
+    </div>
+  );
+};
+
+type OwnProps = {
+  semester: Semester;
+};
+
+/**
+ * Tab row for switching between saved timetable arrangements ("slots") of a
+ * semester. See https://github.com/nusmodifications/nusmods/issues/4455
+ */
+const TimetableSlotsSwitcher: FC<OwnProps> = ({ semester }) => {
+  const slots = useSelector(getTimetableSlots)(semester);
+  const activeSlotId = useSelector(getActiveSlotId)(semester);
+  const dispatch = useDispatch();
+
+  const onSwitchSlot = useCallback(
+    (slotId: string) => dispatch(switchTimetableSlot(semester, slotId)),
+    [dispatch, semester],
+  );
+  const onAddSlot = useCallback(
+    (options: { title?: string; duplicateCurrent?: boolean }) =>
+      dispatch(addTimetableSlot(semester, options)),
+    [dispatch, semester],
+  );
+  const onRenameSlot = useCallback(
+    (slotId: string, title: string) => dispatch(renameTimetableSlot(semester, slotId, title)),
+    [dispatch, semester],
+  );
+  const onDeleteSlot = useCallback(
+    (slotId: string) => dispatch(deleteTimetableSlot(semester, slotId)),
+    [dispatch, semester],
+  );
+
+  return (
+    <TimetableSlotsSwitcherComponent
+      slots={slots}
+      activeSlotId={activeSlotId}
+      onSwitchSlot={onSwitchSlot}
+      onAddSlot={onAddSlot}
+      onRenameSlot={onRenameSlot}
+      onDeleteSlot={onDeleteSlot}
+    />
+  );
+};
+
+export default TimetableSlotsSwitcher;

--- a/website/src/views/timetable/TimetableSlotsSwitcher.tsx
+++ b/website/src/views/timetable/TimetableSlotsSwitcher.tsx
@@ -2,7 +2,7 @@ import { FC, FormEvent, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Downshift from 'downshift';
 import classnames from 'classnames';
-import { Copy, Edit2, FilePlus, MoreHorizontal, Plus, Trash2 } from 'react-feather';
+import { Columns, Copy, Edit2, FilePlus, MoreHorizontal, Plus, Trash2 } from 'react-feather';
 
 import type { Semester } from 'types/modules';
 import type { TimetableSlot } from 'types/reducers';
@@ -20,7 +20,7 @@ import CloseButton from 'views/components/CloseButton';
 import styles from './TimetableSlotsSwitcher.scss';
 
 type AddAction = 'NEW' | 'DUPLICATE';
-type ManageAction = 'RENAME' | 'DELETE';
+type ManageAction = 'RENAME' | 'DELETE' | 'COMPARE';
 
 type Props = {
   slots: TimetableSlot[];
@@ -29,6 +29,7 @@ type Props = {
   onAddSlot: (options: { title?: string; duplicateCurrent?: boolean }) => void;
   onRenameSlot: (slotId: string, title: string) => void;
   onDeleteSlot: (slotId: string) => void;
+  onCompare?: () => void;
 };
 
 export const TimetableSlotsSwitcherComponent: FC<Props> = ({
@@ -38,6 +39,7 @@ export const TimetableSlotsSwitcherComponent: FC<Props> = ({
   onAddSlot,
   onRenameSlot,
   onDeleteSlot,
+  onCompare,
 }) => {
   const [isRenameOpen, setRenameOpen] = useState(false);
   const [isDeleteOpen, setDeleteOpen] = useState(false);
@@ -73,12 +75,15 @@ export const TimetableSlotsSwitcherComponent: FC<Props> = ({
     [onAddSlot],
   );
 
+  const canCompare = slots.length > 1 && !!onCompare;
+
   const onSelectManageAction = useCallback(
     (item: ManageAction | null) => {
       if (item === 'RENAME') openRenameModal();
       if (item === 'DELETE' && canDelete) setDeleteOpen(true);
+      if (item === 'COMPARE') onCompare?.();
     },
-    [canDelete, openRenameModal],
+    [canDelete, onCompare, openRenameModal],
   );
 
   return (
@@ -168,12 +173,23 @@ export const TimetableSlotsSwitcherComponent: FC<Props> = ({
               >
                 <Edit2 className="svg svg-small" /> Rename
               </button>
+              {canCompare && (
+                <button
+                  type="button"
+                  className={classnames('dropdown-item', {
+                    'dropdown-selected': highlightedIndex === 1,
+                  })}
+                  {...getItemProps({ item: 'COMPARE' })}
+                >
+                  <Columns className="svg svg-small" /> Compare&hellip;
+                </button>
+              )}
               <button
                 type="button"
                 disabled={!canDelete}
                 title={canDelete ? undefined : 'The last timetable cannot be deleted'}
                 className={classnames('dropdown-item', {
-                  'dropdown-selected': highlightedIndex === 1,
+                  'dropdown-selected': highlightedIndex === (canCompare ? 2 : 1),
                 })}
                 {...getItemProps({ item: 'DELETE', disabled: !canDelete })}
               >
@@ -234,13 +250,14 @@ export const TimetableSlotsSwitcherComponent: FC<Props> = ({
 
 type OwnProps = {
   semester: Semester;
+  onCompare?: () => void;
 };
 
 /**
  * Tab row for switching between saved timetable arrangements ("slots") of a
  * semester. See https://github.com/nusmodifications/nusmods/issues/4455
  */
-const TimetableSlotsSwitcher: FC<OwnProps> = ({ semester }) => {
+const TimetableSlotsSwitcher: FC<OwnProps> = ({ semester, onCompare }) => {
   const slots = useSelector(getTimetableSlots)(semester);
   const activeSlotId = useSelector(getActiveSlotId)(semester);
   const dispatch = useDispatch();
@@ -271,6 +288,7 @@ const TimetableSlotsSwitcher: FC<OwnProps> = ({ semester }) => {
       onAddSlot={onAddSlot}
       onRenameSlot={onRenameSlot}
       onDeleteSlot={onDeleteSlot}
+      onCompare={onCompare}
     />
   );
 };


### PR DESCRIPTION
> **Stacked on #4460.** This PR is built on top of the save-slots PR and includes its commit, so it should be reviewed and merged after that one. Until then its diff shows both the slots feature and the comparison view.

## Context

Completes #4455: with multiple saved timetables (the save-slots PR), users also want to compare arrangements side-by-side instead of using OS split screen or screenshots.

## What this does

- **Compare…** in the slot switcher's `⋯` menu (shown when a semester has ≥2 slots) replaces the timetable with two read-only grids side by side, defaulting to the active slot vs. the next one.
- Each pane has a dropdown to pick any slot, a course count, and a **Use this timetable** button that switches to that slot and exits compare mode (the active slot's pane shows a disabled "Current timetable" instead).
- Grids render in vertical orientation so they pair naturally; below the `md` breakpoint the Bootstrap columns stack, which is the mobile behaviour.
- Compare mode is plain component state — no new route. (A `?compare=` deep link is a possible future enhancement.) It resets on semester change.

## Implementation

- `TimetableSlotsCompare` renders the bare `Timetable` grid directly (the `VenueDetails` pattern) — the heavy interactive `TimetableContent` isn't involved. Per pane: `getSlotTimetableData` → `hydrateSemTimetableWithLessons` (hidden modules omitted) → colour via `fillColorMapping` with the slot's own saved colours → `arrangeLessonsForWeek`.
- Slot modules are fetched on mount in case they're missing from the module bank; hydration tolerates missing modules while they load.

## Testing

- Component tests with a real store: two grids render from an active + an inactive slot, pane pickers, "Use this timetable" switches state and exits, close button.
- `pnpm run ci` passes.
- Manually verified in Chromium: enter/exit compare, correct modules in each pane, mobile stacking (screenshot), "Use this timetable" restores the right arrangement.

<img width="1440" height="1409" alt="compare" src="https://github.com/user-attachments/assets/a6da3697-d99e-457d-8f93-58f19f1e7d01" />
<img width="375" height="2347" alt="compare-mobile" src="https://github.com/user-attachments/assets/40263d3e-5c1a-4f7d-aac8-713652ddeed9" />
