### PR TITLE
Increase scraper Elasticsearch request timeout

### DIFF
--- a/scrapers/nus-v2/src/services/io/elastic.ts
+++ b/scrapers/nus-v2/src/services/io/elastic.ts
@@ -20,6 +20,7 @@ type ModuleSearchBody = {
 };
 
 const INDEX_NAME = 'modules_v2';
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 
 // Tokenizes a string into an array of digits
 const first_digit_tokenizer = {
@@ -114,7 +115,10 @@ export default class ElasticPersist implements Persist {
       throw new Error('elasticConfig in config.json is not set');
     }
 
-    const client = new Client(config.elasticConfig);
+    const client = new Client({
+      requestTimeout: DEFAULT_REQUEST_TIMEOUT_MS,
+      ...config.elasticConfig,
+    });
 
     this.client = createIndex(client);
   }


### PR DESCRIPTION
## Summary

- Set a 120 second default Elasticsearch request timeout for the NUS v2 scraper
- Keep deployment `elasticConfig` able to override the timeout if needed

Fixes #4462.

## Test plan

- `pnpm --filter nus-v2 build`

Note: `pnpm install --frozen-lockfile` was needed locally to refresh workspace links before the build; Husky could not update git config in the sandbox, but the install completed.