### PR TITLE
docs: document GitHub token rotation targets

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -6,7 +6,9 @@ Create a new issue on GitHub with this checklist after the finals every semester
 
 ### Around End of Semester 2
 
-- [ ] Venue issues are created by [Cloudflare workers](https://github.com/nusmodifications/serverless-functions), and the GitHub access token expires after 366 days. Update the personal access token on the Cloudflare dashboard and grant write permissions under [Issues](https://docs.github.com/en/rest/issues/issues?apiVersion=2026-03-10#create-an-issue) for the `nusmods` repository.
+- [ ] Rotate `GITHUB_API_TOKEN`, which expires after 366 days, and update it in both deployment platforms:
+  - [ ] In the [Cloudflare workers](https://github.com/nusmodifications/serverless-functions), update the token on the Cloudflare dashboard and grant write permissions under [Issues](https://docs.github.com/en/rest/issues/issues?apiVersion=2026-03-10#create-an-issue) for the `nusmods` repository so venue issues can be created.
+  - [ ] In Vercel, update the token for both the `nusmods-website` and `nusmods-export` projects so fork PR builds can be identified by `vercel_ignore_build.sh`.
 
 ### 1 week before NUS IT Data Update
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -8,7 +8,7 @@ Create a new issue on GitHub with this checklist after the finals every semester
 
 - [ ] Rotate `GITHUB_API_TOKEN`, which expires after 366 days, and update it in both deployment platforms:
   - [ ] In the [Cloudflare workers](https://github.com/nusmodifications/serverless-functions), update the token on the Cloudflare dashboard and grant write permissions under [Issues](https://docs.github.com/en/rest/issues/issues?apiVersion=2026-03-10#create-an-issue) for the `nusmods` repository so venue issues can be created.
-  - [ ] In Vercel, update the token for both the `nusmods-website` and `nusmods-export` projects so fork PR builds can be identified by `vercel_ignore_build.sh`.
+  - [ ] In Vercel, update the token for both the `nusmods-website` and `nusmods-export` projects so fork PR builds can be identified by `vercel_ignore_build.sh`. The token is used by the projects' ignored build step, not by either service at runtime.
 
 ### 1 week before NUS IT Data Update
 


### PR DESCRIPTION
## Summary

- name the expiring credential as `GITHUB_API_TOKEN`
- document updating it in the Cloudflare Workers deployment
- document updating it in both the `nusmods-website` and `nusmods-export` Vercel projects

This prevents token rotation from restoring venue issue creation while leaving Vercel fork PR detection with a stale token.

## Validation

- `git diff --check`
- repository pre-commit formatting hook (`oxfmt`)
