### PR TITLE
fix(TA): validate timetable when disabling TA mode

### DIFF
--- a/website/src/actions/timetables.test.ts
+++ b/website/src/actions/timetables.test.ts
@@ -594,9 +594,9 @@ describe(actions.disableTaModule, () => {
     const dispatch = jest.fn();
     const action = actions.disableTaModule(semester, 'CS1010S');
     action(dispatch, () => state);
-    const [[firstAction]] = dispatch.mock.calls;
+    const [[firstAction], [secondAction]] = dispatch.mock.calls;
 
-    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledTimes(2);
     expect(firstAction).toEqual({
       payload: {
         lessonConfig: {
@@ -609,6 +609,7 @@ describe(actions.disableTaModule, () => {
       },
       type: 'REMOVE_TA_MODULE',
     });
+    expect(secondAction).toEqual(expect.any(Function));
   });
 
   test('should dispatch action with serializedLessonDetails lessonId if semesterData cannot be found to create non-TA lessonConfig', () => {
@@ -621,9 +622,9 @@ describe(actions.disableTaModule, () => {
     const dispatch = jest.fn();
     const action = actions.disableTaModule(semester, 'CS1010S');
     action(dispatch, () => state);
-    const [[firstAction]] = dispatch.mock.calls;
+    const [[firstAction], [secondAction]] = dispatch.mock.calls;
 
-    expect(dispatch).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledTimes(2);
     expect(firstAction).toEqual({
       payload: {
         lessonConfig: {
@@ -636,5 +637,6 @@ describe(actions.disableTaModule, () => {
       },
       type: 'REMOVE_TA_MODULE',
     });
+    expect(secondAction).toEqual(expect.any(Function));
   });
 });

--- a/website/src/actions/timetables.ts
+++ b/website/src/actions/timetables.ts
@@ -456,6 +456,7 @@ export function disableTaModule(semester: Semester, moduleCode: ModuleCode) {
     const semesterData: SemesterData | undefined = getModuleSemesterData(module, semester);
     if (!semesterData) {
       dispatch(removeTaModule(semester, moduleCode, taModuleLessonConfig));
+      dispatch(validateTimetable(semester));
       return;
     }
     const lessonConfig: ModuleLessonConfig = getClosestLessonConfig(
@@ -464,5 +465,6 @@ export function disableTaModule(semester: Semester, moduleCode: ModuleCode) {
     );
 
     dispatch(removeTaModule(semester, moduleCode, lessonConfig));
+    dispatch(validateTimetable(semester));
   };
 }


### PR DESCRIPTION
Closes #4553 .

Currently, disabling TA mode doesn't validate the timetable. This could lead to certain lesson types not being repopulated correctly when TA mode is disabled.

For example, if I removed all lecture lessons but leave tutorial lessons in TA mode, the lecture lessons should be automatically repopulated when TA mode is disabled.